### PR TITLE
Make name changing server-side

### DIFF
--- a/src/client/components/App/App.spec.tsx
+++ b/src/client/components/App/App.spec.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import { fireEvent, screen, render } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '@/test-utils';
 
 import { App } from './App';
-import { store } from '@/client/redux/store';
+import { RootState } from '@/client/redux/store';
 
 describe('App', () => {
     it('goes to the compact decklist view', () => {
-        render(
-            <Provider store={store}>
-                <App />
-            </Provider>
-        );
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Grestch',
+            },
+        };
+        render(<App />, { preloadedState });
         expect(
             screen.queryByText('Deal 3 damage to any target')
         ).toBeInTheDocument();

--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -1,49 +1,49 @@
-import React, { useEffect } from 'react';
-import { io, Socket } from 'socket.io-client';
-import { useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { HistoryRouter as Router } from 'redux-first-history/rr6';
 import { Link, Route, Routes } from 'react-router-dom';
 
+import { makeSampleDeck1 } from '@/factories/deck';
+import { isUserInitialized } from '@/client/redux/selectors';
+import { history, RootState } from '@/client/redux/store';
+
 import { DeckList } from '../DeckList';
 import { CompactDeckList } from '../CompactDeckList';
-import { makeSampleDeck1 } from '@/factories/deck';
-import { disconnectUser, initializeUser } from '@/client/redux/user';
-import { AppDispatch, history } from '@/client/redux/store';
 import { IntroScreen } from '../IntroScreen';
+import { WebSocketProvider } from '../WebSockets';
 
 export const App: React.FC = () => {
-    const dispatch: AppDispatch = useDispatch();
-    const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io();
-    useEffect(() => {
-        socket.on('connect', () => {
-            dispatch(initializeUser({ id: socket.id }));
-        });
-        socket.on('disconnect', () => {
-            dispatch(disconnectUser());
-        });
-    }, []);
-
     const deck = makeSampleDeck1();
 
-    return (
-        <div>
-            <IntroScreen />
-            <Router history={history}>
-                <React.Fragment>
-                    <Link to="/">Deck List 1</Link>
-                    <br />
-                    <Link to="/compact">Compact Deck List</Link>
+    const isUserPastIntroScreen = useSelector<RootState>(isUserInitialized);
 
-                    <Routes>
-                        <Route path="/" element={<DeckList deck={deck} />} />
-                        <Route
-                            path="/compact"
-                            element={<CompactDeckList deck={deck} />}
-                        />
-                        <Route element={<DeckList deck={deck} />} />
-                    </Routes>
-                </React.Fragment>
-            </Router>
-        </div>
+    return (
+        <WebSocketProvider>
+            <div>
+                <IntroScreen />
+                <br />
+                <Router history={history}>
+                    {isUserPastIntroScreen && (
+                        <React.Fragment>
+                            <Link to="/">Deck List 1</Link>
+                            <br />
+                            <Link to="/compact">Compact Deck List</Link>
+
+                            <Routes>
+                                <Route
+                                    path="/"
+                                    element={<DeckList deck={deck} />}
+                                />
+                                <Route
+                                    path="/compact"
+                                    element={<CompactDeckList deck={deck} />}
+                                />
+                                <Route element={<DeckList deck={deck} />} />
+                            </Routes>
+                        </React.Fragment>
+                    )}
+                </Router>
+            </div>
+        </WebSocketProvider>
     );
 };

--- a/src/client/components/IntroScreen/IntroScreen.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
 
 import { RootState } from '@/client/redux/store';
-import { chooseName } from '@/client/redux/user';
 import { NameChanger } from '../NameChanger';
+import { WebSocketContext } from '../WebSockets';
 
 /**
  * The Intro Screen is where people set their names / see games in
@@ -11,15 +11,25 @@ import { NameChanger } from '../NameChanger';
  * @returns {JSX.Element} Intro screen component
  */
 export const IntroScreen: React.FC = () => {
-    const dispatch = useDispatch();
     const name = useSelector<RootState>((state) => state.user.name);
+    const webSocket = useContext(WebSocketContext);
 
-    const handleSubmit = (newName: string) =>
-        dispatch(chooseName({ name: newName }));
+    const handleSubmit = (newName: string) => {
+        webSocket.chooseName(newName.trim());
+    };
+
+    const logOut = () => {
+        webSocket.chooseName('');
+    };
     return (
         <>
             {name ? (
-                <>Name: {name}</>
+                <>
+                    Name: {name}{' '}
+                    <button type="button" onClick={logOut}>
+                        Logout
+                    </button>
+                </>
             ) : (
                 <NameChanger handleSubmit={handleSubmit} />
             )}

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -1,0 +1,57 @@
+import React, { createContext } from 'react';
+import { useDispatch } from 'react-redux';
+import { io, Socket } from 'socket.io-client';
+
+import { chooseName as chooseNameReducer } from '@/client/redux/user';
+
+export const WebSocketContext = createContext<WebSocketValue>(null);
+
+type WebSocketValue = {
+    chooseName: ClientToServerEvents['chooseName'];
+    socket: Socket<ServerToClientEvents, ClientToServerEvents>;
+};
+
+/**
+ * Redux-Integrated WebSockets Provider.  The need for this arises b/c
+ * child components will need to call socket.io in order to do things like:
+ *
+ * - joining a game
+ * - choosing a name
+ * - performing a game action
+ *
+ * The pattern we set up is that each action will
+ *
+ * Based on this guide:
+ * https://www.pluralsight.com/guides/using-web-sockets-in-your-reactredux-app
+ * */
+export const WebSocketProvider: React.FC = ({ children }) => {
+    let socket: Socket<ServerToClientEvents, ClientToServerEvents>;
+    let ws: WebSocketValue;
+
+    // WebSocketProvider needs to go 1 layer beneath the Redux layer
+    const dispatch = useDispatch();
+
+    const chooseName = (name: string) => {
+        socket.emit('chooseName', name);
+    };
+
+    if (!socket) {
+        socket = io();
+
+        socket.on('confirmName', (name: string) => {
+            dispatch(chooseNameReducer({ name }));
+        });
+        ws = { socket, chooseName };
+    }
+
+    /**
+     * We cannot simply store functions / sockets in redux - redux wants
+     * flattened objects / arrays without functions - hence a need for
+     * context providers on top of the redux solution
+     */
+    return (
+        <WebSocketContext.Provider value={ws}>
+            {children}
+        </WebSocketContext.Provider>
+    );
+};

--- a/src/client/components/WebSockets/index.ts
+++ b/src/client/components/WebSockets/index.ts
@@ -1,0 +1,1 @@
+export * from './WebSockets';

--- a/src/client/redux/selectors.spec.ts
+++ b/src/client/redux/selectors.spec.ts
@@ -15,7 +15,7 @@ describe('selectors', () => {
                 isUserInitialized({
                     user: { name: '' },
                 })
-            ).toBe(true);
+            ).toBe(false);
         });
     });
 });

--- a/src/client/redux/selectors.spec.ts
+++ b/src/client/redux/selectors.spec.ts
@@ -1,0 +1,21 @@
+import { isUserInitialized } from './selectors';
+
+describe('selectors', () => {
+    describe('isUserInitialized', () => {
+        it('returns true if the user has a name selected', () => {
+            expect(
+                isUserInitialized({
+                    user: { name: 'Maya the Bishop' },
+                })
+            ).toBe(true);
+        });
+
+        it('returns false if the user has no name yet', () => {
+            expect(
+                isUserInitialized({
+                    user: { name: '' },
+                })
+            ).toBe(true);
+        });
+    });
+});

--- a/src/client/redux/selectors.ts
+++ b/src/client/redux/selectors.ts
@@ -1,0 +1,4 @@
+import { RootState } from './store';
+
+export const isUserInitialized = (state: Partial<RootState>): boolean =>
+    !!state.user.name;

--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -10,20 +10,35 @@ const { createReduxHistory, routerMiddleware, routerReducer } =
         history: createBrowserHistory(),
     });
 
-const createRootReducer = () =>
+export const createRootReducer = () =>
     combineReducers({
         router: routerReducer,
         user: userReducer,
     });
 
+const preloadedState = {
+    user: userSlice.getInitialState(),
+};
+
 export const store = configureStore({
     reducer: createRootReducer(),
     devTools: true,
     enhancers: [applyMiddleware(routerMiddleware)],
-    preloadedState: {
-        user: userSlice.getInitialState(),
-    },
+    preloadedState,
 });
+
+export const configureStoreWithMiddlewares = (stateOverrides = {}) => {
+    return configureStore({
+        reducer: createRootReducer(),
+        devTools: true,
+        enhancers: [applyMiddleware(routerMiddleware)],
+        preloadedState: {
+            ...preloadedState,
+            ...stateOverrides,
+        },
+    });
+};
+
 export const history = createReduxHistory(store);
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/server/homepage.html
+++ b/src/server/homepage.html
@@ -2,7 +2,7 @@
     <head>
         <title>Monks and Mages</title>
         <style>
-            body { margin: 0; padding-bottom: 3rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+            body { margin: 10px; padding-bottom: 3rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
       
             #form { background: rgba(0, 0, 0, 0.15); padding: 0.25rem; position: fixed; bottom: 0; left: 0; right: 0; display: flex; height: 3rem; box-sizing: border-box; backdrop-filter: blur(10px); }
             #input { border: none; padding: 0 1rem; flex-grow: 1; border-radius: 2rem; margin: 0.25rem; }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,12 +1,21 @@
 import express from 'express';
 import http from 'http';
 import path from 'path';
-import { Server } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 
 const app = express();
 const port = 3000;
 const server = http.createServer(app);
-const io = new Server(server);
+const io = new Server<ClientToServerEvents, ServerToClientEvents>(server);
+
+const namesToIds = new Map<string, string>();
+const clearName = (idToMatch: string) => {
+    const matchingName = [...namesToIds.entries()].find(
+        ([, id]) => id === idToMatch
+    );
+    if (!matchingName) return;
+    namesToIds.delete(matchingName[0]);
+};
 
 // Serves everything from dist/client as /client, e.g. http://localhost:3000/client/index.js
 app.use('/client.bundle.js', (_, res) => {
@@ -18,11 +27,30 @@ app.get('*', (_, res) => {
     res.sendFile(path.join(__dirname, 'homepage.html'));
 });
 
-io.on('connection', (socket) => {
-    socket.on('chatMessage', (msg: string) => {
-        io.emit('chatMessage', msg);
-    });
-});
+io.on(
+    'connection',
+    (socket: Socket<ClientToServerEvents, ServerToClientEvents>) => {
+        socket.on('chatMessage', (msg: string) => {
+            io.emit('chatMessage', msg);
+        });
+
+        socket.on('chooseName', (name: string) => {
+            if (!name) {
+                clearName(socket.id);
+                socket.emit('confirmName', '');
+                return;
+            }
+            if (!namesToIds.has(name)) {
+                namesToIds.set(name, socket.id);
+                socket.emit('confirmName', name);
+            }
+        });
+
+        socket.on('disconnect', () => {
+            clearName(socket.id);
+        });
+    }
+);
 
 server.listen(port, () => {
     // eslint-disable-next-line no-console

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './test-utils';

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -1,0 +1,35 @@
+import { EnhancedStore } from '@reduxjs/toolkit'; // for redux-toolkit
+// import { Store } from 'redux' // for non-toolkit
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+    render as rtlRender,
+    RenderOptions,
+    RenderResult,
+} from '@testing-library/react';
+import React, { ReactElement, ReactNode } from 'react';
+import { Provider } from 'react-redux';
+
+import { configureStoreWithMiddlewares, RootState } from '@/client/redux/store';
+
+type ReduxRenderOptions = {
+    preloadedState?: Partial<RootState>;
+    renderOptions?: Omit<RenderOptions, 'wrapper'>;
+    store?: EnhancedStore; // for redux-toolkit
+    // store?: Store // for non-toolkit
+};
+
+// a verison of RTL's render that is a reusable way to
+// incorporate redux state into tests
+export function render(
+    ui: ReactElement,
+    {
+        preloadedState = {},
+        store = configureStoreWithMiddlewares(preloadedState),
+        ...renderOptions
+    }: ReduxRenderOptions = {}
+): RenderResult {
+    function Wrapper({ children }: { children?: ReactNode }): ReactElement {
+        return <Provider store={store}>{children}</Provider>;
+    }
+    return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,12 +1,14 @@
 interface ServerToClientEvents {
     basicEmit: (a: number, b: string, c: Buffer) => void;
     chatMessage: (input: string) => void;
+    confirmName: (name: string) => void;
     noArg: () => void;
     withAck: (d: string, callback: (e: number) => void) => void;
 }
 
 interface ClientToServerEvents {
     chatMessage: (input: string) => void;
+    chooseName: (name: string) => void;
     hello: () => void;
 }
 


### PR DESCRIPTION
In most games, you have the option to pick a name.

This commit adds:

- a WebSocket provider that provides down all descendant components (such as IntroScreen) a way to access methods (e.g. chooseName) associated with the socket connection

- we changed the intro screen to involve picking a name before seeing anything else.

demo:

https://user-images.githubusercontent.com/1839462/155854794-6f90f4fd-ba16-4382-a73f-59403c3e2090.mov
