### PR TITLE
Move out `SelfPlayerBoard` and `OtherPlayerBoard` sections

### DIFF
--- a/src/client/components/GameBoard/GameBoard.tsx
+++ b/src/client/components/GameBoard/GameBoard.tsx
@@ -1,43 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { getCurrentPlayer, getOtherPlayers } from '@/client/redux/selectors';
+import { getOtherPlayers } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
 import { Player } from '@/types/board';
-import { CardGridItem } from '../CardGridItem';
-import { WebSocketContext } from '../WebSockets';
-import { GameActionTypes } from '@/types/gameActions';
-
-interface CurrentPlayerBoardProps {
-    currentPlayer: Player;
-}
-
-const CurrentPlayerBoard: React.FC<CurrentPlayerBoardProps> = ({
-    currentPlayer,
-}) => {
-    const webSocket = useContext(WebSocketContext);
-    const passTurn = () => {
-        webSocket.takeGameAction({ type: GameActionTypes.PASS_TURN });
-    };
-    if (!currentPlayer) return null;
-    return (
-        <>
-            <li>
-                <b>{currentPlayer.name}</b>
-                {currentPlayer.isActivePlayer && (
-                    <>
-                        <div>Active Player</div>
-                        <button onClick={passTurn}>Pass Turn</button>
-                    </>
-                )}
-            </li>
-            {/* TODO: make cards have unique id's and use that as the key instead of index */}
-            {currentPlayer.hand.map((card, index) => (
-                <CardGridItem key={index} card={card} />
-            ))}
-        </>
-    );
-};
+import { SelfPlayerBoard } from '../SelfPlayerBoard';
 
 interface OtherPlayerBoardProps {
     player: Player;
@@ -57,15 +24,12 @@ const OtherPlayerBoard: React.FC<OtherPlayerBoardProps> = ({ player }) => {
 };
 
 export const GameBoard: React.FC = () => {
-    const currentPlayer = useSelector<RootState, Player | null>(
-        getCurrentPlayer
-    );
     const otherPlayers = useSelector<RootState, Player[]>(getOtherPlayers);
 
     return (
         <div>
             Game started
-            <CurrentPlayerBoard currentPlayer={currentPlayer} />
+            <SelfPlayerBoard />
             {otherPlayers.map((player) => (
                 <OtherPlayerBoard key={player.name} player={player} />
             ))}

--- a/src/client/components/GameBoard/GameBoard.tsx
+++ b/src/client/components/GameBoard/GameBoard.tsx
@@ -5,23 +5,7 @@ import { getOtherPlayers } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
 import { Player } from '@/types/board';
 import { SelfPlayerBoard } from '../SelfPlayerBoard';
-
-interface OtherPlayerBoardProps {
-    player: Player;
-}
-
-const OtherPlayerBoard: React.FC<OtherPlayerBoardProps> = ({ player }) => {
-    return (
-        <li>
-            <b>
-                {player.name}
-                {player.isActivePlayer && <div>Active Player</div>}
-            </b>
-            <br />
-            Cards in Hand: {player.numCardsInHand}
-        </li>
-    );
-};
+import { OtherPlayerBoard } from '../OtherPlayerBoard';
 
 export const GameBoard: React.FC = () => {
     const otherPlayers = useSelector<RootState, Player[]>(getOtherPlayers);
@@ -29,10 +13,10 @@ export const GameBoard: React.FC = () => {
     return (
         <div>
             Game started
-            <SelfPlayerBoard />
             {otherPlayers.map((player) => (
                 <OtherPlayerBoard key={player.name} player={player} />
             ))}
+            <SelfPlayerBoard />
         </div>
     );
 };

--- a/src/client/components/OtherPlayerBoard/OtherPlayerBoard.spec.tsx
+++ b/src/client/components/OtherPlayerBoard/OtherPlayerBoard.spec.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OtherPlayerBoard } from './OtherPlayerBoard';
+import { makeNewPlayer } from '@/factories/player';
+import { SAMPLE_DECKLIST_1 } from '@/factories/deck';
+
+describe('Other Player Board Section', () => {
+    it("renders the other player's name", () => {
+        const player = makeNewPlayer('Phyllis', SAMPLE_DECKLIST_1);
+        render(<OtherPlayerBoard player={player} />);
+        expect(screen.getByText('Phyllis')).toBeInTheDocument();
+    });
+});

--- a/src/client/components/OtherPlayerBoard/OtherPlayerBoard.tsx
+++ b/src/client/components/OtherPlayerBoard/OtherPlayerBoard.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Player } from '@/types/board';
+
+interface OtherPlayerBoardProps {
+    player: Player;
+}
+
+/**
+ * @returns {JSX.Element} - returns another player's section of the board (not the self-player),
+ * including all their units and resources
+ */
+export const OtherPlayerBoard: React.FC<OtherPlayerBoardProps> = ({
+    player,
+}) => {
+    return (
+        <li>
+            <b>
+                {player.name}
+                {player.isActivePlayer && <div>Active Player</div>}
+            </b>
+            <br />
+            Cards in Hand: {player.numCardsInHand}
+        </li>
+    );
+};

--- a/src/client/components/OtherPlayerBoard/index.ts
+++ b/src/client/components/OtherPlayerBoard/index.ts
@@ -1,0 +1,1 @@
+export * from './OtherPlayerBoard';

--- a/src/client/components/SelfPlayerBoard/SelfPlayerBoard.spec.tsx
+++ b/src/client/components/SelfPlayerBoard/SelfPlayerBoard.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { RootState } from '@/client/redux/store';
+import { makeNewBoard } from '@/factories/board';
+import { render } from '@/test-utils';
+import { SelfPlayerBoard } from './SelfPlayerBoard';
+
+describe('Self Player Board', () => {
+    it('renders your hand', () => {
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Melvin',
+            },
+            board: makeNewBoard(['Melvin', 'Melissa']),
+        };
+        render(<SelfPlayerBoard />, { preloadedState });
+        const unitCards = screen.queryAllByTestId('UnitGridItem');
+        const resourceCards = screen.queryAllByTestId('ResourceCard-GridItem');
+        const spellCards = screen.queryAllByTestId('SpellGridItem');
+        expect(
+            unitCards.length + resourceCards.length + spellCards.length
+        ).toEqual(preloadedState.board.players[0].numCardsInHand);
+    });
+});

--- a/src/client/components/SelfPlayerBoard/SelfPlayerBoard.tsx
+++ b/src/client/components/SelfPlayerBoard/SelfPlayerBoard.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
 
-import { getCurrentPlayer } from '@/client/redux/selectors';
+import { getSelfPlayer } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
 import { Player } from '@/types/board';
 import { GameActionTypes } from '@/types/gameActions';
@@ -13,20 +13,18 @@ import { WebSocketContext } from '../WebSockets';
  * for the self-player's (aka your) side of the board
  */
 export const SelfPlayerBoard: React.FC = () => {
-    const currentPlayer = useSelector<RootState, Player | null>(
-        getCurrentPlayer
-    );
+    const selfPlayer = useSelector<RootState, Player | null>(getSelfPlayer);
 
     const webSocket = useContext(WebSocketContext);
     const passTurn = () => {
         webSocket.takeGameAction({ type: GameActionTypes.PASS_TURN });
     };
-    if (!currentPlayer) return null;
+    if (!selfPlayer) return null;
     return (
         <>
             <li>
-                <b>{currentPlayer.name}</b>
-                {currentPlayer.isActivePlayer && (
+                <b>{selfPlayer.name}</b>
+                {selfPlayer.isActivePlayer && (
                     <>
                         <div>Active Player</div>
                         <button onClick={passTurn}>Pass Turn</button>
@@ -34,7 +32,7 @@ export const SelfPlayerBoard: React.FC = () => {
                 )}
             </li>
             {/* TODO: make cards have unique id's and use that as the key instead of index */}
-            {currentPlayer.hand.map((card, index) => (
+            {selfPlayer.hand.map((card, index) => (
                 <CardGridItem key={index} card={card} />
             ))}
         </>

--- a/src/client/components/SelfPlayerBoard/SelfPlayerBoard.tsx
+++ b/src/client/components/SelfPlayerBoard/SelfPlayerBoard.tsx
@@ -1,0 +1,42 @@
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
+
+import { getCurrentPlayer } from '@/client/redux/selectors';
+import { RootState } from '@/client/redux/store';
+import { Player } from '@/types/board';
+import { GameActionTypes } from '@/types/gameActions';
+import { CardGridItem } from '../CardGridItem';
+import { WebSocketContext } from '../WebSockets';
+
+/**
+ * @returns {JSX.Element} - represents everything deployed (units and resources)
+ * for the self-player's (aka your) side of the board
+ */
+export const SelfPlayerBoard: React.FC = () => {
+    const currentPlayer = useSelector<RootState, Player | null>(
+        getCurrentPlayer
+    );
+
+    const webSocket = useContext(WebSocketContext);
+    const passTurn = () => {
+        webSocket.takeGameAction({ type: GameActionTypes.PASS_TURN });
+    };
+    if (!currentPlayer) return null;
+    return (
+        <>
+            <li>
+                <b>{currentPlayer.name}</b>
+                {currentPlayer.isActivePlayer && (
+                    <>
+                        <div>Active Player</div>
+                        <button onClick={passTurn}>Pass Turn</button>
+                    </>
+                )}
+            </li>
+            {/* TODO: make cards have unique id's and use that as the key instead of index */}
+            {currentPlayer.hand.map((card, index) => (
+                <CardGridItem key={index} card={card} />
+            ))}
+        </>
+    );
+};

--- a/src/client/components/SelfPlayerBoard/index.ts
+++ b/src/client/components/SelfPlayerBoard/index.ts
@@ -1,0 +1,1 @@
+export * from './SelfPlayerBoard';

--- a/src/client/components/SpellGridItem/SpellGridItem.tsx
+++ b/src/client/components/SpellGridItem/SpellGridItem.tsx
@@ -23,7 +23,7 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({ card }) => {
 
     return (
         <CardFrame
-            data-testid="ResourceGridItem"
+            data-testid="SpellGridItem"
             primaryColor={getColorForCard(card)}
         >
             <CardHeader>

--- a/src/client/redux/selectors.spec.ts
+++ b/src/client/redux/selectors.spec.ts
@@ -1,9 +1,5 @@
 import { makeNewBoard } from '@/factories/board';
-import {
-    getCurrentPlayer,
-    getOtherPlayers,
-    isUserInitialized,
-} from './selectors';
+import { getSelfPlayer, getOtherPlayers, isUserInitialized } from './selectors';
 
 describe('selectors', () => {
     describe('isUserInitialized', () => {
@@ -24,13 +20,13 @@ describe('selectors', () => {
         });
     });
 
-    describe('getCurrentPlayer', () => {
+    describe('getSelfPlayer', () => {
         it('returns the player that matches the name', () => {
             const state = {
                 user: { name: 'Bruno' },
                 board: makeNewBoard(['Bruno', 'Carla']),
             };
-            expect(getCurrentPlayer(state).name).toBe('Bruno');
+            expect(getSelfPlayer(state).name).toBe('Bruno');
         });
     });
 

--- a/src/client/redux/selectors.ts
+++ b/src/client/redux/selectors.ts
@@ -5,7 +5,7 @@ export const isUserInitialized = (state: Partial<RootState>): boolean =>
     !!state.user.name;
 
 // get the Player
-export const getCurrentPlayer = (state: Partial<RootState>): Player | null => {
+export const getSelfPlayer = (state: Partial<RootState>): Player | null => {
     if (!state.board?.players) return null;
 
     return (state.board.players || []).find(
@@ -17,13 +17,13 @@ export const getCurrentPlayer = (state: Partial<RootState>): Player | null => {
 export const getOtherPlayers = (state: Partial<RootState>): Player[] => {
     if (!state.board?.players) return [];
 
-    const indexOfCurrentPlayer = state.board.players.findIndex(
+    const indexOfSelfPlayer = state.board.players.findIndex(
         (player) => player?.name === state.user.name
     );
-    if (indexOfCurrentPlayer === -1) {
+    if (indexOfSelfPlayer === -1) {
         return state.board.players;
     }
-    const nextPlayers = state.board.players.slice(indexOfCurrentPlayer + 1);
-    const prevPlayers = state.board.players.slice(0, indexOfCurrentPlayer);
+    const nextPlayers = state.board.players.slice(indexOfSelfPlayer + 1);
+    const prevPlayers = state.board.players.slice(0, indexOfSelfPlayer);
     return [...nextPlayers, ...prevPlayers];
 };

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -69,7 +69,6 @@ export const configureIo = (server: HttpServer) => {
         const firstRoomName = getRoomForSocket(socket);
         if (!firstRoomName) return null;
         const board = startedBoards.get(firstRoomName);
-        console.log(board);
         return board;
     };
 
@@ -140,7 +139,6 @@ export const configureIo = (server: HttpServer) => {
                 const board = getBoardForSocket(socket);
                 const roomName = getRoomForSocket(socket);
                 const playerName = idsToNames.get(socket.id);
-                console.log(playerName);
                 if (!board || !playerName) {
                     // TODO: add error handling emits down to the client, display via error toasts
                     return;
@@ -150,7 +148,6 @@ export const configureIo = (server: HttpServer) => {
                     gameAction,
                     playerName,
                 }); // calculate new state after actions is taken
-                console.log(newBoardState);
                 // TODO: add error handling when user tries to take an invalid action
                 startedBoards.set(roomName, newBoardState); // apply state changes to in-memory storage of boards
                 sendBoardForRoom(roomName); // update clients with changes


### PR DESCRIPTION
Internal refactoring (not any external facing changes in the client except switching the order of self / other players)

- renamed `CurrentPlayerBoard` to `SelfPlayerBoard` and extracted it.  Current player felt like it described the player with `isActivePlayer=true`, rather than the "self" player, which represent's the user's player.  We had already called it `SELF_PLAYER` under `types/effects.ts` - this just makes everything more consistent.

- extracted OtherPlayersBoard out to an external component to make it easier to manage

Partly covers #37.