### PR TITLE
Refactor: rename rooms slice to lobby slice

### DIFF
--- a/src/client/components/Rooms/Rooms.spec.tsx
+++ b/src/client/components/Rooms/Rooms.spec.tsx
@@ -8,7 +8,7 @@ import { RootState } from '@/client/redux/store';
 describe('Rooms', () => {
     it('renders multiple rooms', () => {
         const preloadedState: Partial<RootState> = {
-            rooms: {
+            lobby: {
                 rooms: [
                     {
                         roomName: 'Room 6',

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -7,7 +7,10 @@ import { RootState } from '@/client/redux/store';
 import { WebSocketContext } from '../WebSockets';
 import { DetailedRoom } from '@/types';
 import { PrimaryColorButton } from '../Button';
-import { MAX_ROOM_NAME_LENGTH } from '@/constants/lobbyConstants';
+import {
+    DeckListSelections,
+    MAX_ROOM_NAME_LENGTH,
+} from '@/constants/lobbyConstants';
 
 const RoomsContainer = styled.div`
     display: grid;
@@ -19,7 +22,7 @@ const RoomsContainer = styled.div`
 
 const LeftColumn = styled.div`
     display: grid;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto 1fr;
     grid-gap: 10px;
     padding: 20px;
     background: wheat;
@@ -51,7 +54,7 @@ const RoomsTab = styled.h1`
 export const Rooms: React.FC = () => {
     const name = useSelector<RootState, string>((state) => state.user.name);
     const rooms = useSelector<RootState, DetailedRoom[]>(
-        (state) => state.rooms.rooms || []
+        (state) => state.lobby.rooms || []
     );
     const joinedRoom = rooms.find((detailedRoom) =>
         detailedRoom.players.find((player) => player === name)
@@ -76,8 +79,10 @@ export const Rooms: React.FC = () => {
     return (
         <RoomsContainer>
             <LeftColumn>
-                <label htmlFor="newRoomName">
-                    <b>Create New Room</b>{' '}
+                <div>
+                    <label htmlFor="newRoomName">
+                        <b>Create New Room</b>{' '}
+                    </label>
                     <input
                         value={newRoomName}
                         maxLength={MAX_ROOM_NAME_LENGTH}
@@ -88,7 +93,7 @@ export const Rooms: React.FC = () => {
                             setNewRoomName(event.target.value);
                         }}
                     />
-                </label>
+                </div>
 
                 <span>
                     <PrimaryColorButton
@@ -100,6 +105,17 @@ export const Rooms: React.FC = () => {
                         Create
                     </PrimaryColorButton>
                 </span>
+
+                <div>
+                    <hr />
+                    <label htmlFor="deckSelection">
+                        <b>Choose a Deck</b>{' '}
+                    </label>
+                    <select name="deckSelection">
+                        <option>{DeckListSelections.MONKS}</option>
+                        <option>{DeckListSelections.MAGES}</option>
+                    </select>
+                </div>
             </LeftColumn>
             <MiddleColumn>
                 <RoomsTab>Rooms</RoomsTab>

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -7,7 +7,7 @@ import {
     chooseName as chooseNameReducer,
     initializeUser,
 } from '@/client/redux/user';
-import { updateRoomsAndPlayers } from '@/client/redux/room';
+import { updateRoomsAndPlayers } from '@/client/redux/lobby';
 import { AppDispatch } from '@/client/redux/store';
 import { updateBoardState } from '@/client/redux/board';
 import {

--- a/src/client/redux/lobby/index.ts
+++ b/src/client/redux/lobby/index.ts
@@ -1,0 +1,1 @@
+export * from './lobby';

--- a/src/client/redux/lobby/lobby.ts
+++ b/src/client/redux/lobby/lobby.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
 import { DetailedRoom } from '@/types';
 
-export const roomsSlice = createSlice({
-    name: 'rooms',
+export const lobbySlice = createSlice({
+    name: 'lobby',
     initialState: { rooms: [] as DetailedRoom[] },
     reducers: {
         updateRoomsAndPlayers(state, action: PayloadAction<DetailedRoom[]>) {
@@ -11,7 +11,7 @@ export const roomsSlice = createSlice({
     },
 });
 
-export const roomsReducer: Reducer<{ rooms: DetailedRoom[] }> =
-    roomsSlice.reducer;
+export const lobbyReducer: Reducer<{ rooms: DetailedRoom[] }> =
+    lobbySlice.reducer;
 
-export const { updateRoomsAndPlayers } = roomsSlice.actions;
+export const { updateRoomsAndPlayers } = lobbySlice.actions;

--- a/src/client/redux/room/index.ts
+++ b/src/client/redux/room/index.ts
@@ -1,1 +1,0 @@
-export * from './room';

--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -4,7 +4,7 @@ import { createBrowserHistory } from 'history';
 import { applyMiddleware } from 'redux';
 
 import { boardReducer } from './board';
-import { roomsReducer } from './room';
+import { lobbyReducer } from './lobby';
 import { userReducer, userSlice } from './user';
 import { clientSideGameExtrasReducer } from './clientSideGameExtras';
 
@@ -18,7 +18,7 @@ export const createRootReducer = () =>
         board: boardReducer,
         clientSideGameExtras: clientSideGameExtrasReducer,
         router: routerReducer,
-        rooms: roomsReducer,
+        lobby: lobbyReducer,
         user: userReducer,
     });
 

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -4,6 +4,11 @@ export const DEFAULT_ROOM_NAMES = [
     'Cobra Castle 🐍',
 ];
 
+export enum DeckListSelections {
+    MAGES = 'mages',
+    MONKS = 'monks',
+}
+
 export const MAX_PLAYER_NAME_LENGTH = 25;
 
 export const MAX_ROOM_NAME_LENGTH = 50;


### PR DESCRIPTION
Making rooms 'lobby' instead so that it can encompass more aspects of the lobby screen, e.g. deck list selection

Needed for #125