### PR TITLE
Visual updates for 'ResourcePool'

### DIFF
--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -23,6 +23,8 @@ const LeftColumn = styled.div`
     display: grid;
     grid-template-rows: 1fr 1fr 100px;
     place-items: center;
+    z-index: 1;
+    background: white;
 `;
 
 const CenterColumn = styled.div`

--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { PlayerBriefInfo } from './PlayerBriefInfo';
 import { SAMPLE_DECKLIST_1 } from '@/factories/deck';
 import { makeNewPlayer } from '@/factories/player';
+import { Resource } from '@/types/resources';
 
 describe('Player Brief Info', () => {
     it('renders the player name', () => {
@@ -23,5 +24,13 @@ describe('Player Brief Info', () => {
         render(<PlayerBriefInfo player={player} />);
         expect(screen.getByText('41')).toBeInTheDocument();
         expect(screen.getByText('7')).toBeInTheDocument();
+    });
+
+    it('renders the players resource pool', () => {
+        const player = makeNewPlayer('Grandma Jenkins', SAMPLE_DECKLIST_1);
+        player.resourcePool = { [Resource.BAMBOO]: 3 };
+        render(<PlayerBriefInfo player={player} />);
+        expect(screen.getByText('3')).toBeInTheDocument();
+        expect(screen.getByText('🎋')).toBeInTheDocument();
     });
 });

--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 import { Player } from '@/types/board';
 import { Colors } from '@/constants/colors';
+import { CastingCostFrame } from '../CastingCost';
+import { Resource, RESOURCE_GLOSSARY } from '@/types/resources';
 
 interface PlayerBriefInfoProps {
     player: Player;
@@ -14,7 +16,7 @@ interface PlayerBriefBorderProps {
 
 const PlayerBriefBorder = styled.div<PlayerBriefBorderProps>`
     width: 170px;
-    height: 170px;
+    height: 220px;
     border: 6px solid
         ${({ isActivePlayer }) =>
             isActivePlayer ? Colors.FOCUS_BLUE : Colors.DARK_BROWN};
@@ -26,10 +28,12 @@ const UpperSection = styled.div`
     font-family: Courier;
     margin-right: 5px;
     text-align: right;
+    display: grid;
 `;
 
 const MiddleSection = styled.div`
     position: relative;
+    height: 100px;
     margin: 5px;
     border: 3px solid ${Colors.DARK_BROWN};
     color: white;
@@ -38,6 +42,7 @@ const MiddleSection = styled.div`
     font-size: 56px;
     display: grid;
     place-items: end;
+    align-self: flex-end;
     ::before {
         content: '';
         position: absolute;
@@ -61,15 +66,49 @@ const LowerSection = styled.div`
 `;
 
 export const PlayerBriefInfo: React.FC<PlayerBriefInfoProps> = ({ player }) => {
+    const {
+        resourcePool,
+        numCardsInDeck,
+        numCardsInHand,
+        health,
+        name,
+        isActivePlayer,
+    } = player;
+
+    const shouldShowResourcePool =
+        Object.entries(resourcePool)
+            .map(([, quantity]) => quantity)
+            .reduce((a, b) => a + b, 0) > 0;
     return (
-        <PlayerBriefBorder isActivePlayer={player.isActivePlayer}>
+        <PlayerBriefBorder isActivePlayer={isActivePlayer}>
             <UpperSection>
-                <b>{player.numCardsInDeck}</b> <span>🂡 (Deck)</span>
-                <br></br>
-                <b>{player.numCardsInHand}</b> <span>🂡 (Hand)</span>
+                <div>
+                    <b>{numCardsInDeck}</b> <span>🂡 (Deck)</span>
+                </div>
+                <div>
+                    <b>{numCardsInHand}</b> <span>🂡 (Hand)</span>
+                </div>
+                {shouldShowResourcePool && (
+                    <div>
+                        {Object.entries(resourcePool).map(
+                            ([resource, quantity]) => (
+                                <span key={resource}>
+                                    {quantity}
+                                    <CastingCostFrame>
+                                        {
+                                            RESOURCE_GLOSSARY[
+                                                resource as Resource
+                                            ].icon
+                                        }
+                                    </CastingCostFrame>
+                                </span>
+                            )
+                        )}
+                    </div>
+                )}
             </UpperSection>
-            <MiddleSection>{`${player.health}`}</MiddleSection>
-            <LowerSection>{player.name}</LowerSection>
+            <MiddleSection>{`${health}`}</MiddleSection>
+            <LowerSection>{name}</LowerSection>
         </PlayerBriefBorder>
     );
 };


### PR DESCRIPTION
Shown: new part of the `PlayerBriefInfo` component:

<img width="1335" alt="Screen Shot 2022-03-06 at 7 51 01 PM" src="https://user-images.githubusercontent.com/1839462/156950390-59285d3d-c157-4653-bd72-b294549109f2.png">
