### PR TITLE
Implement perform attack vs. unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ yarn test
 
 ```
 
+To run tests for a particular file:
+
+```
+yarn test src/server/gameEngine/gameEngine.spec.ts
+```
+
 To run tests once through:
 
 ```

--- a/src/client/components/CardGridItem/CardGridItem.tsx
+++ b/src/client/components/CardGridItem/CardGridItem.tsx
@@ -9,11 +9,13 @@ import { GameManagerContext } from '../GameManager';
 interface CardGridItemProps {
     card: Card;
     hasOnClick?: boolean;
+    isOnBoard?: boolean;
 }
 
 export const CardGridItem: React.FC<CardGridItemProps> = ({
     card,
     hasOnClick,
+    isOnBoard,
 }) => {
     const { handleClickCard } = useContext(GameManagerContext) || {};
     const onClick = () => {
@@ -35,6 +37,7 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
             <UnitGridItem
                 card={card}
                 onClick={hasOnClick ? onClick : undefined}
+                isOnBoard={isOnBoard}
             />
         );
     }

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
@@ -36,6 +36,7 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
                         card={unitCard}
                         key={unitCard.id}
                         hasOnClick
+                        isOnBoard
                     />
                 ))}
             </div>

--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
@@ -5,6 +5,8 @@ import { PlayerBriefInfo } from './PlayerBriefInfo';
 import { SAMPLE_DECKLIST_1 } from '@/factories/deck';
 import { makeNewPlayer } from '@/factories/player';
 import { Resource } from '@/types/resources';
+import { makeCard } from '@/factories/cards';
+import { UnitCards } from '@/cardDb/units';
 
 describe('Player Brief Info', () => {
     it('renders the player name', () => {
@@ -26,11 +28,19 @@ describe('Player Brief Info', () => {
         expect(screen.getByText('7')).toBeInTheDocument();
     });
 
+    it('renders the cemetery', () => {
+        const player = makeNewPlayer('Grandma Jenkins', SAMPLE_DECKLIST_1);
+        player.cemetery = [makeCard(UnitCards.ASSASSIN)];
+        render(<PlayerBriefInfo player={player} />);
+        expect(screen.getByText('1')).toBeInTheDocument();
+    });
+
     it('renders the players resource pool', () => {
         const player = makeNewPlayer('Grandma Jenkins', SAMPLE_DECKLIST_1);
-        player.resourcePool = { [Resource.BAMBOO]: 3 };
+        player.resourcePool = { [Resource.BAMBOO]: 3, [Resource.FIRE]: 0 };
         render(<PlayerBriefInfo player={player} />);
         expect(screen.getByText('3')).toBeInTheDocument();
         expect(screen.getByText('🎋')).toBeInTheDocument();
+        expect(screen.queryByText('🔥')).not.toBeInTheDocument();
     });
 });

--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.tsx
@@ -88,21 +88,25 @@ export const PlayerBriefInfo: React.FC<PlayerBriefInfoProps> = ({ player }) => {
                 <div>
                     <b>{numCardsInHand}</b> <span>🂡 (Hand)</span>
                 </div>
+                <div>
+                    <b>{player.cemetery.length}</b> <span>🂡 (Cemetery)</span>
+                </div>
                 {shouldShowResourcePool && (
                     <div>
                         {Object.entries(resourcePool).map(
-                            ([resource, quantity]) => (
-                                <span key={resource}>
-                                    {quantity}
-                                    <CastingCostFrame>
-                                        {
-                                            RESOURCE_GLOSSARY[
-                                                resource as Resource
-                                            ].icon
-                                        }
-                                    </CastingCostFrame>
-                                </span>
-                            )
+                            ([resource, quantity]) =>
+                                !!quantity && (
+                                    <span key={resource}>
+                                        {quantity}
+                                        <CastingCostFrame>
+                                            {
+                                                RESOURCE_GLOSSARY[
+                                                    resource as Resource
+                                                ].icon
+                                            }
+                                        </CastingCostFrame>
+                                    </span>
+                                )
                         )}
                     </div>
                 )}

--- a/src/client/redux/clientSideGameExtras/clientSideGameExtras.ts
+++ b/src/client/redux/clientSideGameExtras/clientSideGameExtras.ts
@@ -18,11 +18,14 @@ export const clientSideGameExtrasSlice = createSlice({
         passTurn(state) {
             state.attackingUnit = undefined;
         },
+        performAttack(state) {
+            state.attackingUnit = undefined;
+        },
     },
 });
 
 export const clientSideGameExtrasReducer: Reducer<ClientSideGameExtras> =
     clientSideGameExtrasSlice.reducer;
 
-export const { selectAttackingUnit, passTurn } =
+export const { selectAttackingUnit, passTurn, performAttack } =
     clientSideGameExtrasSlice.actions;

--- a/src/transformers/canPlayerPayForCard/canPlayerPayForCard.ts
+++ b/src/transformers/canPlayerPayForCard/canPlayerPayForCard.ts
@@ -20,9 +20,10 @@ export const canPlayerPayForCard = (
 
     ORDERED_RESOURCES.forEach((resource) => {
         if (resource === Resource.GENERIC) return;
-        if (!cost[resource]) return;
-        if (cost[resource] > (resourcePool[resource] || 0)) canCast = false;
-        else resourcePool[resource] -= cost[resource];
+        const resourceCost = cost[resource] || 0;
+        const currentResources = resourcePool[resource] || 0;
+        if (resourceCost > currentResources) canCast = false;
+        else resourcePool[resource] = currentResources - resourceCost;
         remainingForGeneric += resourcePool[resource];
     });
 

--- a/src/transformers/canPlayerPayForCard/canPlayerPayForCards.spec.ts
+++ b/src/transformers/canPlayerPayForCard/canPlayerPayForCards.spec.ts
@@ -16,6 +16,17 @@ describe('can player pay for card', () => {
         ); // costs 1 fire, 2 iron, 2 generic
     });
 
+    it('returns true if the player has exactly enough resources (including for the generic cost)', () => {
+        const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
+        player.resourcePool = {
+            [Resource.BAMBOO]: 1,
+            [Resource.IRON]: 1,
+        };
+        expect(
+            canPlayerPayForCard(player, makeCard(UnitCards.LONGBOWMAN))
+        ).toBe(true); // costs 1 bamboo, 1 generic
+    });
+
     it('returns false if the player lacks the resources', () => {
         const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
         player.resourcePool = {

--- a/src/transformers/payForCard/payForCard.spec.ts
+++ b/src/transformers/payForCard/payForCard.spec.ts
@@ -12,9 +12,22 @@ describe('pay for card', () => {
             [Resource.IRON]: 2,
         };
         const cannonCard = makeCard(UnitCards.CANNON); // costs 1 fire, 2 iron, 2 generic
-        expect(payForCard(player, cannonCard).resourcePool).toEqual({
+        expect(payForCard(player, cannonCard).resourcePool).toMatchObject({
             [Resource.FIRE]: 0,
             [Resource.IRON]: 0,
+        });
+    });
+
+    it('pays for the card if the player has exactly enough resources', () => {
+        const player = makeNewPlayer('Georgia', SAMPLE_DECKLIST_1);
+        player.resourcePool = {
+            [Resource.IRON]: 1,
+            [Resource.BAMBOO]: 1,
+        };
+        const cannonCard = makeCard(UnitCards.LONGBOWMAN); // costs 1 bamboo, 1 generic
+        expect(payForCard(player, cannonCard).resourcePool).toMatchObject({
+            [Resource.IRON]: 0,
+            [Resource.BAMBOO]: 0,
         });
     });
 

--- a/src/transformers/payForCard/payForCard.ts
+++ b/src/transformers/payForCard/payForCard.ts
@@ -22,9 +22,10 @@ export const payForCard = (
 
     ORDERED_RESOURCES.forEach((resource) => {
         if (resource === Resource.GENERIC) return;
-        if (!cost[resource]) return;
-        if (cost[resource] > (resourcePool[resource] || 0)) canCast = false;
-        else resourcePool[resource] -= cost[resource];
+        const resourceCost = cost[resource] || 0;
+        const resourcesToPayWith = resourcePool[resource] || 0;
+        if (resourceCost > resourcesToPayWith) canCast = false;
+        else resourcePool[resource] = resourcesToPayWith - resourceCost;
         const remainingForGeneric = Math.min(
             costLeftForGeneric,
             resourcePool[resource]


### PR DESCRIPTION
Remaining:
- implement "poisonous" attacks
- implement 'attack enemy player'
- implement '# of attacks left' indicator
- show chat messages about attacks

Future ideas:
- implement sounds for attacking (each creature should have a different one)
- implement "silent" mode

https://user-images.githubusercontent.com/1839462/157177033-8e30fd6d-6804-4167-96cc-8deff9886920.mov


