### PR TITLE
Set up scripts for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Monks and Mages is a trading card-style game inspired by [Heroes of Might and Ma
 
 # Installation and Running
 
-This game can be run locally if you have [node](https://nodejs.org/en/download/) and [yarn installed globally](https://yarnpkg.com/getting-started/install)
+This game can be run locally if you have [node v16.x](https://nodejs.org/en/download/) and [yarn installed globally](https://yarnpkg.com/getting-started/install)
 
 To get started:
 
@@ -19,6 +19,8 @@ or alternatively, to get automatic builds via watchmode:
 yarn install
 yarn dev
 ```
+
+Go to `http://localhost:3000/` to see the game (and open it in multiple browser windows to simulate multiple players)
 
 To see sockets.io debug screen:
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "private": true,
     "scripts": {
         "build": "npx webpack",
-        "start": "npx webpack & cp src/server/homepage.html dist/homepage.html & node .",
-        "dev": "npx webpack --watch & cp src/server/homepage.html dist/homepage.html & -w & nodemon .",
-        "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
         "ci": "yarn lint && jest",
+        "dev": "npx webpack --watch & cp src/server/homepage.html dist/homepage.html & -w & nodemon .",
+        "heroku-prebuild": "yarn install --dev",
+        "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+        "start": "npx webpack & cp src/server/homepage.html dist/homepage.html & node .",
         "test": "yarn lint && jest --watchAll"
     },
     "dependencies": {
@@ -65,8 +66,11 @@
         "typescript": "^4.5.4",
         "typescript-plugin-styled-components": "^2.0.0",
         "webpack": "^5.66.0",
-        "webpack-cli": "^4.9.1",
+        "webpack-cli": "^4.9.2",
         "webpack-node-externals": "^3.0.0"
+    },
+    "engines": {
+        "node": "17.x"
     },
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "engines": {
-        "node": "17.x"
+        "node": "16.x"
     },
     "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,9 +308,9 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@discoveryjs/json-ext@^0.5.0":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
-  integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
+  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
@@ -5593,7 +5593,7 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-cli@^4.9.1:
+webpack-cli@^4.9.2:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.2.tgz#77c1adaea020c3f9e2db8aad8ea78d235c83659d"
   integrity sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==


### PR DESCRIPTION
- Fixes the version to v17.x for node: https://devcenter.heroku.com/articles/deploying-nodejs#specify-the-version-of-node

- ran into an error where I found that heroku was asking 'We will use "yarn" to install the CLI via "yarn add -D webpack-cli"' on the logs
After investigating further, I see from stackoverflow that heroku runs with NODE_ENV=production and that we need to tell it to install all our dev dependencies like so: https://stackoverflow.com/a/53326418

For: #105