### PR TITLE
Various effects resolutions solutions

### DIFF
--- a/src/client/components/GameManager/handleClickOnCard.spec.ts
+++ b/src/client/components/GameManager/handleClickOnCard.spec.ts
@@ -12,6 +12,7 @@ import {
     performAttack,
     selectAttackingUnit,
 } from '@/client/redux/clientSideGameExtras';
+import { SpellCards } from '@/cardDb/spells';
 
 describe('handle click on card', () => {
     let dispatch: AppDispatch;
@@ -137,6 +138,24 @@ describe('handle click on card', () => {
                 cardId: unitCard.id,
                 unitTarget: defender.id,
             });
+        });
+    });
+
+    describe('Effects resolutions', () => {
+        it('blocks clicking on a card if an effect is in play', () => {
+            const unitCard = makeResourceCard(Resource.BAMBOO);
+            const spellCard = makeCard(SpellCards.A_GENTLE_GUST);
+            state.board.players[0].hand = [unitCard];
+            state.board.players[0].effectQueue = spellCard.effects;
+
+            handleClickOnCard({
+                cardId: unitCard.id,
+                dispatch,
+                state,
+                socket,
+            });
+
+            expect(socket.emit).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/src/client/components/GameManager/handleClickOnCard.ts
+++ b/src/client/components/GameManager/handleClickOnCard.ts
@@ -42,6 +42,12 @@ export const handleClickOnCard = ({
     const selfPlayer = getSelfPlayer(state);
     const otherPlayers = getOtherPlayers(state);
     const attackingUnit = getAttackingUnit(state);
+    const { effectQueue } = selfPlayer;
+
+    if (effectQueue.length > 0) {
+        return;
+    }
+
     if (!selfPlayer?.hand) {
         return;
     }

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
@@ -1,21 +1,64 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { RootState } from '@/client/redux/store';
 import { makeNewBoard } from '@/factories/board';
 import { render } from '@/test-utils';
 import { SelfPlayerInfo } from './SelfPlayerInfo';
+import { passTurn } from '@/client/redux/clientSideGameExtras';
+import { GameActionTypes } from '@/types/gameActions';
+import { SpellCards } from '@/cardDb/spells';
 
 describe('Self Player Board', () => {
-    it("renders the pass turn button, if you're the active player", () => {
+    it('disables the pass turn button if effects are remaining', () => {
+        const board = makeNewBoard(['Melvin', 'Melissa'], 0);
+        board.players[0].effectQueue = [...SpellCards.A_GENTLE_GUST.effects];
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Melvin',
+            },
+            board,
+        };
+        render(<SelfPlayerInfo />, {
+            preloadedState,
+        });
+        expect(screen.getByText('Pass Turn')).toBeDisabled();
+    });
+
+    it("passes the turn if you're the active player", () => {
         const preloadedState: Partial<RootState> = {
             user: {
                 name: 'Melvin',
             },
             board: makeNewBoard(['Melvin', 'Melissa'], 0),
         };
-        render(<SelfPlayerInfo />, { preloadedState });
-        expect(screen.getByText('Pass Turn')).toBeInTheDocument();
+        const { dispatch, webSocket } = render(<SelfPlayerInfo />, {
+            preloadedState,
+        });
+        fireEvent.click(screen.getByText('Pass Turn'));
+        expect(dispatch).toHaveBeenCalledWith(passTurn());
+        expect(dispatch).toHaveBeenCalledWith(passTurn());
+        expect(webSocket.takeGameAction).toHaveBeenCalledWith({
+            type: GameActionTypes.PASS_TURN,
+        });
+    });
+
+    it("passes the turn if you're the active player", () => {
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Melvin',
+            },
+            board: makeNewBoard(['Melvin', 'Melissa'], 0),
+        };
+        const { dispatch, webSocket } = render(<SelfPlayerInfo />, {
+            preloadedState,
+        });
+        fireEvent.click(screen.getByText('Pass Turn'));
+        expect(dispatch).toHaveBeenCalledWith(passTurn());
+        expect(dispatch).toHaveBeenCalledWith(passTurn());
+        expect(webSocket.takeGameAction).toHaveBeenCalledWith({
+            type: GameActionTypes.PASS_TURN,
+        });
     });
 
     it("hides the pass turn button, if you're not the active player", () => {

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.tsx
@@ -28,7 +28,10 @@ export const SelfPlayerInfo: React.FC = () => {
         <>
             <PlayerBriefInfo player={selfPlayer} />
             {selfPlayer.isActivePlayer && (
-                <PrimaryColorButton onClick={passTurn}>
+                <PrimaryColorButton
+                    onClick={passTurn}
+                    disabled={selfPlayer?.effectQueue?.length > 0}
+                >
                     Pass Turn
                 </PrimaryColorButton>
             )}

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -10,12 +10,16 @@ import {
 import { updateRoomsAndPlayers } from '@/client/redux/room';
 import { AppDispatch } from '@/client/redux/store';
 import { updateBoardState } from '@/client/redux/board';
-import { ClientToServerEvents, ServerToClientEvents } from '@/types';
+import {
+    ClientToServerEvents,
+    ResolveEffectsParams,
+    ServerToClientEvents,
+} from '@/types';
 import { GameAction } from '@/types/gameActions';
 
 export const WebSocketContext = createContext<WebSocketValue>(null);
 
-interface WebSocketValue extends Partial<ClientToServerEvents> {
+export interface WebSocketValue extends Partial<ClientToServerEvents> {
     socket: Socket<ServerToClientEvents, ClientToServerEvents>;
 }
 
@@ -74,6 +78,10 @@ export const WebSocketProvider: React.FC = ({ children }) => {
             newSocket.emit('chooseName', name);
         };
 
+        const resolveEffect = (params: ResolveEffectsParams) => {
+            newSocket.emit('resolveEffect', params);
+        };
+
         const startGame = () => {
             newSocket.emit('startGame');
         };
@@ -87,6 +95,7 @@ export const WebSocketProvider: React.FC = ({ children }) => {
             socket: newSocket,
             chooseName,
             joinRoom,
+            resolveEffect,
             startGame,
             takeGameAction,
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { Board } from './types/board';
+import { Effect } from './types/cards';
 import { GameAction } from './types/gameActions';
 
 export interface ServerToClientEvents {
@@ -8,10 +9,21 @@ export interface ServerToClientEvents {
     updateBoard: (board: Board) => void;
 }
 
+export interface ResolveEffectsParams {
+    effect: Effect;
+    playerNames?: string[];
+    unitCardIds: string[];
+}
+
 export interface ClientToServerEvents {
     chooseName: (name: string) => void;
     getRooms: () => void;
     joinRoom: (roomName: string) => void;
+    resolveEffect: ({
+        effect,
+        playerNames,
+        unitCardIds,
+    }: ResolveEffectsParams) => void;
     startGame: () => void;
     takeGameAction: (gameAction: GameAction) => void;
 }

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -14,6 +14,15 @@ export enum TargetTypes {
     UNIT = 'UNIT',
 }
 
+const AutoResolvingTargets = [
+    TargetTypes.ALL_OPPONENTS,
+    TargetTypes.ALL_OPPOSING_UNITS,
+    TargetTypes.ALL_PLAYERS,
+    TargetTypes.ALL_SELF_UNITS_GRAVEYARD,
+    TargetTypes.ALL_UNITS,
+    TargetTypes.SELF_PLAYER,
+];
+
 /**
  * Effects that a card can have (both spells and units)
  */
@@ -38,6 +47,14 @@ export enum EffectType {
     BUFF_TEAM_HP, // increases maxHp and hp for whole team
     BUFF_HAND_ATTACK, // buffs all creatures in hand
 }
+
+/**
+ * Default targets of effects, e.g.
+ */
+const getDefaultTargetForEffect = {
+    [EffectType.DRAW]: TargetTypes.SELF_PLAYER,
+    [EffectType.DEAL_DAMAGE]: TargetTypes.ANY,
+};
 
 /**
  * Passive effects of a unit


### PR DESCRIPTION
- Improved the render from test-utils so that tests that used it can access mock versions of the WebSockets context values.

- added some preliminary constants around effects, e.g. default targets, which ones auto-resolve

- blocked clicking on cards if there are active effects (#77)

- block pass turn button if effects exist - Closes #80