### PR TITLE
Add board-obscuring logic

### DIFF
--- a/src/client/components/GameBoard/GameBoard.spec.tsx
+++ b/src/client/components/GameBoard/GameBoard.spec.tsx
@@ -4,7 +4,7 @@ import { render } from '@/test-utils';
 
 import { GameBoard } from './GameBoard';
 import { RootState } from '@/client/redux/store';
-import { makeNewBoard } from '@/factories/board/makeNewBoard';
+import { makeNewBoard } from '@/factories/board';
 
 describe('GameBoard', () => {
     it('renders player names', () => {

--- a/src/factories/board/index.ts
+++ b/src/factories/board/index.ts
@@ -1,0 +1,1 @@
+export * from './makeNewBoard';

--- a/src/factories/board/makeNewBoard.ts
+++ b/src/factories/board/makeNewBoard.ts
@@ -1,6 +1,6 @@
 import { Board, GameState } from '@/types/board';
 import { SAMPLE_DECKLIST_1 } from '../deck';
-import { makeNewPlayer } from '../player/makeNewPlayer';
+import { makeNewPlayer } from '../player';
 
 export const makeNewBoard = (playerNames: string[]): Board => {
     return {

--- a/src/factories/player/index.ts
+++ b/src/factories/player/index.ts
@@ -1,0 +1,1 @@
+export * from './makeNewPlayer';

--- a/src/factories/player/makeNewPlayer.ts
+++ b/src/factories/player/makeNewPlayer.ts
@@ -1,3 +1,5 @@
+import shuffle from 'lodash.shuffle';
+
 import { Player } from '@/types/board';
 import { DeckList } from '@/types/cards';
 import { makeDeck } from '../deck';
@@ -7,17 +9,20 @@ export const makeNewPlayer = (
     decklist: DeckList
 ): Player => {
     const deck = makeDeck(decklist);
+    const shuffledDeck = shuffle(deck);
+    const activeDeck = shuffledDeck.slice(7);
+    const hand = shuffledDeck.slice(0, 7);
     return {
         cemetery: [],
-        deck,
+        deck: activeDeck,
         effectQueue: [],
-        hand: [],
+        hand,
         health: 15,
         isActivePlayer: false,
         isAlive: true,
         name: playerName,
-        numCardsInDeck: deck.length,
-        numCardsInHand: 0,
+        numCardsInDeck: activeDeck.length,
+        numCardsInHand: hand.length,
         resourcePool: {},
         resources: [],
         resourcesLeftToDeploy: 1,

--- a/src/server/obscureBoardInfo/index.ts
+++ b/src/server/obscureBoardInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './obscureBoardInfo';

--- a/src/server/obscureBoardInfo/obscureBoardInfo.spec.ts
+++ b/src/server/obscureBoardInfo/obscureBoardInfo.spec.ts
@@ -1,0 +1,34 @@
+import { makeNewBoard } from '@/factories/board';
+import { obscureBoardInfo } from './obscureBoardInfo';
+
+describe('Obscure board info', () => {
+    it("hides other players' hands", () => {
+        const board = makeNewBoard(['Timmy', 'Tom']);
+        const boardTommySees = obscureBoardInfo(board, 'Tom');
+        expect(
+            boardTommySees.players.find((player) => player.name === 'Timmy')
+                .hand
+        ).toEqual([]);
+    });
+
+    it('does not hide your own hand', () => {
+        const board = makeNewBoard(['Timmy', 'Tom']);
+        const boardTommySees = obscureBoardInfo(board, 'Tom');
+        expect(
+            boardTommySees.players.find((player) => player.name === 'Tom').hand
+        ).not.toEqual([]);
+    });
+
+    it('hides decks', () => {
+        const board = makeNewBoard(['Timmy', 'Tom']);
+        const boardTommySees = obscureBoardInfo(board, 'Tom');
+        expect(
+            boardTommySees.players.find((player) => player.name === 'Tom').deck
+        ).toEqual([]);
+
+        expect(
+            boardTommySees.players.find((player) => player.name === 'Timmy')
+                .deck
+        ).toEqual([]);
+    });
+});

--- a/src/server/obscureBoardInfo/obscureBoardInfo.ts
+++ b/src/server/obscureBoardInfo/obscureBoardInfo.ts
@@ -1,0 +1,25 @@
+import cloneDeep from 'lodash.clonedeep';
+
+import { Board } from '@/types/board';
+
+/**
+ * @param board - players, game state, and chat log
+ * @param forPlayerName - the player name to not hide information for (e.g. don't hide the player's hand)
+ */
+export const obscureBoardInfo = (
+    board: Board,
+    forPlayerName: string
+): Board => {
+    const obscuredBoard = cloneDeep(board);
+
+    obscuredBoard.players
+        .filter((player) => player.name !== forPlayerName)
+        .forEach((player) => {
+            player.hand = [];
+        });
+
+    obscuredBoard.players.forEach((player) => {
+        player.deck = [];
+    });
+    return obscuredBoard;
+};


### PR DESCRIPTION
Part of #13:

`
Write a function called obscureHiddenInfo that obscures the 'cardInHand' information for everyone except for players. Also obscure the 'cardsInDeck' for all players. This function should be used on the updateBoard ServerToClient event.
`

https://user-images.githubusercontent.com/1839462/156501223-09ca1f59-b14c-4285-9640-abc2f0b57e7d.mov

After this update, players should not be able to see private, server-side only info, specifically:
- other players' hands
- the order of cards in decks.
