### PR TITLE
Add process.env.PORT

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { configureIo } from './sockets';
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 const server = http.createServer(app);
 
 // Serves everything from dist/client as /client, e.g. http://localhost:3000/client/index.js


### PR DESCRIPTION
Ran into this error:
`Web process failed to bind to $PORT within 60 seconds of launch`

Fix was to use the port number that heroku uses: https://stackoverflow.com/a/15693371