### PR TITLE
Cleanup: Improved Routing Usage

### DIFF
--- a/src/client/components/App/App.spec.tsx
+++ b/src/client/components/App/App.spec.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { render } from '@/test-utils';
 
 import { App } from './App';
 import { RootState } from '@/client/redux/store';
 
 describe('App', () => {
-    it('goes to the compact decklist view', () => {
+    it('renders a name selection', () => {
         const preloadedState: Partial<RootState> = {
             user: {
-                name: 'Grestch',
+                name: '',
             },
         };
         render(<App />, { preloadedState });
-        expect(
-            screen.queryByText('Deal 3 damage to any target')
-        ).toBeInTheDocument();
-        fireEvent.click(screen.getByText('Compact Deck List'));
-        expect(
-            screen.queryByText('Deal 3 damage to any target')
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Select a Name')).toBeInTheDocument();
+    });
+
+    it('renders a particular name if already selected', () => {
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Gretsch',
+            },
+        };
+        render(<App />, { preloadedState });
+        expect(screen.queryByText('Name: Gretsch')).toBeInTheDocument();
     });
 });

--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { HistoryRouter as Router } from 'redux-first-history/rr6';
-import { Link, Route, Routes } from 'react-router-dom';
+import { push } from 'redux-first-history';
+import { Route, Routes } from 'react-router-dom';
 
 import { makeSampleDeck1 } from '@/factories/deck';
 import { isUserInitialized } from '@/client/redux/selectors';
 import { history, RootState } from '@/client/redux/store';
 
 import { DeckList } from '../DeckList';
-import { CompactDeckList } from '../CompactDeckList';
 import { IntroScreen } from '../IntroScreen';
 import { Rooms } from '../Rooms';
 import { WebSocketProvider } from '../WebSockets';
@@ -18,31 +18,38 @@ export const App: React.FC = () => {
 
     const isUserPastIntroScreen = useSelector<RootState>(isUserInitialized);
 
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (history.location.pathname !== '/') {
+            dispatch(push('/'));
+        }
+    }, []);
+
     return (
         <WebSocketProvider>
             <div>
-                <IntroScreen />
-                <br />
                 <Router history={history}>
-                    {isUserPastIntroScreen && (
+                    {
                         <React.Fragment>
-                            <Link to="/">Deck List 1</Link>
-                            <br />
-                            <Link to="/compact">Compact Deck List</Link>
-
+                            <IntroScreen />
                             <Routes>
                                 <Route
                                     path="/"
-                                    element={<DeckList deck={deck} />}
+                                    element={
+                                        <>
+                                            {isUserPastIntroScreen && <Rooms />}
+                                        </>
+                                    }
                                 />
                                 <Route
-                                    path="/compact"
-                                    element={<CompactDeckList deck={deck} />}
+                                    path="/ingame"
+                                    element={<div>IN-GAME</div>}
                                 />
                                 <Route element={<DeckList deck={deck} />} />
                             </Routes>
                         </React.Fragment>
-                    )}
+                    }
                 </Router>
             </div>
         </WebSocketProvider>

--- a/src/client/components/IntroScreen/IntroScreen.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.tsx
@@ -4,7 +4,8 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/client/redux/store';
 import { NameChanger } from '../NameChanger';
 import { WebSocketContext } from '../WebSockets';
-import { Rooms } from '../Rooms';
+
+// TODO: rename IntroScreen to LoginBar
 
 /**
  * The Intro Screen is where people set their names / see games in
@@ -30,7 +31,6 @@ export const IntroScreen: React.FC = () => {
                     <button type="button" onClick={logOut}>
                         Logout
                     </button>
-                    <Rooms />
                 </>
             ) : (
                 <NameChanger handleSubmit={handleSubmit} />

--- a/src/client/components/IntroScreen/IntroScreen.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.tsx
@@ -5,7 +5,7 @@ import { RootState } from '@/client/redux/store';
 import { NameChanger } from '../NameChanger';
 import { WebSocketContext } from '../WebSockets';
 
-// TODO: rename IntroScreen to LoginBar
+// TODO: rename IntroScreen to LoginBar: https://github.com/lijim/monks-and-mages/issues/28
 
 /**
  * The Intro Screen is where people set their names / see games in

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -21,6 +21,9 @@ export const Rooms: React.FC = () => {
     // TODO:
     // only allow 1 room at a time to be joined
 
+    // TODO:
+    // don't allow players outside a room to start a room
+
     return (
         <div>
             {rooms.map((detailedRoom) => (

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { io, Socket } from 'socket.io-client';
 
+import { push } from 'redux-first-history';
 import {
     chooseName as chooseNameReducer,
     initializeUser,
@@ -50,6 +51,10 @@ export const WebSocketProvider: React.FC = ({ children }) => {
 
         newSocket.on('listRooms', (detailedRooms) => {
             dispatch(updateRoomsAndPlayers(detailedRooms));
+        });
+
+        newSocket.on('startGame', () => {
+            dispatch(push('/ingame'));
         });
 
         // Client-to-server events

--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -29,11 +29,14 @@ export const store = configureStore({
     preloadedState,
 });
 
-export const configureStoreWithMiddlewares = (stateOverrides = {}) => {
+export const configureStoreWithMiddlewares = (
+    stateOverrides = {},
+    routerMiddlewareOveride = routerMiddleware
+) => {
     return configureStore({
         reducer: createRootReducer(),
         devTools: true,
-        enhancers: [applyMiddleware(routerMiddleware)],
+        enhancers: [applyMiddleware(routerMiddlewareOveride)],
         preloadedState: {
             ...preloadedState,
             ...stateOverrides,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -111,6 +111,7 @@ io.on(
                     roomName,
                     makeNewBoard(getNamesFromIds([...socketIds]))
                 );
+                io.to(roomName).emit('startGame');
             });
             io.emit('listRooms', getDetailedRooms());
         });

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -43,7 +43,10 @@ export function render(
         history,
     });
 
-    const store = configureStoreWithMiddlewares(preloadedState);
+    const store = configureStoreWithMiddlewares(
+        preloadedState,
+        routerMiddleware
+    );
 
     function Wrapper({ children }: { children?: ReactNode }): ReactElement {
         return <Provider store={store}>{children}</Provider>;

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -8,6 +8,8 @@ import {
 } from '@testing-library/react';
 import React, { ReactElement, ReactNode } from 'react';
 import { Provider } from 'react-redux';
+import { createReduxHistoryContext } from 'redux-first-history';
+import { createBrowserHistory } from 'history';
 
 import { configureStoreWithMiddlewares, RootState } from '@/client/redux/store';
 
@@ -22,12 +24,27 @@ type ReduxRenderOptions = {
 // incorporate redux state into tests
 export function render(
     ui: ReactElement,
-    {
-        preloadedState = {},
-        store = configureStoreWithMiddlewares(preloadedState),
-        ...renderOptions
-    }: ReduxRenderOptions = {}
+    { preloadedState = {}, ...renderOptions }: ReduxRenderOptions = {}
 ): RenderResult {
+    const originalHistory = createBrowserHistory();
+
+    // history-mocking test utils from:
+    // https://github.com/salvoravida/redux-first-history/blob/master/__tests__/store.ts
+    const history = {
+        ...originalHistory,
+        go: jest.fn(originalHistory.go),
+        back: jest.fn(originalHistory.back),
+        forward: jest.fn(originalHistory.forward),
+        push: jest.fn(originalHistory.push),
+        replace: jest.fn(originalHistory.replace),
+    };
+
+    const { routerMiddleware } = createReduxHistoryContext({
+        history,
+    });
+
+    const store = configureStoreWithMiddlewares(preloadedState);
+
     function Wrapper({ children }: { children?: ReactNode }): ReactElement {
         return <Provider store={store}>{children}</Provider>;
     }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,7 @@
 interface ServerToClientEvents {
     confirmName: (name: string) => void;
     listRooms: (rooms: DetailedRoom[]) => void;
+    startGame: () => void;
 }
 
 interface ClientToServerEvents {


### PR DESCRIPTION
Cleanup around the way we consume the router from redux-first-history / react-router v6.

1. Adds a serverToClient event called startGame that makes all users in the room dispatch the history event of /ingame

2. On the app, I made a useEffect that pushes '/' on the initial load of the page.  I don't foresee a use for saving the memory right now, so we're going to merely dispatch this instead

3. Removed the Rooms display off IntroScreen and into the main App's Routes component.  Right now introScreen is more aptly 'LoginBar' b/c it's only handling where users set their names and log out