### PR TITLE
Add room joining demo

### DIFF
--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -10,6 +10,7 @@ import { history, RootState } from '@/client/redux/store';
 import { DeckList } from '../DeckList';
 import { CompactDeckList } from '../CompactDeckList';
 import { IntroScreen } from '../IntroScreen';
+import { Rooms } from '../Rooms';
 import { WebSocketProvider } from '../WebSockets';
 
 export const App: React.FC = () => {

--- a/src/client/components/IntroScreen/IntroScreen.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/client/redux/store';
 import { NameChanger } from '../NameChanger';
 import { WebSocketContext } from '../WebSockets';
+import { Rooms } from '../Rooms';
 
 /**
  * The Intro Screen is where people set their names / see games in
@@ -11,7 +12,7 @@ import { WebSocketContext } from '../WebSockets';
  * @returns {JSX.Element} Intro screen component
  */
 export const IntroScreen: React.FC = () => {
-    const name = useSelector<RootState>((state) => state.user.name);
+    const name = useSelector<RootState, string>((state) => state.user.name);
     const webSocket = useContext(WebSocketContext);
 
     const handleSubmit = (newName: string) => {
@@ -29,6 +30,7 @@ export const IntroScreen: React.FC = () => {
                     <button type="button" onClick={logOut}>
                         Logout
                     </button>
+                    <Rooms />
                 </>
             ) : (
                 <NameChanger handleSubmit={handleSubmit} />

--- a/src/client/components/RoomSquare/RoomSquare.spec.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { RoomSquare } from './RoomSquare';
+
+describe('Room Square', () => {
+    it('renders a room name + players', () => {
+        render(
+            <RoomSquare
+                detailedRoom={{
+                    roomName: 'Room 6',
+                    players: ['Kimmy', 'Jimmy', 'Timmy'],
+                }}
+            />
+        );
+        expect(screen.getByText('Room 6')).toBeInTheDocument();
+        expect(screen.getByText('Kimmy')).toBeInTheDocument();
+        expect(screen.getByText('Jimmy')).toBeInTheDocument();
+        expect(screen.getByText('Timmy')).toBeInTheDocument();
+    });
+});

--- a/src/client/components/RoomSquare/RoomSquare.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type RoomSquareProps = {
+    detailedRoom: DetailedRoom;
+};
+
+/**
+ * @returns component for a single room to be displayed on the main
+ * Rooms component.  Should show the name of the group + players
+ */
+export const RoomSquare: React.FC<RoomSquareProps> = ({
+    detailedRoom: { roomName, players },
+}) => {
+    return (
+        <div>
+            <h1>{roomName}</h1>
+            <div>
+                <ul>
+                    {players.map((player) => (
+                        <li>{player}</li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/src/client/components/Rooms/Rooms.spec.tsx
+++ b/src/client/components/Rooms/Rooms.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '@/test-utils';
+
+import { Rooms } from './Rooms';
+import { RootState } from '@/client/redux/store';
+
+describe('Rooms', () => {
+    it('renders multiple rooms', () => {
+        const preloadedState: Partial<RootState> = {
+            rooms: {
+                rooms: [
+                    {
+                        roomName: 'Room 6',
+                        players: ['Kimmy', 'Jimmy', 'Timmy'],
+                    },
+                    {
+                        roomName: 'Room 7',
+                        players: ['Peter', 'Paul', 'Mary'],
+                    },
+                ],
+            },
+        };
+        render(<Rooms />, { preloadedState });
+        expect(screen.queryByText('Room 6')).toBeInTheDocument();
+        expect(screen.queryByText('Room 7')).toBeInTheDocument();
+        expect(screen.queryByText('Paul')).toBeInTheDocument();
+    });
+});

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -1,0 +1,33 @@
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
+import { RoomSquare } from '../RoomSquare/RoomSquare';
+import { RootState } from '@/client/redux/store';
+import { WebSocketContext } from '../WebSockets';
+
+export const Rooms: React.FC = () => {
+    const rooms = useSelector<RootState, DetailedRoom[]>(
+        (state) => state.rooms.rooms || []
+    );
+    const webSocket = useContext(WebSocketContext);
+
+    const joinRoom = (roomName: string) => {
+        webSocket.joinRoom(roomName);
+    };
+
+    // TODO:
+    // only allow 1 room at a time to be joined
+    // add start button in for game when 2+ players are in a room
+
+    return (
+        <div>
+            {rooms.map((detailedRoom) => (
+                <RoomSquare
+                    detailedRoom={detailedRoom}
+                    key={detailedRoom.roomName}
+                />
+            ))}
+            <button onClick={() => joinRoom('room 1')}>Room 1 join</button>
+            <button onClick={() => joinRoom('room 2')}>Room 2 join</button>
+        </div>
+    );
+};

--- a/src/client/components/Rooms/index.ts
+++ b/src/client/components/Rooms/index.ts
@@ -1,0 +1,1 @@
+export * from './Rooms';

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -6,13 +6,13 @@ import {
     chooseName as chooseNameReducer,
     initializeUser,
 } from '@/client/redux/user';
+import { updateRoomsAndPlayers } from '@/client/redux/room';
 
 export const WebSocketContext = createContext<WebSocketValue>(null);
 
-type WebSocketValue = {
-    chooseName: ClientToServerEvents['chooseName'];
+interface WebSocketValue extends Partial<ClientToServerEvents> {
     socket: Socket<ServerToClientEvents, ClientToServerEvents>;
-};
+}
 
 /**
  * Redux-Integrated WebSockets Provider.  The need for this arises b/c
@@ -47,12 +47,20 @@ export const WebSocketProvider: React.FC = ({ children }) => {
             dispatch(initializeUser({ id: newSocket.id }));
         });
 
+        newSocket.on('listRooms', (detailedRooms) => {
+            dispatch(updateRoomsAndPlayers(detailedRooms));
+        });
+
+        const joinRoom = (roomName: string) => {
+            newSocket.emit('joinRoom', roomName);
+        };
+
         const chooseName = (name: string) => {
             newSocket.emit('chooseName', name);
         };
 
         setSocket(newSocket);
-        setWs({ socket, chooseName });
+        setWs({ socket, chooseName, joinRoom });
     }
 
     /**

--- a/src/client/redux/room/index.ts
+++ b/src/client/redux/room/index.ts
@@ -1,0 +1,1 @@
+export * from './room';

--- a/src/client/redux/room/room.ts
+++ b/src/client/redux/room/room.ts
@@ -1,0 +1,16 @@
+import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
+
+export const roomsSlice = createSlice({
+    name: 'rooms',
+    initialState: { rooms: [] as DetailedRoom[] },
+    reducers: {
+        updateRoomsAndPlayers(state, action: PayloadAction<DetailedRoom[]>) {
+            state.rooms = action.payload;
+        },
+    },
+});
+
+export const roomsReducer: Reducer<{ rooms: DetailedRoom[] }> =
+    roomsSlice.reducer;
+
+export const { updateRoomsAndPlayers } = roomsSlice.actions;

--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -3,6 +3,7 @@ import { createReduxHistoryContext } from 'redux-first-history';
 import { createBrowserHistory } from 'history';
 import { applyMiddleware } from 'redux';
 
+import { roomsReducer } from './room';
 import { userReducer, userSlice } from './user';
 
 const { createReduxHistory, routerMiddleware, routerReducer } =
@@ -13,6 +14,7 @@ const { createReduxHistory, routerMiddleware, routerReducer } =
 export const createRootReducer = () =>
     combineReducers({
         router: routerReducer,
+        rooms: roomsReducer,
         user: userReducer,
     });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import http from 'http';
 import path from 'path';
 import { Server, Socket } from 'socket.io';
 import { instrument } from '@socket.io/admin-ui';
+import { Board } from '@/types/board';
 
 const app = express();
 const port = 3000;
@@ -18,6 +19,7 @@ instrument(io, {
     auth: false,
 });
 
+const idsToNames = new Map<string, string>();
 const namesToIds = new Map<string, string>();
 const clearName = (idToMatch: string) => {
     const matchingName = [...namesToIds.entries()].find(
@@ -25,8 +27,32 @@ const clearName = (idToMatch: string) => {
     );
     if (!matchingName) return;
     namesToIds.delete(matchingName[0]);
+    idsToNames.delete(idToMatch);
 };
 
+const boards = new Map<string, Board>();
+
+// TODO: use adapters instead to get rooms => games
+// implement one that just retrieves shallowly all the rooms
+// implement one that retrieves the whole room's game
+
+// gets all public rooms + players in those rooms
+const getDetailedRooms = () => {
+    const detailedRooms: DetailedRoom[] = [];
+    const roomsAndIds = io.sockets.adapter.rooms;
+    [...roomsAndIds.entries()].forEach(([roomName, socketIds]) => {
+        if (!roomName.startsWith('public-')) return; // skip private rooms
+
+        const room = { roomName, players: [] as string[] };
+        socketIds.forEach((socketId) => {
+            if (idsToNames.has(socketId)) {
+                room.players.push(idsToNames.get(socketId));
+            }
+        });
+        detailedRooms.push(room);
+    });
+    return detailedRooms;
+};
 // Serves everything from dist/client as /client, e.g. http://localhost:3000/client/index.js
 app.use('/client.bundle.js', (_, res) => {
     res.sendFile(path.join(__dirname, 'client.bundle.js'));
@@ -40,27 +66,50 @@ app.get('*', (_, res) => {
 io.on(
     'connection',
     (socket: Socket<ClientToServerEvents, ServerToClientEvents>) => {
-        socket.on('chatMessage', (msg: string) => {
-            io.emit('chatMessage', msg);
-        });
+        socket.emit('listRooms', getDetailedRooms());
 
         socket.on('chooseName', (name: string) => {
             if (!name) {
                 clearName(socket.id);
+                socket.rooms.forEach((room) => socket.leave(room));
+                io.emit('listRooms', getDetailedRooms());
                 socket.emit('confirmName', '');
                 return;
             }
             if (!namesToIds.has(name)) {
                 namesToIds.set(name, socket.id);
+                idsToNames.set(socket.id, name);
                 socket.emit('confirmName', name);
             }
         });
 
+        socket.on('getRooms', () => {
+            socket.emit('listRooms', getDetailedRooms());
+        });
+
+        socket.on('joinRoom', (roomName) => {
+            if (!roomName) return; // blank-string room name not allowed
+            socket.join(`public-${roomName}`);
+            io.emit('listRooms', getDetailedRooms());
+        });
+
+        socket.on('startGame', () => {
+            socket.rooms.forEach((roomName) => {
+                boards.get(roomName);
+            });
+        });
+
         socket.on('disconnect', () => {
             clearName(socket.id);
+            io.emit('listRooms', getDetailedRooms());
         });
     }
 );
+
+// TODO: implement these
+io.of('/').adapter.on('delete-room', () => {});
+io.of('/').adapter.on('join-room', () => {});
+io.of('/').adapter.on('leave-room', () => {});
 
 server.listen(port, () => {
     // eslint-disable-next-line no-console

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,17 +1,17 @@
 interface ServerToClientEvents {
-    basicEmit: (a: number, b: string, c: Buffer) => void;
-    chatMessage: (input: string) => void;
     confirmName: (name: string) => void;
-    noArg: () => void;
-    withAck: (d: string, callback: (e: number) => void) => void;
+    listRooms: (rooms: DetailedRoom[]) => void;
 }
 
 interface ClientToServerEvents {
-    chatMessage: (input: string) => void;
     chooseName: (name: string) => void;
-    hello: () => void;
+    getRooms: () => void;
+    joinRoom: (roomName: string) => void;
+    startGame: () => void;
 }
 
-interface InterServerEvents {
-    ping: () => void;
-}
+type DetailedRoom = {
+    hasStartedGame?: boolean;
+    players: string[];
+    roomName: string;
+};

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -11,6 +11,8 @@ export type Player = {
     health: number;
     isActivePlayer: boolean;
     isAlive: boolean;
+    // TODO: add name
+    // TODO: add factory method to make a player
     numCardsInDeck: number;
     numCardsInHand: number;
     resourcePool: PartialRecord<Resource, number>;


### PR DESCRIPTION
Part of #9

Adding a basic demo for a 'room' that a user can join after selecting a name.

When users join these rooms (which are powered by socket.io's [rooms feature](https://socket.io/docs/v4/rooms/)), they update all the other sockets/users that someone joined a room.

Similarly, when a user leaves a room or disconnects, or resets their name, it disconnects them from the room and makes them update everyone else.

I chose this approach b/c I'm thinking the number of users may be small and we can tackle the scaling issues of the game later.  I just wanted to get something working and functional for game lobbies.

Added a bunch of todo's like using adapters for game logic, adding limits to number of rooms that can be joined, etc.  We'll tackle this + the idea of 'starting a game' and 'making game actions' in upcoming PR's

Demo:

https://user-images.githubusercontent.com/1839462/156121291-c874f3c9-aa4f-41b3-8e0f-a10f23c2b1ce.mov

