### PR TITLE
Create PlayerBoardSection component

### DIFF
--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -29,13 +29,11 @@ const CenterColumn = styled.div`
     grid-template-rows: 1fr 1fr 100px;
 `;
 
-// TODO: rename OtherPlayerBoard to OtherPlayerInfo, rename OtherPlayerBoardSection to OtherPlayerBoard
-const OtherPlayerBoardSection = styled.div`
+const OtherPlayerBoard = styled.div`
     background-color: ${Colors.FELT_GREEN};
 `;
 
-// TODO: rename SelfPlayerBoard to SelfPlayerInfo, rename SelfPlayerBoardSection to SelfPlayerBoard
-const SelfPlayerBoardSection = styled.div`
+const SelfPlayerBoard = styled.div`
     background-color: ${Colors.FELT_GREEN_ALT};
 `;
 
@@ -60,12 +58,8 @@ export const GameDisplay: React.FC = () => {
                 <section></section>
             </LeftColumn>
             <CenterColumn>
-                <OtherPlayerBoardSection>
-                    Other Player Board
-                </OtherPlayerBoardSection>
-                <SelfPlayerBoardSection>
-                    Self Player Board
-                </SelfPlayerBoardSection>
+                <OtherPlayerBoard />
+                <SelfPlayerBoard />
                 <HandOfCards />
             </CenterColumn>
             <RightColumn>Right Chat Column</RightColumn>

--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
-import { getOtherPlayers } from '@/client/redux/selectors';
+import { getOtherPlayers, getSelfPlayer } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
 import { Colors } from '@/constants/colors';
 import { Player } from '@/types/board';
 import { SelfPlayerInfo } from '../SelfPlayerInfo';
 import { OtherPlayerInfo } from '../OtherPlayerInfo';
 import { HandOfCards } from '../HandOfCards';
+import { PlayerBoardSection } from '../PlayerBoardSection';
 
 const GameGrid = styled.div`
     width: 100%;
@@ -29,19 +30,12 @@ const CenterColumn = styled.div`
     grid-template-rows: 1fr 1fr 100px;
 `;
 
-const OtherPlayerBoard = styled.div`
-    background-color: ${Colors.FELT_GREEN};
-`;
-
-const SelfPlayerBoard = styled.div`
-    background-color: ${Colors.FELT_GREEN_ALT};
-`;
-
 const RightColumn = styled.div`
     border: 1px solid ${Colors.DARK_BROWN};
 `;
 
 export const GameDisplay: React.FC = () => {
+    const selfPlayer = useSelector<RootState, Player>(getSelfPlayer);
     const otherPlayers = useSelector<RootState, Player[]>(getOtherPlayers);
 
     return (
@@ -58,8 +52,10 @@ export const GameDisplay: React.FC = () => {
                 <section></section>
             </LeftColumn>
             <CenterColumn>
-                <OtherPlayerBoard />
-                <SelfPlayerBoard />
+                {otherPlayers.map((player) => (
+                    <PlayerBoardSection key={player.name} player={player} />
+                ))}
+                <PlayerBoardSection player={selfPlayer} isSelfPlayer />
                 <HandOfCards />
             </CenterColumn>
             <RightColumn>Right Chat Column</RightColumn>

--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -6,7 +6,7 @@ import { getOtherPlayers } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
 import { Colors } from '@/constants/colors';
 import { Player } from '@/types/board';
-import { SelfPlayerBoard } from '../SelfPlayerBoard';
+import { SelfPlayerInfo } from '../SelfPlayerInfo';
 import { OtherPlayerInfo } from '../OtherPlayerInfo';
 import { HandOfCards } from '../HandOfCards';
 
@@ -55,7 +55,7 @@ export const GameDisplay: React.FC = () => {
                     ))}
                 </section>
                 <section>
-                    <SelfPlayerBoard />
+                    <SelfPlayerInfo />
                 </section>
                 <section></section>
             </LeftColumn>

--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -7,7 +7,7 @@ import { RootState } from '@/client/redux/store';
 import { Colors } from '@/constants/colors';
 import { Player } from '@/types/board';
 import { SelfPlayerBoard } from '../SelfPlayerBoard';
-import { OtherPlayerBoard } from '../OtherPlayerBoard';
+import { OtherPlayerInfo } from '../OtherPlayerInfo';
 import { HandOfCards } from '../HandOfCards';
 
 const GameGrid = styled.div`
@@ -51,7 +51,7 @@ export const GameDisplay: React.FC = () => {
             <LeftColumn>
                 <section>
                     {otherPlayers.map((player) => (
-                        <OtherPlayerBoard key={player.name} player={player} />
+                        <OtherPlayerInfo key={player.name} player={player} />
                     ))}
                 </section>
                 <section>

--- a/src/client/components/OtherPlayerBoard/index.ts
+++ b/src/client/components/OtherPlayerBoard/index.ts
@@ -1,1 +1,0 @@
-export * from './OtherPlayerBoard';

--- a/src/client/components/OtherPlayerInfo/OtherPlayerInfo.spec.tsx
+++ b/src/client/components/OtherPlayerInfo/OtherPlayerInfo.spec.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { OtherPlayerBoard } from './OtherPlayerBoard';
+import { OtherPlayerInfo } from './OtherPlayerInfo';
 import { makeNewPlayer } from '@/factories/player';
 import { SAMPLE_DECKLIST_1 } from '@/factories/deck';
 
-describe('Other Player Board Section', () => {
+describe('Other Player Info', () => {
     it("renders the other player's name", () => {
         const player = makeNewPlayer('Phyllis', SAMPLE_DECKLIST_1);
-        render(<OtherPlayerBoard player={player} />);
+        render(<OtherPlayerInfo player={player} />);
         expect(screen.getByText('Phyllis')).toBeInTheDocument();
     });
 });

--- a/src/client/components/OtherPlayerInfo/OtherPlayerInfo.tsx
+++ b/src/client/components/OtherPlayerInfo/OtherPlayerInfo.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Player } from '@/types/board';
 import { PlayerBriefInfo } from '../PlayerBriefInfo';
 
-interface OtherPlayerBoardProps {
+interface OtherPlayerInfoProps {
     player: Player;
 }
 
@@ -11,8 +11,6 @@ interface OtherPlayerBoardProps {
  * @returns {JSX.Element} - returns another player's section of the board (not the self-player),
  * including all their units and resources
  */
-export const OtherPlayerBoard: React.FC<OtherPlayerBoardProps> = ({
-    player,
-}) => {
+export const OtherPlayerInfo: React.FC<OtherPlayerInfoProps> = ({ player }) => {
     return <PlayerBriefInfo player={player}></PlayerBriefInfo>;
 };

--- a/src/client/components/OtherPlayerInfo/OtherPlayerInfo.tsx
+++ b/src/client/components/OtherPlayerInfo/OtherPlayerInfo.tsx
@@ -8,8 +8,8 @@ interface OtherPlayerInfoProps {
 }
 
 /**
- * @returns {JSX.Element} - returns another player's section of the board (not the self-player),
- * including all their units and resources
+ * @returns {JSX.Element} - the other player's information (for the left hand side
+ * of the GameDisplay)
  */
 export const OtherPlayerInfo: React.FC<OtherPlayerInfoProps> = ({ player }) => {
     return <PlayerBriefInfo player={player}></PlayerBriefInfo>;

--- a/src/client/components/OtherPlayerInfo/index.ts
+++ b/src/client/components/OtherPlayerInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './OtherPlayerInfo';

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.spec.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { makeNewPlayer } from '@/factories/player';
+import { SAMPLE_DECKLIST_1 } from '@/factories/deck';
+import { PlayerBoardSection } from './PlayerBoardSection';
+import { makeCard, makeResourceCard } from '@/factories/cards';
+import { UnitCards } from '@/cardDb/units';
+import { Resource } from '@/types/resources';
+
+describe('Player Board Section', () => {
+    it('renders unit cards', () => {
+        const player = makeNewPlayer('April', SAMPLE_DECKLIST_1);
+        player.units = [
+            makeCard(UnitCards.FIRE_MAGE),
+            makeCard(UnitCards.WATER_MAGE),
+        ];
+        render(<PlayerBoardSection player={player} />);
+        expect(screen.getByText('Fire Mage')).toBeInTheDocument();
+    });
+
+    it('renders resource cards', () => {
+        const player = makeNewPlayer('April', SAMPLE_DECKLIST_1);
+        player.resources = [
+            makeResourceCard(Resource.BAMBOO),
+            makeResourceCard(Resource.FIRE),
+        ];
+        render(<PlayerBoardSection player={player} />);
+        expect(screen.getByText('Fire')).toBeInTheDocument();
+        expect(screen.getByText('Bamboo')).toBeInTheDocument();
+    });
+});

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Player } from '@/types/board';
+import { Colors } from '@/constants/colors';
+import { CardGridItem } from '../CardGridItem';
+
+interface PlayerBoardSectionProps {
+    isSelfPlayer?: boolean;
+    player: Player;
+}
+
+interface PlayerBoardSectionContainerProps {
+    isSelfPlayer: boolean;
+}
+
+const PlayerBoardSectionContainer = styled.div<PlayerBoardSectionContainerProps>`
+    background-color: ${({ isSelfPlayer }) =>
+        isSelfPlayer ? Colors.FELT_GREEN_ALT : Colors.FELT_GREEN};
+`;
+
+export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
+    isSelfPlayer,
+    player,
+}) => {
+    if (!player?.units || !player?.resources) {
+        return <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer} />;
+    }
+    const { units, resources } = player;
+    return (
+        <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer}>
+            <div>
+                {units.map((unitCard) => (
+                    <CardGridItem card={unitCard} />
+                ))}
+            </div>
+            <div>
+                {resources.map((resourceCard) => (
+                    <CardGridItem card={resourceCard} />
+                ))}
+            </div>
+        </PlayerBoardSectionContainer>
+    );
+};

--- a/src/client/components/PlayerBoardSection/index.ts
+++ b/src/client/components/PlayerBoardSection/index.ts
@@ -1,0 +1,1 @@
+export * from './PlayerBoardSection';

--- a/src/client/components/SelfPlayerBoard/index.ts
+++ b/src/client/components/SelfPlayerBoard/index.ts
@@ -1,1 +1,0 @@
-export * from './SelfPlayerBoard';

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
@@ -4,7 +4,7 @@ import { screen } from '@testing-library/react';
 import { RootState } from '@/client/redux/store';
 import { makeNewBoard } from '@/factories/board';
 import { render } from '@/test-utils';
-import { SelfPlayerBoard } from './SelfPlayerBoard';
+import { SelfPlayerInfo } from './SelfPlayerInfo';
 
 describe('Self Player Board', () => {
     it("renders the pass turn button, if you're the active player", () => {
@@ -14,7 +14,7 @@ describe('Self Player Board', () => {
             },
             board: makeNewBoard(['Melvin', 'Melissa'], 0),
         };
-        render(<SelfPlayerBoard />, { preloadedState });
+        render(<SelfPlayerInfo />, { preloadedState });
         expect(screen.getByText('Pass Turn')).toBeInTheDocument();
     });
 
@@ -25,7 +25,7 @@ describe('Self Player Board', () => {
             },
             board: makeNewBoard(['Melvin', 'Melissa'], 1),
         };
-        render(<SelfPlayerBoard />, { preloadedState });
+        render(<SelfPlayerInfo />, { preloadedState });
         expect(screen.queryByText('Pass Turn')).not.toBeInTheDocument();
     });
 });

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.tsx
@@ -9,10 +9,9 @@ import { WebSocketContext } from '../WebSockets';
 import { PlayerBriefInfo } from '../PlayerBriefInfo';
 
 /**
- * @returns {JSX.Element} - represents everything deployed (units and resources)
- * for the self-player's (aka your) side of the board
+ * @returns {JSX.Element} - your player info (health, cards, etc.) + the pass turn button
  */
-export const SelfPlayerBoard: React.FC = () => {
+export const SelfPlayerInfo: React.FC = () => {
     const selfPlayer = useSelector<RootState, Player | null>(getSelfPlayer);
 
     const webSocket = useContext(WebSocketContext);

--- a/src/client/components/SelfPlayerInfo/index.ts
+++ b/src/client/components/SelfPlayerInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './SelfPlayerInfo';


### PR DESCRIPTION
Refactors `OtherPlayerBoardSection` and `SelfPlayerBoardSection` to just be one `PlayerBoardSection` that unifies the two.

Closes #37 

Same as #53 visually, but this sets us up to implement #48