### PR TITLE
Add 'active player' logic

### DIFF
--- a/src/client/components/GameBoard/GameBoard.spec.tsx
+++ b/src/client/components/GameBoard/GameBoard.spec.tsx
@@ -17,5 +17,6 @@ describe('GameBoard', () => {
         render(<GameBoard />, { preloadedState });
         expect(screen.queryByText('Tommy')).toBeInTheDocument();
         expect(screen.queryByText('Timmy')).toBeInTheDocument();
+        expect(screen.queryAllByText('Active Player')).toHaveLength(1);
     });
 });

--- a/src/client/components/GameBoard/GameBoard.tsx
+++ b/src/client/components/GameBoard/GameBoard.tsx
@@ -18,9 +18,11 @@ const CurrentPlayerBoard: React.FC<CurrentPlayerBoardProps> = ({
         <>
             <li>
                 <b>{currentPlayer.name}</b>
+                {currentPlayer.isActivePlayer && <div>Active Player</div>}
             </li>
-            {currentPlayer.hand.map((card) => (
-                <CardGridItem card={card} />
+            {/* TODO: make cards have unique id's and use that as the key instead of index */}
+            {currentPlayer.hand.map((card, index) => (
+                <CardGridItem key={index} card={card} />
             ))}
         </>
     );
@@ -33,7 +35,10 @@ interface OtherPlayerBoardProps {
 const OtherPlayerBoard: React.FC<OtherPlayerBoardProps> = ({ player }) => {
     return (
         <li>
-            <b>{player.name}</b>
+            <b>
+                {player.name}
+                {player.isActivePlayer && <div>Active Player</div>}
+            </b>
             <br />
             Cards in Hand: {player.numCardsInHand}
         </li>

--- a/src/client/components/GameBoard/GameBoard.tsx
+++ b/src/client/components/GameBoard/GameBoard.tsx
@@ -6,6 +6,40 @@ import { RootState } from '@/client/redux/store';
 import { Player } from '@/types/board';
 import { CardGridItem } from '../CardGridItem';
 
+interface CurrentPlayerBoardProps {
+    currentPlayer: Player;
+}
+
+const CurrentPlayerBoard: React.FC<CurrentPlayerBoardProps> = ({
+    currentPlayer,
+}) => {
+    if (!currentPlayer) return null;
+    return (
+        <>
+            <li>
+                <b>{currentPlayer.name}</b>
+            </li>
+            {currentPlayer.hand.map((card) => (
+                <CardGridItem card={card} />
+            ))}
+        </>
+    );
+};
+
+interface OtherPlayerBoardProps {
+    player: Player;
+}
+
+const OtherPlayerBoard: React.FC<OtherPlayerBoardProps> = ({ player }) => {
+    return (
+        <li>
+            <b>{player.name}</b>
+            <br />
+            Cards in Hand: {player.numCardsInHand}
+        </li>
+    );
+};
+
 export const GameBoard: React.FC = () => {
     const currentPlayer = useSelector<RootState, Player | null>(
         getCurrentPlayer
@@ -15,22 +49,9 @@ export const GameBoard: React.FC = () => {
     return (
         <div>
             Game started
-            {currentPlayer && (
-                <>
-                    <li>
-                        <b>{currentPlayer.name}</b>
-                    </li>
-                    {currentPlayer.hand.map((card) => (
-                        <CardGridItem card={card} />
-                    ))}
-                </>
-            )}
+            <CurrentPlayerBoard currentPlayer={currentPlayer} />
             {otherPlayers.map((player) => (
-                <li key={player.name}>
-                    <b>{player.name}</b>
-                    <br />
-                    Cards in Hand: {player.numCardsInHand}
-                </li>
+                <OtherPlayerBoard key={player.name} player={player} />
             ))}
         </div>
     );

--- a/src/factories/board/makeNewBoard.spec.ts
+++ b/src/factories/board/makeNewBoard.spec.ts
@@ -9,5 +9,19 @@ describe('Make New Board', () => {
         expect(board.players[1].health).toEqual(15);
     });
 
+    it('makes a random player the starting player', () => {
+        const board = makeNewBoard(['Hal', 'Orin', 'Samus']);
+        expect(
+            board.players[0].isActivePlayer ||
+                board.players[1].isActivePlayer ||
+                board.players[2].isActivePlayer
+        ).toEqual(true);
+        expect(
+            board.players[0].isActivePlayer &&
+                board.players[1].isActivePlayer &&
+                board.players[2].isActivePlayer
+        ).toEqual(false);
+    });
+
     it.todo('caps at 4 players and makes everyone else a spectator');
 });

--- a/src/factories/board/makeNewBoard.ts
+++ b/src/factories/board/makeNewBoard.ts
@@ -3,11 +3,14 @@ import { SAMPLE_DECKLIST_1 } from '../deck';
 import { makeNewPlayer } from '../player';
 
 export const makeNewBoard = (playerNames: string[]): Board => {
+    const players = playerNames.map((playerName) =>
+        makeNewPlayer(playerName, SAMPLE_DECKLIST_1)
+    );
+
+    players[Math.floor(Math.random() * players.length)].isActivePlayer = true;
     return {
         chatLog: [],
         gameState: GameState.PLAYING,
-        players: playerNames.map((playerName) =>
-            makeNewPlayer(playerName, SAMPLE_DECKLIST_1)
-        ),
+        players,
     };
 };


### PR DESCRIPTION
adds the concept of 'active player' into makeBoard, so that when we do #39, we have an active player to validate + a player to pass the turn to

<img width="1344" alt="Screen Shot 2022-03-03 at 11 21 05 PM" src="https://user-images.githubusercontent.com/1839462/156698799-07e3b59c-964d-4e48-9af9-e0aa6b1b117d.png">
 