### PR TITLE
Make type.d.ts a non-ambient file

### DIFF
--- a/src/client/components/RoomSquare/RoomSquare.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { DetailedRoom } from '@/types';
+
 type RoomSquareProps = {
     detailedRoom: DetailedRoom;
     onStartGameClicked?: () => void;

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { RoomSquare } from '../RoomSquare/RoomSquare';
 import { RootState } from '@/client/redux/store';
 import { WebSocketContext } from '../WebSockets';
+import { DetailedRoom } from '@/types';
 
 export const Rooms: React.FC = () => {
     const rooms = useSelector<RootState, DetailedRoom[]>(

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -8,6 +8,7 @@ import {
     initializeUser,
 } from '@/client/redux/user';
 import { updateRoomsAndPlayers } from '@/client/redux/room';
+import { ClientToServerEvents, ServerToClientEvents } from '@/types';
 
 export const WebSocketContext = createContext<WebSocketValue>(null);
 

--- a/src/client/redux/room/room.ts
+++ b/src/client/redux/room/room.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
+import { DetailedRoom } from '@/types';
 
 export const roomsSlice = createSlice({
     name: 'rooms',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,11 @@ import { Server, Socket } from 'socket.io';
 import { instrument } from '@socket.io/admin-ui';
 import { Board } from '@/types/board';
 import { makeNewBoard } from '@/factories/board/makeNewBoard';
+import {
+    ClientToServerEvents,
+    DetailedRoom,
+    ServerToClientEvents,
+} from '@/types';
 
 const app = express();
 const port = 3000;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,20 @@
-interface ServerToClientEvents {
+import { Board } from './types/board';
+
+export interface ServerToClientEvents {
     confirmName: (name: string) => void;
     listRooms: (rooms: DetailedRoom[]) => void;
     startGame: () => void;
+    updateBoard: (board: Board) => void;
 }
 
-interface ClientToServerEvents {
+export interface ClientToServerEvents {
     chooseName: (name: string) => void;
     getRooms: () => void;
     joinRoom: (roomName: string) => void;
     startGame: () => void;
 }
 
-type DetailedRoom = {
+export type DetailedRoom = {
     hasStartedGame?: boolean;
     players: string[];
     roomName: string;


### PR DESCRIPTION
I'm adding a serverToClientEvent method called updateBoard that updates sockets with a particular board state.

In order to integrate this, we need to add an import file to types.d.ts.  However, the moment that we have an import in a .d.ts file, it no longer becomes global:

https://stackoverflow.com/questions/39040108/import-class-in-definition-file-d-ts

Renamed it to just types.ts to reflect this