### PR TITLE
Move yarn install --dev command into cleanup stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "build": "npx webpack",
         "ci": "yarn lint && jest",
         "dev": "npx webpack --watch & cp src/server/homepage.html dist/homepage.html & -w & nodemon .",
-        "heroku-prebuild": "yarn install --dev",
+        "heroku-cleanup": "yarn install --dev",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
         "start": "npx webpack & cp src/server/homepage.html dist/homepage.html & node .",
         "test": "yarn lint && jest --watchAll"


### PR DESCRIPTION
Heroku prunes the dev dependencies after the build

According to https://devcenter.heroku.com/articles/nodejs-support:
`"heroku-cleanup": "echo This runs after Heroku prunes and caches dependencies."`

We were trying to install dev dependencies previously, but it got pruned b/c of the post-build step