### PR TITLE
Fix: correctly calculate deploying unit costs

### DIFF
--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -228,5 +228,26 @@ describe('Game Action', () => {
             expect(newBoardState.players[0].numCardsInHand).toBe(0);
             expect(newBoardState.players[0].units[0]).toEqual(unitCard);
         });
+
+        it('does not deploy a unit when the player cannot pay for it', () => {
+            const unitCard = makeCard(UnitCards.CANNON);
+            board.players[0].hand = [unitCard];
+            board.players[0].numCardsInHand = 1;
+            board.players[0].resourcePool = {
+                [Resource.FIRE]: 2,
+                [Resource.IRON]: 2,
+            };
+            const newBoardState = applyGameAction({
+                board,
+                gameAction: {
+                    type: GameActionTypes.DEPLOY_UNIT,
+                    cardId: unitCard.id,
+                },
+                playerName: 'Timmy',
+            });
+            expect(newBoardState.players[0].hand).toEqual([unitCard]);
+            expect(newBoardState.players[0].numCardsInHand).toBe(1);
+            expect(newBoardState.players[0].units).toHaveLength(0);
+        });
     });
 });

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -139,10 +139,10 @@ export const applyGameAction = ({
                     activePlayer,
                     matchingCard
                 ).resourcePool;
+                activePlayer.units.push(matchingCard);
+                activePlayer.numCardsInHand -= 1;
+                activePlayer.hand.splice(matchingCardIndex, 1);
             }
-            activePlayer.units.push(matchingCard);
-            activePlayer.numCardsInHand -= 1;
-            activePlayer.hand.splice(matchingCardIndex, 1);
             return clonedBoard;
         }
         default:

--- a/src/transformers/canPlayerPayForCard/canPlayerPayForCard.ts
+++ b/src/transformers/canPlayerPayForCard/canPlayerPayForCard.ts
@@ -21,13 +21,13 @@ export const canPlayerPayForCard = (
     ORDERED_RESOURCES.forEach((resource) => {
         if (resource === Resource.GENERIC) return;
         if (!cost[resource]) return;
-        if (cost[resource] > resourcePool[resource] || 0) canCast = false;
+        if (cost[resource] > (resourcePool[resource] || 0)) canCast = false;
         else resourcePool[resource] -= cost[resource];
         remainingForGeneric += resourcePool[resource];
     });
 
-    if (cost[Resource.GENERIC]) {
-        canCast = cost[Resource.GENERIC] >= remainingForGeneric;
+    if (cost[Resource.GENERIC] && canCast) {
+        canCast = cost[Resource.GENERIC] <= remainingForGeneric;
     }
     return canCast;
 };

--- a/src/transformers/canPlayerPayForCard/canPlayerPayForCards.spec.ts
+++ b/src/transformers/canPlayerPayForCard/canPlayerPayForCards.spec.ts
@@ -26,4 +26,15 @@ describe('can player pay for card', () => {
             false
         ); // costs 1 fire, 2 iron, 2 generic
     });
+
+    it('returns false if the player lacks the resources (test case 2)', () => {
+        const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
+        player.resourcePool = {
+            [Resource.FIRE]: 2,
+            [Resource.IRON]: 2,
+        };
+        expect(canPlayerPayForCard(player, makeCard(UnitCards.CANNON))).toBe(
+            false
+        ); // costs 1 fire, 2 iron, 2 generic
+    });
 });

--- a/src/transformers/payForCard/payForCard.spec.ts
+++ b/src/transformers/payForCard/payForCard.spec.ts
@@ -5,7 +5,7 @@ import { Resource } from '@/types/resources';
 import { payForCard } from './payForCard';
 
 describe('pay for card', () => {
-    it('returns true if the player has enough resources (including for the generic cost)', () => {
+    it('pays for the card if the player has enough resources (including for the generic cost)', () => {
         const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
         player.resourcePool = {
             [Resource.FIRE]: 3,
@@ -18,7 +18,7 @@ describe('pay for card', () => {
         });
     });
 
-    it('returns false if the player lacks the resources', () => {
+    it('does not pay if the player lacks the resources', () => {
         const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
         player.resourcePool = {
             [Resource.FIRE]: 4,
@@ -28,6 +28,19 @@ describe('pay for card', () => {
         expect(payForCard(player, cannonCard).resourcePool).toEqual({
             [Resource.FIRE]: 4,
             [Resource.IRON]: 1,
+        });
+    });
+
+    it('does not pay if the player lacks the resources (2)', () => {
+        const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
+        player.resourcePool = {
+            [Resource.FIRE]: 2,
+            [Resource.IRON]: 2,
+        };
+        const cannonCard = makeCard(UnitCards.CANNON); // costs 1 fire, 2 iron, 2 generic
+        expect(payForCard(player, cannonCard).resourcePool).toEqual({
+            [Resource.FIRE]: 2,
+            [Resource.IRON]: 2,
         });
     });
 });

--- a/src/transformers/payForCard/payForCard.ts
+++ b/src/transformers/payForCard/payForCard.ts
@@ -23,7 +23,7 @@ export const payForCard = (
     ORDERED_RESOURCES.forEach((resource) => {
         if (resource === Resource.GENERIC) return;
         if (!cost[resource]) return;
-        if (cost[resource] > resourcePool[resource] || 0) canCast = false;
+        if (cost[resource] > (resourcePool[resource] || 0)) canCast = false;
         else resourcePool[resource] -= cost[resource];
         const remainingForGeneric = Math.min(
             costLeftForGeneric,


### PR DESCRIPTION
Tweaks + tests to cover these scenarios to allow for paying the right price on units - previously, there were scenarios where users could pay for cards that they shouldn't have been able to, e.g. a card that costs 5 resources like a cannon, could have been paid for with 4 resources.

It's very easy to make bugs when designing a game engine.  This is why this project places a high emphasis on testing - it allows us to catch the bugs before they even show up.  And when we find bugs, we can add test coverage to make sure that they don't regress in the future