### PR TITLE
Revamp lobby screen

### DIFF
--- a/src/client/components/App/App.spec.tsx
+++ b/src/client/components/App/App.spec.tsx
@@ -23,6 +23,6 @@ describe('App', () => {
             },
         };
         render(<App />, { preloadedState });
-        expect(screen.queryByText('Name: Gretsch')).toBeInTheDocument();
+        expect(screen.queryByText('Gretsch')).toBeInTheDocument();
     });
 });

--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { HistoryRouter as Router } from 'redux-first-history/rr6';
 import { Route, Routes } from 'react-router-dom';
+import styled from 'styled-components';
 import 'react-popper-tooltip/dist/styles.css';
 
 import { makeSampleDeck1 } from '@/factories/deck';
@@ -13,6 +14,13 @@ import { IntroScreen } from '../IntroScreen';
 import { Rooms } from '../Rooms';
 import { GameDisplay } from '../GameDisplay';
 import { GameManager } from '../GameManager';
+
+const LobbyBackground = styled.div`
+    background: linear-gradient(70deg, #eed, transparent);
+    height: 100vh;
+    display: grid;
+    grid-template-rows: auto 1fr;
+`;
 
 export const App: React.FC = () => {
     const deck = makeSampleDeck1();
@@ -29,10 +37,10 @@ export const App: React.FC = () => {
                                 <Route
                                     path="/"
                                     element={
-                                        <>
+                                        <LobbyBackground>
                                             <IntroScreen />
                                             {isUserPastIntroScreen && <Rooms />}
-                                        </>
+                                        </LobbyBackground>
                                     }
                                 />
                                 <Route

--- a/src/client/components/Button/Button.tsx
+++ b/src/client/components/Button/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { Colors } from '@/constants/colors';
@@ -44,7 +43,8 @@ export const Button = styled.button.attrs(
     }
     position: relative;
     cursor: pointer;
-    width: 150px;
+    padding-left: ${({ emoji }) => (emoji ? '50' : '20')}px;
+    padding-right: ${({ emoji }) => (emoji ? '50' : '20')}px;
     color: white;
     font-size: 22px;
     border: 1px solid ${({ borderColor }) => borderColor};
@@ -56,4 +56,9 @@ export const Button = styled.button.attrs(
 export const PrimaryColorButton = styled(Button).attrs({
     backgroundColor: Colors.FIRE_ORANGE,
     hoverBackgroundColor: Colors.FIRE_ORANGE_EMPHASIZED,
+})``;
+
+export const SecondaryColorButton = styled(Button).attrs({
+    backgroundColor: Colors.SECONDARY_GREEN,
+    hoverBackgroundColor: Colors.SECONDARY_GREEN_EMPHASIZED,
 })``;

--- a/src/client/components/IntroScreen/IntroScreen.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.tsx
@@ -1,11 +1,17 @@
 import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
+import styled from 'styled-components';
 
 import { RootState } from '@/client/redux/store';
 import { NameChanger } from '../NameChanger';
 import { WebSocketContext } from '../WebSockets';
 
 // TODO: rename IntroScreen to LoginBar: https://github.com/lijim/monks-and-mages/issues/28
+
+const NameDisplayer = styled.div`
+    padding-left: 50px;
+    padding-top: 20px;
+`;
 
 /**
  * The Intro Screen is where people set their names / see games in
@@ -26,12 +32,13 @@ export const IntroScreen: React.FC = () => {
     return (
         <>
             {name ? (
-                <>
-                    Name: {name}{' '}
-                    <button type="button" onClick={logOut}>
+                <NameDisplayer>
+                    👤 <b>{name}</b> (
+                    <a href="#" type="button" onClick={logOut}>
                         Logout
-                    </button>
-                </>
+                    </a>
+                    )
+                </NameDisplayer>
             ) : (
                 <NameChanger handleSubmit={handleSubmit} />
             )}

--- a/src/client/components/NameChanger/NameChanger.tsx
+++ b/src/client/components/NameChanger/NameChanger.tsx
@@ -1,6 +1,6 @@
-import { MAX_PLAYER_NAME_LENGTH } from '@/constants/lobbyConstants';
 import React, { FormEvent, useState } from 'react';
 import styled from 'styled-components';
+import { MAX_PLAYER_NAME_LENGTH } from '@/constants/lobbyConstants';
 import { PrimaryColorButton } from '../Button';
 
 interface NameChangerProps {

--- a/src/client/components/NameChanger/NameChanger.tsx
+++ b/src/client/components/NameChanger/NameChanger.tsx
@@ -1,3 +1,4 @@
+import { MAX_PLAYER_NAME_LENGTH } from '@/constants/lobbyConstants';
 import React, { FormEvent, useState } from 'react';
 import styled from 'styled-components';
 import { PrimaryColorButton } from '../Button';
@@ -49,6 +50,7 @@ export const NameChanger: React.FC<NameChangerProps> = ({ handleSubmit }) => {
                     <input
                         id="name-selector"
                         role="textbox"
+                        maxLength={MAX_PLAYER_NAME_LENGTH}
                         autoFocus
                         autoComplete="off" // ignore for password managers
                         data-lpignore="true" // ignore for lastPass

--- a/src/client/components/RoomSquare/RoomSquare.spec.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.spec.tsx
@@ -31,6 +31,36 @@ describe('Room Square', () => {
         expect(screen.getByText('Room 6')).toBeInTheDocument();
     });
 
+    it('joins the room', () => {
+        const mockJoinRoom = jest.fn();
+        render(
+            <RoomSquare
+                detailedRoom={{
+                    roomName: 'public-Room 6',
+                    players: ['Kimmy', 'Jimmy', 'Timmy'],
+                }}
+                joinRoom={mockJoinRoom}
+            />
+        );
+        fireEvent.click(screen.getByText('Join'));
+        expect(mockJoinRoom).toHaveBeenCalled();
+    });
+
+    it('hides the join room option', () => {
+        const mockJoinRoom = jest.fn();
+        render(
+            <RoomSquare
+                detailedRoom={{
+                    roomName: 'public-Room 6',
+                    players: ['Kimmy', 'Jimmy', 'Timmy'],
+                }}
+                hasJoined
+                joinRoom={mockJoinRoom}
+            />
+        );
+        expect(screen.queryByText('Join')).not.toBeInTheDocument();
+    });
+
     it('renders Started if a game has started', () => {
         render(
             <RoomSquare
@@ -53,6 +83,7 @@ describe('Room Square', () => {
                     players: ['Kimmy'],
                     hasStartedGame: false,
                 }}
+                hasJoined
                 onStartGameClicked={mockStartGame}
             />
         );
@@ -69,6 +100,7 @@ describe('Room Square', () => {
                     players: ['Kimmy', 'Jimmy'],
                     hasStartedGame: true,
                 }}
+                hasJoined
                 onStartGameClicked={mockStartGame}
             />
         );
@@ -85,6 +117,7 @@ describe('Room Square', () => {
                     players: ['Kimmy', 'Jimmy', 'Timmy'],
                     hasStartedGame: false,
                 }}
+                hasJoined
                 onStartGameClicked={mockStartGame}
             />
         );

--- a/src/client/components/RoomSquare/RoomSquare.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { DetailedRoom } from '@/types';
+import { SecondaryColorButton } from '../Button';
 
 type RoomSquareProps = {
     detailedRoom: DetailedRoom;
+    hasJoined?: boolean;
+    joinRoom?: () => void;
     onStartGameClicked?: () => void;
 };
+
+const PlayerList = styled.ul`
+    list-style-type: none;
+`;
 
 /**
  * @returns component for a single room to be displayed on the main
@@ -13,22 +21,36 @@ type RoomSquareProps = {
  */
 export const RoomSquare: React.FC<RoomSquareProps> = ({
     detailedRoom: { hasStartedGame, roomName, players },
+    hasJoined,
+    joinRoom,
     onStartGameClicked,
 }) => {
     const normalizedRoomName = roomName.replace('public-', '');
     return (
         <div>
-            <h1>{normalizedRoomName}</h1>
+            <h1>
+                {normalizedRoomName}
+                <span>
+                    {' '}
+                    {!hasJoined && (
+                        <SecondaryColorButton onClick={joinRoom}>
+                            Join
+                        </SecondaryColorButton>
+                    )}
+                    {!hasStartedGame && players.length > 1 && hasJoined && (
+                        <SecondaryColorButton onClick={onStartGameClicked}>
+                            Start Game
+                        </SecondaryColorButton>
+                    )}
+                </span>
+            </h1>
             {hasStartedGame && <span>Started</span>}
-            {!hasStartedGame && players.length > 1 && (
-                <button onClick={onStartGameClicked}>Start Game</button>
-            )}
             <div>
-                <ul>
+                <PlayerList>
                     {players.map((player) => (
-                        <li key={player}>{player}</li>
+                        <li key={player}>👤 {player}</li>
                     ))}
-                </ul>
+                </PlayerList>
             </div>
         </div>
     );

--- a/src/client/components/RoomSquare/RoomSquare.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.tsx
@@ -48,7 +48,9 @@ export const RoomSquare: React.FC<RoomSquareProps> = ({
             <div>
                 <PlayerList>
                     {players.map((player) => (
-                        <li key={player}>👤 {player}</li>
+                        <li key={player}>
+                            👤 <span>{player}</span>
+                        </li>
                     ))}
                 </PlayerList>
             </div>

--- a/src/client/components/Rooms/Rooms.spec.tsx
+++ b/src/client/components/Rooms/Rooms.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { render } from '@/test-utils';
 
 import { Rooms } from './Rooms';

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -1,14 +1,45 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
 import { RoomSquare } from '../RoomSquare/RoomSquare';
 import { RootState } from '@/client/redux/store';
 import { WebSocketContext } from '../WebSockets';
 import { DetailedRoom } from '@/types';
+import { PrimaryColorButton } from '../Button';
+import { MAX_ROOM_NAME_LENGTH } from '@/constants/lobbyConstants';
 
+const RoomsContainer = styled.div`
+    display: grid;
+    margin: 50px;
+    grid-template-columns: 250px 1fr;
+    overflow-y: hidden;
+`;
+
+const LeftColumn = styled.div`
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-gap: 10px;
+`;
+
+const MiddleColumn = styled.div`
+    overflow-y: scroll;
+`;
+
+/**
+ * Rooms is the primary lobby component responsible for rendering what users
+ * see when they've selected a name
+ * @returns @{JSX.Element}
+ */
 export const Rooms: React.FC = () => {
+    const name = useSelector<RootState, string>((state) => state.user.name);
     const rooms = useSelector<RootState, DetailedRoom[]>(
         (state) => state.rooms.rooms || []
     );
+    const joinedRoom = rooms.find((detailedRoom) =>
+        detailedRoom.players.find((player) => player === name)
+    );
+    const [newRoomName, setNewRoomName] = useState('Room 1 🥑');
     const webSocket = useContext(WebSocketContext);
 
     const joinRoom = (roomName: string) => {
@@ -26,16 +57,59 @@ export const Rooms: React.FC = () => {
     // don't allow players outside a room to start a room
 
     return (
-        <div>
-            {rooms.map((detailedRoom) => (
-                <RoomSquare
-                    detailedRoom={detailedRoom}
-                    key={detailedRoom.roomName}
-                    onStartGameClicked={startGame}
-                />
-            ))}
-            <button onClick={() => joinRoom('room 1')}>Room 1 join</button>
-            <button onClick={() => joinRoom('room 2')}>Room 2 join</button>
-        </div>
+        <RoomsContainer>
+            <LeftColumn>
+                <label htmlFor="newRoomName">
+                    <b>Create New Room</b>{' '}
+                    <input
+                        value={newRoomName}
+                        maxLength={MAX_ROOM_NAME_LENGTH}
+                        name="newRoomName"
+                        type="text"
+                        placeholder="The Training Grounds"
+                        onChange={(event) => {
+                            setNewRoomName(event.target.value);
+                        }}
+                    />
+                </label>
+
+                <span>
+                    <PrimaryColorButton
+                        onClick={() => {
+                            joinRoom(newRoomName);
+                        }}
+                        disabled={!newRoomName}
+                    >
+                        Create New Room
+                    </PrimaryColorButton>
+                </span>
+            </LeftColumn>
+            <MiddleColumn>
+                <h1>Rooms</h1>
+                {rooms &&
+                    [...rooms]
+                        .sort((roomA, roomB) =>
+                            roomA.roomName
+                                .toLowerCase()
+                                .localeCompare(roomB.roomName.toLowerCase())
+                        )
+                        .map((detailedRoom) => (
+                            <RoomSquare
+                                hasJoined={joinedRoom === detailedRoom}
+                                joinRoom={() => {
+                                    const normalizedRoomName =
+                                        detailedRoom.roomName.replace(
+                                            'public-',
+                                            ''
+                                        );
+                                    joinRoom(normalizedRoomName);
+                                }}
+                                detailedRoom={detailedRoom}
+                                key={detailedRoom.roomName}
+                                onStartGameClicked={startGame}
+                            />
+                        ))}
+            </MiddleColumn>
+        </RoomsContainer>
     );
 };

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -7,4 +7,6 @@ export enum Colors {
     FIRE_ORANGE = '#f57322',
     FIRE_ORANGE_EMPHASIZED = '#dc671e',
     FOCUS_BLUE = '#0071bc', // for outlines, accessiblity, showing active player
+    SECONDARY_GREEN = '#08A946',
+    SECONDARY_GREEN_EMPHASIZED = '#057932',
 }

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_ROOM_NAMES = [
+    'Aardvark Alley 🐜',
+    'Beetle Boulevard 🪲',
+    'Cobra Castle 🐍',
+];
+
+export const MAX_PLAYER_NAME_LENGTH = 25;
+
+export const MAX_ROOM_NAME_LENGTH = 50;

--- a/src/server/sockets/socket.spec.ts
+++ b/src/server/sockets/socket.spec.ts
@@ -13,6 +13,7 @@ import {
     DetailedRoom,
     ServerToClientEvents,
 } from '@/types';
+import { DEFAULT_ROOM_NAMES } from '@/constants/lobbyConstants';
 
 /**
  * TODO:
@@ -67,6 +68,16 @@ describe('sockets', () => {
 
         it('joins a room', (done) => {
             clientSocket.emit('joinRoom', 'treehouse-1');
+
+            const defaultRooms = DEFAULT_ROOM_NAMES.map(
+                (roomName): DetailedRoom => {
+                    return {
+                        roomName: `public-${roomName}`,
+                        players: [],
+                        hasStartedGame: false,
+                    };
+                }
+            );
             clientSocket.on('listRooms', (roomsAndIds: DetailedRoom[]) => {
                 expect(roomsAndIds).toEqual([
                     {
@@ -74,6 +85,7 @@ describe('sockets', () => {
                         players: ['Dora Wini'],
                         hasStartedGame: false,
                     },
+                    ...defaultRooms,
                 ]);
                 done();
             });


### PR DESCRIPTION
- Added new colors / backgrounds / layouts to the lobby experience
- renamed the default rooms (server always includes these in the listRooms response):

  - Aardvark Alley 🐜
  - Beetle Boulevard 🪲 
  - Cobra Castle 🐍

- Added logic to only display start button if the player is part of the game 
- Always sort the rooms alphabetically

Before (kind of bland / very minimal):

https://user-images.githubusercontent.com/1839462/158006413-f3e8a885-a6a6-4ff9-8a29-08c96f78882d.mov

Now (improved color schemes, layouts):

https://user-images.githubusercontent.com/1839462/158006434-769583de-b6fd-4f1d-9345-14c8bdb45bbd.mov


Precursor to #125 