### PR TITLE
Refactor: turn `makeNewBoard` into a unary function

### DIFF
--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -1,5 +1,5 @@
-import { Colors } from '@/constants/colors';
 import styled from 'styled-components';
+import { Colors } from '@/constants/colors';
 
 interface CardFrameProps {
     isRaised?: boolean;

--- a/src/client/components/GameDisplay/GameDisplay.spec.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.spec.tsx
@@ -13,7 +13,7 @@ describe('GameDisplay', () => {
             user: {
                 name: 'Tommy',
             },
-            board: makeNewBoard(['Tommy', 'Timmy']),
+            board: makeNewBoard({ playerNames: ['Tommy', 'Timmy'] }),
         };
         render(<GameDisplay />, { preloadedState });
         expect(screen.queryByText('Tommy')).toBeInTheDocument();
@@ -21,7 +21,10 @@ describe('GameDisplay', () => {
     });
 
     it('renders active effects', () => {
-        const board = makeNewBoard(['Tommy', 'Timmy'], 0);
+        const board = makeNewBoard({
+            playerNames: ['Tommy', 'Timmy'],
+            startingPlayerIndex: 0,
+        });
         const preloadedState: Partial<RootState> = {
             user: {
                 name: 'Tommy',

--- a/src/client/components/GameManager/GameManager.spec.tsx
+++ b/src/client/components/GameManager/GameManager.spec.tsx
@@ -9,7 +9,10 @@ jest.useFakeTimers();
 
 describe('Game Manager', () => {
     it('auto-resolves targets', async () => {
-        const board = makeNewBoard(['Antoinette', 'Beatrice', 'Claudia'], 0);
+        const board = makeNewBoard({
+            playerNames: ['Antoinette', 'Beatrice', 'Claudia'],
+            startingPlayerIndex: 0,
+        });
         const effect = {
             type: EffectType.BOUNCE,
             target: TargetTypes.ALL_OPPOSING_UNITS,
@@ -33,7 +36,10 @@ describe('Game Manager', () => {
     });
 
     it('fizzles the last effect if it has no valid targets', async () => {
-        const board = makeNewBoard(['Antoinette', 'Beatrice', 'Claudia'], 0);
+        const board = makeNewBoard({
+            playerNames: ['Antoinette', 'Beatrice', 'Claudia'],
+            startingPlayerIndex: 0,
+        });
         const effect = {
             type: EffectType.BOUNCE,
             target: TargetTypes.OWN_UNIT,

--- a/src/client/components/GameManager/handleClickOnCard.spec.ts
+++ b/src/client/components/GameManager/handleClickOnCard.spec.ts
@@ -29,7 +29,10 @@ describe('handle click on card', () => {
             isDisconnected: false,
             name: 'Cleopatra',
         };
-        state.board = makeNewBoard(['Cleopatra', 'Marc Antony'], 0);
+        state.board = makeNewBoard({
+            playerNames: ['Cleopatra', 'Marc Antony'],
+            startingPlayerIndex: 0,
+        });
         done();
     });
 

--- a/src/client/components/GameManager/handleClickOnPlayer.spec.ts
+++ b/src/client/components/GameManager/handleClickOnPlayer.spec.ts
@@ -25,7 +25,10 @@ describe('handle click on player', () => {
             isDisconnected: false,
             name: 'Cleopatra',
         };
-        state.board = makeNewBoard(['Cleopatra', 'Marc Antony'], 0);
+        state.board = makeNewBoard({
+            playerNames: ['Cleopatra', 'Marc Antony'],
+            startingPlayerIndex: 0,
+        });
         done();
     });
 

--- a/src/client/components/HandOfCards/HandOfCards.spec.tsx
+++ b/src/client/components/HandOfCards/HandOfCards.spec.tsx
@@ -12,7 +12,10 @@ describe('Hand of Cards', () => {
             user: {
                 name: 'Tommy',
             },
-            board: makeNewBoard(['Tommy', 'Timmy']),
+            board: makeNewBoard({
+                playerNames: ['Tommy', 'Timmy'],
+                startingPlayerIndex: 0,
+            }),
         };
         render(<HandOfCards />, { preloadedState });
         const unitCards = screen.queryAllByTestId('UnitGridItem');

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
@@ -11,7 +11,10 @@ import { SpellCards } from '@/cardDb/spells';
 
 describe('Self Player Board', () => {
     it('disables the pass turn button if effects are remaining', () => {
-        const board = makeNewBoard(['Melvin', 'Melissa'], 0);
+        const board = makeNewBoard({
+            playerNames: ['Melvin', 'Melissa'],
+            startingPlayerIndex: 0,
+        });
         board.players[0].effectQueue = [...SpellCards.A_GENTLE_GUST.effects];
         const preloadedState: Partial<RootState> = {
             user: {
@@ -30,7 +33,10 @@ describe('Self Player Board', () => {
             user: {
                 name: 'Melvin',
             },
-            board: makeNewBoard(['Melvin', 'Melissa'], 0),
+            board: makeNewBoard({
+                playerNames: ['Melvin', 'Melissa'],
+                startingPlayerIndex: 0,
+            }),
         };
         const { dispatch, webSocket } = render(<SelfPlayerInfo />, {
             preloadedState,
@@ -48,7 +54,10 @@ describe('Self Player Board', () => {
             user: {
                 name: 'Melvin',
             },
-            board: makeNewBoard(['Melvin', 'Melissa'], 0),
+            board: makeNewBoard({
+                playerNames: ['Melvin', 'Melissa'],
+                startingPlayerIndex: 0,
+            }),
         };
         const { dispatch, webSocket } = render(<SelfPlayerInfo />, {
             preloadedState,
@@ -66,7 +75,10 @@ describe('Self Player Board', () => {
             user: {
                 name: 'Melvin',
             },
-            board: makeNewBoard(['Melvin', 'Melissa'], 1),
+            board: makeNewBoard({
+                playerNames: ['Melvin', 'Melissa'],
+                startingPlayerIndex: 1,
+            }),
         };
         render(<SelfPlayerInfo />, { preloadedState });
         expect(screen.queryByText('Pass Turn')).not.toBeInTheDocument();

--- a/src/client/redux/selectors.spec.ts
+++ b/src/client/redux/selectors.spec.ts
@@ -34,7 +34,7 @@ describe('selectors', () => {
         it('returns the player that matches the name', () => {
             const state = {
                 user: { name: 'Bruno' },
-                board: makeNewBoard(['Bruno', 'Carla']),
+                board: makeNewBoard({ playerNames: ['Bruno', 'Carla'] }),
             };
             expect(getSelfPlayer(state).name).toBe('Bruno');
         });
@@ -44,7 +44,9 @@ describe('selectors', () => {
         it('returns all players for spectators', () => {
             const state = {
                 user: { name: 'Bobby' },
-                board: makeNewBoard(['Bruno', 'Carla', 'James']),
+                board: makeNewBoard({
+                    playerNames: ['Bruno', 'Carla', 'James'],
+                }),
             };
             expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
                 ['Bruno', 'Carla', 'James']
@@ -54,7 +56,9 @@ describe('selectors', () => {
         it('returns in rotating order (in the middle)', () => {
             const state = {
                 user: { name: 'Bruno' },
-                board: makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']),
+                board: makeNewBoard({
+                    playerNames: ['Alex', 'Bruno', 'Carla', 'Dionne'],
+                }),
             };
             expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
                 ['Carla', 'Dionne', 'Alex']
@@ -64,7 +68,9 @@ describe('selectors', () => {
         it('returns in rotating order (first in board order)', () => {
             const state = {
                 user: { name: 'Alex' },
-                board: makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']),
+                board: makeNewBoard({
+                    playerNames: ['Alex', 'Bruno', 'Carla', 'Dionne'],
+                }),
             };
             expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
                 ['Bruno', 'Carla', 'Dionne']
@@ -74,7 +80,9 @@ describe('selectors', () => {
         it('returns in rotating order (last in board order)', () => {
             const state = {
                 user: { name: 'Dionne' },
-                board: makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']),
+                board: makeNewBoard({
+                    playerNames: ['Alex', 'Bruno', 'Carla', 'Dionne'],
+                }),
             };
             expect(getOtherPlayers(state).map((player) => player.name)).toEqual(
                 ['Alex', 'Bruno', 'Carla']
@@ -84,7 +92,9 @@ describe('selectors', () => {
 
     describe('getLastEffect', () => {
         it("returns the last effect on the player's queue", () => {
-            const board = makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']);
+            const board = makeNewBoard({
+                playerNames: ['Alex', 'Bruno', 'Carla', 'Dionne'],
+            });
             const state = {
                 user: { name: 'Alex' },
                 board,
@@ -106,7 +116,9 @@ describe('selectors', () => {
 
     describe('shouldEffectFizzle', () => {
         it('fizzles effects that target units', () => {
-            const board = makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']);
+            const board = makeNewBoard({
+                playerNames: ['Alex', 'Bruno', 'Carla', 'Dionne'],
+            });
             const state = {
                 user: { name: 'Alex' },
                 board,
@@ -127,7 +139,9 @@ describe('selectors', () => {
         });
 
         it('does not fizzle effects that target a valid unit', () => {
-            const board = makeNewBoard(['Alex', 'Bruno', 'Carla', 'Dionne']);
+            const board = makeNewBoard({
+                playerNames: ['Alex', 'Bruno', 'Carla', 'Dionne'],
+            });
             // Give each player units so the effects won't fizzle
             board.players.forEach((player) => {
                 player.units = [makeCard(UnitCards.CAVALRY_ARCHER)];

--- a/src/factories/board/makeNewBoard.spec.ts
+++ b/src/factories/board/makeNewBoard.spec.ts
@@ -2,7 +2,7 @@ import { makeNewBoard } from './makeNewBoard';
 
 describe('Make New Board', () => {
     it('makes a new board with players', () => {
-        const board = makeNewBoard(['Hal', 'Orin']);
+        const board = makeNewBoard({ playerNames: ['Hal', 'Orin'] });
         expect(board.players[0].name).toEqual('Hal');
         expect(board.players[0].health).toEqual(15);
         expect(board.players[1].name).toEqual('Orin');
@@ -10,7 +10,7 @@ describe('Make New Board', () => {
     });
 
     it('makes a random player the starting player', () => {
-        const board = makeNewBoard(['Hal', 'Orin', 'Samus']);
+        const board = makeNewBoard({ playerNames: ['Hal', 'Orin', 'Samus'] });
         expect(
             board.players[0].isActivePlayer ||
                 board.players[1].isActivePlayer ||

--- a/src/factories/board/makeNewBoard.ts
+++ b/src/factories/board/makeNewBoard.ts
@@ -2,10 +2,15 @@ import { Board, GameState } from '@/types/board';
 import { SAMPLE_DECKLIST_1 } from '../deck';
 import { makeNewPlayer } from '../player';
 
-export const makeNewBoard = (
-    playerNames: string[],
-    startingPlayerIndex: number = Math.floor(Math.random() * playerNames.length)
-): Board => {
+export type MakeNewBoardParams = {
+    playerNames: string[];
+    startingPlayerIndex?: number;
+};
+
+export const makeNewBoard = ({
+    playerNames,
+    startingPlayerIndex = Math.floor(Math.random() * playerNames.length),
+}: MakeNewBoardParams): Board => {
     const players = playerNames.map((playerName) =>
         makeNewPlayer(playerName, SAMPLE_DECKLIST_1)
     );

--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -12,7 +12,10 @@ describe('Game Action', () => {
     let board: Board;
 
     beforeEach(() => {
-        board = makeNewBoard(['Timmy', 'Tommy', 'Bobby'], 0);
+        board = makeNewBoard({
+            playerNames: ['Timmy', 'Tommy', 'Bobby'],
+            startingPlayerIndex: 0,
+        });
     });
 
     it('short-circuits if the player is not the active player', () => {

--- a/src/server/obscureBoardInfo/obscureBoardInfo.spec.ts
+++ b/src/server/obscureBoardInfo/obscureBoardInfo.spec.ts
@@ -3,7 +3,7 @@ import { obscureBoardInfo } from './obscureBoardInfo';
 
 describe('Obscure board info', () => {
     it("hides other players' hands", () => {
-        const board = makeNewBoard(['Timmy', 'Tom']);
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tom'] });
         const boardTommySees = obscureBoardInfo(board, 'Tom');
         expect(
             boardTommySees.players.find((player) => player.name === 'Timmy')
@@ -12,7 +12,7 @@ describe('Obscure board info', () => {
     });
 
     it('does not hide your own hand', () => {
-        const board = makeNewBoard(['Timmy', 'Tom']);
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tom'] });
         const boardTommySees = obscureBoardInfo(board, 'Tom');
         expect(
             boardTommySees.players.find((player) => player.name === 'Tom').hand
@@ -20,7 +20,7 @@ describe('Obscure board info', () => {
     });
 
     it('hides decks', () => {
-        const board = makeNewBoard(['Timmy', 'Tom']);
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tom'] });
         const boardTommySees = obscureBoardInfo(board, 'Tom');
         expect(
             boardTommySees.players.find((player) => player.name === 'Tom').deck

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -12,7 +12,10 @@ describe('resolve effect', () => {
     let board: Board;
 
     beforeEach(() => {
-        board = makeNewBoard(['Timmy', 'Tommy', 'Bobby'], 0);
+        board = makeNewBoard({
+            playerNames: ['Timmy', 'Tommy'],
+            startingPlayerIndex: 0,
+        });
     });
 
     it('does nothing if not coming from the active player', () => {

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -131,7 +131,9 @@ export const configureIo = (server: HttpServer) => {
                 // TODO: handle race condition where 2 people start game at same time
                 socket.rooms.forEach((roomName) => {
                     const socketIds = io.sockets.adapter.rooms.get(roomName);
-                    const board = makeNewBoard(getNamesFromIds([...socketIds]));
+                    const board = makeNewBoard({
+                        playerNames: getNamesFromIds([...socketIds]),
+                    });
                     startedBoards.set(roomName, board);
                     io.to(roomName).emit('startGame');
                     sendBoardForRoom(roomName);


### PR DESCRIPTION
Precursor work to #125 

I'd like to add a param to `makeNewBoard` called `deckListTitlesForPlayers`, but in order to do so with less tech-debt, we need to turn `makeNewBoard` into a unary function