### PR TITLE
Display current vs. other players

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This project runs on a few core technologies:
 -   [socket.io](https://socket.io/)
 -   [React](https://reactjs.org/)
 -   [React Drag and Drop](https://react-dnd.github.io/react-dnd/about)
+-   [React Router v6](https://reactrouter.com)
 
 Linting on this project is done via a combination of typescript, [prettier](https://prettier.io/), and [eslint](https://eslint.org/)
 

--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { HistoryRouter as Router } from 'redux-first-history/rr6';
-import { push } from 'redux-first-history';
 import { Route, Routes } from 'react-router-dom';
 
 import { makeSampleDeck1 } from '@/factories/deck';
@@ -18,14 +17,6 @@ export const App: React.FC = () => {
     const deck = makeSampleDeck1();
 
     const isUserPastIntroScreen = useSelector<RootState>(isUserInitialized);
-
-    const dispatch = useDispatch();
-
-    useEffect(() => {
-        if (history.location.pathname !== '/') {
-            dispatch(push('/'));
-        }
-    }, []);
 
     return (
         <WebSocketProvider>

--- a/src/client/components/GameBoard/GameBoard.tsx
+++ b/src/client/components/GameBoard/GameBoard.tsx
@@ -1,19 +1,36 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
+import { getCurrentPlayer, getOtherPlayers } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
 import { Player } from '@/types/board';
+import { CardGridItem } from '../CardGridItem';
 
 export const GameBoard: React.FC = () => {
-    const players = useSelector<RootState, Player[]>(
-        (state) => state.board?.players || []
+    const currentPlayer = useSelector<RootState, Player | null>(
+        getCurrentPlayer
     );
+    const otherPlayers = useSelector<RootState, Player[]>(getOtherPlayers);
 
     return (
         <div>
             Game started
-            {players.map((player) => (
-                <li key={player.name}>{player.name}</li>
+            {currentPlayer && (
+                <>
+                    <li>
+                        <b>{currentPlayer.name}</b>
+                    </li>
+                    {currentPlayer.hand.map((card) => (
+                        <CardGridItem card={card} />
+                    ))}
+                </>
+            )}
+            {otherPlayers.map((player) => (
+                <li key={player.name}>
+                    <b>{player.name}</b>
+                    <br />
+                    Cards in Hand: {player.numCardsInHand}
+                </li>
             ))}
         </div>
     );

--- a/src/client/redux/selectors.spec.ts
+++ b/src/client/redux/selectors.spec.ts
@@ -1,4 +1,9 @@
-import { isUserInitialized } from './selectors';
+import { makeNewBoard } from '@/factories/board';
+import {
+    getCurrentPlayer,
+    getOtherPlayers,
+    isUserInitialized,
+} from './selectors';
 
 describe('selectors', () => {
     describe('isUserInitialized', () => {
@@ -16,6 +21,58 @@ describe('selectors', () => {
                     user: { name: '' },
                 })
             ).toBe(false);
+        });
+    });
+
+    describe('getCurrentPlayer', () => {
+        it('returns the player that matches the name', () => {
+            const state = {
+                user: { name: 'Bruno' },
+                board: makeNewBoard(['Bruno', 'Carla']),
+            };
+            expect(getCurrentPlayer(state).name).toBe('Bruno');
+        });
+    });
+
+    describe('getOtherPlayers', () => {
+        it('returns all players for spectators', () => {
+            const state = {
+                user: { name: 'Bobby' },
+                board: makeNewBoard(['Bruno', 'Carla', 'James']),
+            };
+            expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
+                ['Bruno', 'Carla', 'James']
+            );
+        });
+
+        it('returns in rotating order (in the middle)', () => {
+            const state = {
+                user: { name: 'Bruno' },
+                board: makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']),
+            };
+            expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
+                ['Carla', 'Dionne', 'Alex']
+            );
+        });
+
+        it('returns in rotating order (first in board order)', () => {
+            const state = {
+                user: { name: 'Alex' },
+                board: makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']),
+            };
+            expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
+                ['Bruno', 'Carla', 'Dionne']
+            );
+        });
+
+        it('returns in rotating order (last in board order)', () => {
+            const state = {
+                user: { name: 'Dionne' },
+                board: makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']),
+            };
+            expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
+                ['Alex', 'Bruno', 'Carla']
+            );
         });
     });
 });

--- a/src/client/redux/selectors.ts
+++ b/src/client/redux/selectors.ts
@@ -1,4 +1,29 @@
+import { Player } from '@/types/board';
 import { RootState } from './store';
 
 export const isUserInitialized = (state: Partial<RootState>): boolean =>
     !!state.user.name;
+
+// get the Player
+export const getCurrentPlayer = (state: Partial<RootState>): Player | null => {
+    if (!state.board?.players) return null;
+
+    return (state.board.players || []).find(
+        (player) => player.name === state.user.name
+    );
+};
+
+// get other players, by turn order
+export const getOtherPlayers = (state: Partial<RootState>): Player[] => {
+    if (!state.board?.players) return [];
+
+    const indexOfCurrentPlayer = state.board.players.findIndex(
+        (player) => player?.name === state.user.name
+    );
+    if (indexOfCurrentPlayer === -1) {
+        return state.board.players;
+    }
+    const nextPlayers = state.board.players.slice(indexOfCurrentPlayer + 1);
+    const prevPlayers = state.board.players.slice(0, indexOfCurrentPlayer);
+    return [...nextPlayers, ...prevPlayers];
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,8 +13,12 @@ app.use('/client.bundle.js', (_, res) => {
 });
 
 // Serves the base page
-app.get('*', (_, res) => {
+app.get('/', (_, res) => {
     res.sendFile(path.join(__dirname, 'homepage.html'));
+});
+
+app.get('*', (_, res) => {
+    res.redirect('/');
 });
 
 configureIo(server);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,9 @@ const clientConfig = {
     entry: {
         client: './src/client/index.tsx',
     },
+    optimization: {
+        minimize: false
+    },
     target: 'web',
     mode: 'production',
     module: {


### PR DESCRIPTION
This PR moves the logic for redirecting over into the express side, instead of the app side.

- Added selectors for displaying the current player + the other players.  Closes #38 
- light reconfiguration of GameBoard to demo showing off the current vs. other player paradigm

Next up:
https://github.com/lijim/monks-and-mages/issues/39

https://user-images.githubusercontent.com/1839462/156694896-7a5bdd9e-9301-4f9c-bd51-f321b4a2c6fb.mov

