### PR TITLE
Auto-fizzle any effect without valid targets

### DIFF
--- a/src/client/components/GameManager/GameManager.spec.tsx
+++ b/src/client/components/GameManager/GameManager.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@/test-utils';
+import { GameManager } from './GameManager';
+import { makeNewBoard } from '@/factories/board';
+import { EffectType, TargetTypes } from '@/types/effects';
+import { RootState } from '@/client/redux/store';
+
+describe('Game Manager', () => {
+    it('auto-resolves targets', () => {
+        const board = makeNewBoard(['Antoinette', 'Beatrice', 'Claudia'], 0);
+        const effect = {
+            type: EffectType.BOUNCE,
+            target: TargetTypes.ALL_OPPOSING_UNITS,
+        };
+        board.players[0].effectQueue = [effect];
+
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Antoinette',
+            },
+            board,
+        };
+        const { webSocket } = render(<GameManager />, { preloadedState });
+        expect(webSocket.socket.emit).toHaveBeenCalledWith('resolveEffect', {
+            effect,
+        });
+    });
+
+    it('fizzles the last effect if it has no valid targets', () => {
+        const board = makeNewBoard(['Antoinette', 'Beatrice', 'Claudia'], 0);
+        const effect = {
+            type: EffectType.BOUNCE,
+            target: TargetTypes.OWN_UNIT,
+        };
+        board.players[0].effectQueue = [effect];
+
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Antoinette',
+            },
+            board,
+        };
+        const { webSocket } = render(<GameManager />, { preloadedState });
+        expect(webSocket.socket.emit).toHaveBeenCalledWith('resolveEffect', {
+            effect,
+        });
+    });
+});

--- a/src/client/components/GameManager/GameManager.tsx
+++ b/src/client/components/GameManager/GameManager.tsx
@@ -12,7 +12,10 @@ import { handleClickOnCard } from './handleClickOnCard';
 import { Player } from '@/types/board';
 import { handleClickOnPlayer } from './handleClickPlayer';
 import { Effect } from '@/types/cards';
-import { getLastEffect } from '@/client/redux/selectors';
+import {
+    getLastEffect,
+    shouldLastEffectFizzle,
+} from '@/client/redux/selectors';
 import {
     AutoResolvingTargets,
     getDefaultTargetForEffect,
@@ -33,6 +36,9 @@ export const GameManager: React.FC = ({ children }) => {
     const lastEffect = useSelector<RootState, Effect | undefined>(
         getLastEffect
     );
+    const willLastEffectFizzle = useSelector<RootState, boolean>(
+        shouldLastEffectFizzle
+    );
 
     useEffect(() => {
         if (!lastEffect) return;
@@ -41,6 +47,11 @@ export const GameManager: React.FC = ({ children }) => {
         // if the target of the effect auto-resolves, e.g. (ALL OPPONENTS),
         // then resolve the effect automatically
         if (AutoResolvingTargets.indexOf(target) > -1) {
+            socket.emit('resolveEffect', {
+                effect: lastEffect,
+            });
+        }
+        if (willLastEffectFizzle) {
             socket.emit('resolveEffect', {
                 effect: lastEffect,
             });

--- a/src/client/redux/selectors.ts
+++ b/src/client/redux/selectors.ts
@@ -1,5 +1,6 @@
 import { Player } from '@/types/board';
 import { Effect } from '@/types/cards';
+import { TargetTypes } from '@/types/effects';
 import { RootState } from './store';
 
 export const isUserInitialized = (state: Partial<RootState>): boolean =>
@@ -41,4 +42,32 @@ export const getLastEffect = (
     const { effectQueue } = selfPlayer;
     if (effectQueue.length === 0) return undefined;
     return effectQueue[effectQueue.length - 1];
+};
+
+/**
+ * @param state
+ * @returns {boolean} - return true if and only if there is an effect in the queue
+ * and the last effect on the effectQueue array is invalid given the current board
+ * state, e.g. it tries to target an opposing unit when there are none
+ */
+export const shouldLastEffectFizzle = (state: Partial<RootState>): boolean => {
+    const lastEffect = getLastEffect(state);
+    if (!lastEffect) return false;
+    const otherPlayers = getOtherPlayers(state);
+    const selfPlayer = getSelfPlayer(state);
+    const players = [...otherPlayers, selfPlayer];
+
+    switch (lastEffect.target) {
+        case TargetTypes.OPPOSING_UNIT: {
+            return otherPlayers.every((player) => player.units.length === 0);
+        }
+        case TargetTypes.OWN_UNIT: {
+            return selfPlayer.units.length === 0;
+        }
+        case TargetTypes.UNIT: {
+            return players.every((player) => player.units.length === 0);
+        }
+        default:
+            return false;
+    }
 };

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -101,6 +101,6 @@ export const resolveEffect = (
             return clonedBoard;
         }
         default:
-            return null;
+            return clonedBoard;
     }
 };


### PR DESCRIPTION
Closes: #99

Before (if there was an effect that targeted something invalid, e.g. 'return a unit back to its hand'), that effect would persist:

https://user-images.githubusercontent.com/1839462/157782997-785bead2-990f-4ed7-b73f-03df3e46b49a.mov

Now (the effect that is invalid fizzles):

https://user-images.githubusercontent.com/1839462/157782900-be6e6e53-b581-48ec-bfeb-1bbee97527e3.mov

