### PR TITLE
Align rooms screen (lobby)

### DIFF
--- a/src/client/components/RoomSquare/RoomSquare.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.tsx
@@ -28,7 +28,7 @@ export const RoomSquare: React.FC<RoomSquareProps> = ({
     const normalizedRoomName = roomName.replace('public-', '');
     return (
         <div>
-            <h1>
+            <h2>
                 {normalizedRoomName}
                 <span>
                     {' '}
@@ -43,7 +43,7 @@ export const RoomSquare: React.FC<RoomSquareProps> = ({
                         </SecondaryColorButton>
                     )}
                 </span>
-            </h1>
+            </h2>
             {hasStartedGame && <span>Started</span>}
             <div>
                 <PlayerList>

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -14,16 +14,33 @@ const RoomsContainer = styled.div`
     margin: 50px;
     grid-template-columns: 250px 1fr;
     overflow-y: hidden;
+    grid-gap: 20px;
 `;
 
 const LeftColumn = styled.div`
     display: grid;
     grid-template-rows: auto 1fr;
     grid-gap: 10px;
+    padding: 20px;
+    background: wheat;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 50%);
+    height: 45%;
 `;
 
 const MiddleColumn = styled.div`
     overflow-y: scroll;
+`;
+
+const RoomsTab = styled.h1`
+    margin: 0;
+    background: pink;
+    color: white;
+    display: inline-grid;
+    place-items: center;
+    height: 40px;
+    padding: 7px;
+    border-top-right-radius: 8px;
+    border-bottom-left-radius: 8px;
 `;
 
 /**
@@ -80,12 +97,12 @@ export const Rooms: React.FC = () => {
                         }}
                         disabled={!newRoomName}
                     >
-                        Create New Room
+                        Create
                     </PrimaryColorButton>
                 </span>
             </LeftColumn>
             <MiddleColumn>
-                <h1>Rooms</h1>
+                <RoomsTab>Rooms</RoomsTab>
                 {rooms &&
                     [...rooms]
                         .sort((roomA, roomB) =>


### PR DESCRIPTION
Before:

<img width="944" alt="Screen Shot 2022-03-12 at 1 36 53 AM" src="https://user-images.githubusercontent.com/1839462/158007122-68b1f342-0210-4d8b-89ec-1938ce2097d5.png">

After:

<img width="1005" alt="Screen Shot 2022-03-12 at 1 37 05 AM" src="https://user-images.githubusercontent.com/1839462/158007127-0b436c8e-5b44-46aa-b5b2-7ef455b680e3.png">

(made room names h2's instead of h1's, added backgrounds to some of the elements on the screen)