### PR TITLE
Stylize intro screen

### DIFF
--- a/src/client/components/App/App.spec.tsx
+++ b/src/client/components/App/App.spec.tsx
@@ -13,7 +13,7 @@ describe('App', () => {
             },
         };
         render(<App />, { preloadedState });
-        expect(screen.queryByText('Select a Name')).toBeInTheDocument();
+        expect(screen.queryByText('Choose a Name')).toBeInTheDocument();
     });
 
     it('renders a particular name if already selected', () => {

--- a/src/client/components/Button/Button.tsx
+++ b/src/client/components/Button/Button.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Colors } from '@/constants/colors';
+
+interface ButtonProps {
+    backgroundColor: string;
+    borderColor?: string;
+    emoji?: string;
+    hoverBackgroundColor: string;
+}
+
+export const Button = styled.button.attrs(
+    ({
+        backgroundColor,
+        borderColor = Colors.DARK_BROWN,
+        emoji = '',
+        hoverBackgroundColor,
+    }: ButtonProps) => ({
+        backgroundColor,
+        borderColor,
+        emoji,
+        hoverBackgroundColor,
+    })
+)`
+    ::before {
+        content: '${({ emoji }) => emoji}';
+        position: absolute;
+        left: 8px;
+    }
+    :not(:disabled):hover {
+        background: ${({ hoverBackgroundColor }) => hoverBackgroundColor};
+    }
+    :not(:disabled) {
+        box-shadow: 0 1px 2px rgb(0 0 0 / 50%);
+    }
+    :active {
+        top: 2px;
+        left: 2px;
+        box-shadow: none;
+    }
+    :disabled {
+        opacity: 0.4;
+    }
+    position: relative;
+    cursor: pointer;
+    width: 150px;
+    color: white;
+    font-size: 22px;
+    border: 1px solid ${({ borderColor }) => borderColor};
+    border-radius: 4px;
+    background: ${({ backgroundColor }) => backgroundColor};
+    height: 40px;
+`;
+
+export const PrimaryColorButton = styled(Button).attrs({
+    backgroundColor: Colors.FIRE_ORANGE,
+    emoji: '▶️',
+    hoverBackgroundColor: Colors.FIRE_ORANGE_EMPHASIZED,
+})``;

--- a/src/client/components/Button/Button.tsx
+++ b/src/client/components/Button/Button.tsx
@@ -55,6 +55,5 @@ export const Button = styled.button.attrs(
 
 export const PrimaryColorButton = styled(Button).attrs({
     backgroundColor: Colors.FIRE_ORANGE,
-    emoji: '▶️',
     hoverBackgroundColor: Colors.FIRE_ORANGE_EMPHASIZED,
 })``;

--- a/src/client/components/Button/index.ts
+++ b/src/client/components/Button/index.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/src/client/components/NameChanger/NameChanger.tsx
+++ b/src/client/components/NameChanger/NameChanger.tsx
@@ -1,8 +1,32 @@
 import React, { FormEvent, useState } from 'react';
+import styled from 'styled-components';
+import { PrimaryColorButton } from '../Button';
 
 interface NameChangerProps {
     handleSubmit: (name: string) => void;
 }
+
+const NameChangerContainer = styled.div`
+    width: 700px;
+    margin: auto;
+    height: 100vh;
+    display: grid;
+    place-items: center;
+`;
+
+const NameChangerForm = styled.form`
+    display: grid;
+    grid-gap: 12px;
+
+    label {
+        display: block;
+        margin-bottom: 4px;
+    }
+    input {
+        height: 40px;
+        width: 300px;
+    }
+`;
 
 /**
  * The name changer component is a presentational component that takes
@@ -18,22 +42,31 @@ export const NameChanger: React.FC<NameChangerProps> = ({ handleSubmit }) => {
         handleSubmit(name);
     };
     return (
-        <>
-            <form onSubmit={onSubmit}>
-                <label htmlFor="name-selector">Select a Name</label>
-                <input
-                    id="name-selector"
-                    role="textbox"
-                    autoComplete="off" // ignore for password managers
-                    data-lpignore="true" // ignore for lastPass
-                    data-form-type="other" // ignore for dashlane
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                />
-                <button role="button" type="submit">
-                    Submit
-                </button>
-            </form>
-        </>
+        <NameChangerContainer>
+            <NameChangerForm onSubmit={onSubmit}>
+                <div>
+                    <label htmlFor="name-selector">Choose a Name</label>
+                    <input
+                        id="name-selector"
+                        role="textbox"
+                        autoFocus
+                        autoComplete="off" // ignore for password managers
+                        data-lpignore="true" // ignore for lastPass
+                        data-form-type="other" // ignore for dashlane
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                    />
+                </div>
+                <div>
+                    <PrimaryColorButton
+                        role="button"
+                        type="submit"
+                        disabled={!name}
+                    >
+                        Start
+                    </PrimaryColorButton>
+                </div>
+            </NameChangerForm>
+        </NameChangerContainer>
     );
 };

--- a/src/client/components/NameChanger/NameChanger.tsx
+++ b/src/client/components/NameChanger/NameChanger.tsx
@@ -59,6 +59,7 @@ export const NameChanger: React.FC<NameChangerProps> = ({ handleSubmit }) => {
                 </div>
                 <div>
                     <PrimaryColorButton
+                        emoji="▶️"
                         role="button"
                         type="submit"
                         disabled={!name}

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.tsx
@@ -7,6 +7,7 @@ import { Player } from '@/types/board';
 import { GameActionTypes } from '@/types/gameActions';
 import { WebSocketContext } from '../WebSockets';
 import { PlayerBriefInfo } from '../PlayerBriefInfo';
+import { PrimaryColorButton } from '../Button';
 
 /**
  * @returns {JSX.Element} - your player info (health, cards, etc.) + the pass turn button
@@ -23,7 +24,9 @@ export const SelfPlayerInfo: React.FC = () => {
         <>
             <PlayerBriefInfo player={selfPlayer} />
             {selfPlayer.isActivePlayer && (
-                <button onClick={passTurn}>Pass Turn</button>
+                <PrimaryColorButton onClick={passTurn}>
+                    Pass Turn
+                </PrimaryColorButton>
             )}
         </>
     );

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -2,5 +2,7 @@ export enum Colors {
     DARK_BROWN = '#4a2e15',
     FELT_GREEN = '#247345',
     FELT_GREEN_ALT = '#36ae68',
+    FIRE_ORANGE = '#f57322',
+    FIRE_ORANGE_EMPHASIZED = '#dc671e',
     FOCUS_BLUE = '#0071bc', // for outlines, accessiblity, showing active player
 }

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -1,3 +1,5 @@
+import { Colors } from '@/constants/colors';
+
 export enum Resource {
     BAMBOO = 'Bamboo', // 🎋
     CRYSTAL = 'Crystal', // 🔮 - magic primary resource
@@ -35,7 +37,11 @@ export const RESOURCE_GLOSSARY: Record<Resource, GlossaryEntry> = {
         name: 'Crystal',
         primaryColor: '#b384d1',
     },
-    [Resource.FIRE]: { icon: '🔥', name: 'Fire', primaryColor: '#f57322' },
+    [Resource.FIRE]: {
+        icon: '🔥',
+        name: 'Fire',
+        primaryColor: Colors.FIRE_ORANGE,
+    },
     [Resource.IRON]: { icon: '🛠️', name: 'Iron', primaryColor: '#5c5955' },
     [Resource.WATER]: { icon: '🌊', name: 'Water', primaryColor: '#2ccdf5' },
 };


### PR DESCRIPTION
Old rough draft design:
<img width="638" alt="Screen Shot 2022-03-07 at 12 15 34 AM" src="https://user-images.githubusercontent.com/1839462/156972253-674837b7-325e-4386-b576-fe5fa9aae503.png">

New design, looks much improved, only missing a game banner / logo:
<img width="1511" alt="Screen Shot 2022-03-07 at 12 14 55 AM" src="https://user-images.githubusercontent.com/1839462/156972201-4397a42e-7600-4acd-84b0-aee91861d522.png">

Used styled-components' "attributes" feature to make an extensible Button and a PrimaryColorButton