### PR TITLE
Show tooltips for unit cards on board

### DIFF
--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -5,6 +5,7 @@ interface CardFrameProps {
     isRaised?: boolean;
     isRotated?: boolean;
     primaryColor?: string;
+    zoomLevel?: number;
 }
 /**
  * Aesthetic components relating to how a card is rendered in full-card mode
@@ -30,7 +31,7 @@ export const CardFrame = styled.div<CardFrameProps>`
         
     `
             : ''}
-    zoom: 0.75;
+    zoom: ${({ zoomLevel = 1 }) => zoomLevel * 0.75};
     cursor: pointer;
     font-size: 14px;
     display: inline-grid;

--- a/src/client/components/CardGridItem/CardGridItem.tsx
+++ b/src/client/components/CardGridItem/CardGridItem.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { usePopperTooltip } from 'react-popper-tooltip';
 
 import { Card, CardType } from '@/types/cards';
 import { ResourceCardGridItem } from '../ResourceCardGridItem';
@@ -9,13 +10,19 @@ import { GameManagerContext } from '../GameManager';
 interface CardGridItemProps {
     card: Card;
     hasOnClick?: boolean;
+    hasTooltip?: boolean;
     isOnBoard?: boolean;
+    zoomLevel?: number;
 }
 
-export const CardGridItem: React.FC<CardGridItemProps> = ({
+/**
+ * renders a card grid item w/ no tooltip
+ */
+export const CardGridSingleItem: React.FC<CardGridItemProps> = ({
     card,
     hasOnClick,
     isOnBoard,
+    zoomLevel,
 }) => {
     const { handleClickCard } = useContext(GameManagerContext) || {};
     const onClick = () => {
@@ -26,6 +33,7 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
             <ResourceCardGridItem
                 card={card}
                 onClick={hasOnClick ? onClick : undefined}
+                zoomLevel={zoomLevel}
             />
         );
     }
@@ -34,6 +42,7 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
             <SpellGridItem
                 card={card}
                 onClick={hasOnClick ? onClick : undefined}
+                zoomLevel={zoomLevel}
             />
         );
     }
@@ -43,8 +52,58 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
                 card={card}
                 onClick={hasOnClick ? onClick : undefined}
                 isOnBoard={isOnBoard}
+                zoomLevel={zoomLevel}
             />
         );
     }
     return undefined;
+};
+
+export const CardGridItem: React.FC<CardGridItemProps> = ({
+    card,
+    hasTooltip,
+    hasOnClick,
+    isOnBoard,
+    zoomLevel = 1,
+}) => {
+    const {
+        getArrowProps,
+        getTooltipProps,
+        setTooltipRef,
+        setTriggerRef,
+        visible,
+    } = usePopperTooltip();
+
+    return (
+        <>
+            {/* The card itself */}
+            <div style={{ display: 'inline-grid' }} ref={setTriggerRef}>
+                <CardGridSingleItem
+                    key={card.id}
+                    card={card}
+                    hasOnClick
+                    zoomLevel={zoomLevel}
+                />
+            </div>
+            {visible && hasTooltip && (
+                <div
+                    ref={setTooltipRef}
+                    {...getTooltipProps({
+                        className: 'tooltip-container',
+                    })}
+                >
+                    <CardGridSingleItem
+                        isOnBoard={isOnBoard}
+                        card={card}
+                        hasOnClick={hasOnClick}
+                    />
+                    <div
+                        {...getArrowProps({
+                            className: 'tooltip-arrow',
+                        })}
+                    />
+                </div>
+            )}
+        </>
+    );
 };

--- a/src/client/components/HandOfCards/HandOfCards.tsx
+++ b/src/client/components/HandOfCards/HandOfCards.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { usePopperTooltip } from 'react-popper-tooltip';
 import { useSelector } from 'react-redux';
 
 import { getSelfPlayer } from '@/client/redux/selectors';
@@ -38,37 +37,9 @@ interface CardInHandProps {
 }
 // one of the cards in the hand of cards
 const CardInHand: React.FC<CardInHandProps> = ({ card }) => {
-    const {
-        getArrowProps,
-        getTooltipProps,
-        setTooltipRef,
-        setTriggerRef,
-        visible,
-    } = usePopperTooltip();
-
     return (
         <WidthLessContainer key={card.id}>
-            {/* The card itself */}
-            <div style={{ width: 220 }} ref={setTriggerRef}>
-                <CardGridItem key={card.id} card={card} hasOnClick />
-            </div>
-
-            {/* Tooltip when card is hovered */}
-            {visible && (
-                <div
-                    ref={setTooltipRef}
-                    {...getTooltipProps({
-                        className: 'tooltip-container',
-                    })}
-                >
-                    <CardGridItem key={card.id} card={card} />
-                    <div
-                        {...getArrowProps({
-                            className: 'tooltip-arrow',
-                        })}
-                    />
-                </div>
-            )}
+            <CardGridItem key={card.id} card={card} hasOnClick hasTooltip />
         </WidthLessContainer>
     );
 };

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
@@ -17,7 +17,6 @@ interface PlayerBoardSectionContainerProps {
 const PlayerBoardSectionContainer = styled.div<PlayerBoardSectionContainerProps>`
     background-color: ${({ isSelfPlayer }) =>
         isSelfPlayer ? Colors.FELT_GREEN_ALT : Colors.FELT_GREEN};
-    zoom: 0.6;
     box-shadow: 0 2px 2px rgb(0 0 0 / 50%);
 `;
 
@@ -29,27 +28,38 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
         return <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer} />;
     }
     const { units, resources } = player;
+    const unitsSection = (
+        <div>
+            {units.map((unitCard) => (
+                <CardGridItem
+                    card={unitCard}
+                    key={unitCard.id}
+                    hasOnClick
+                    hasTooltip
+                    isOnBoard
+                    zoomLevel={0.6}
+                />
+            ))}
+        </div>
+    );
+    const resourcesSection = (
+        <div>
+            {resources.map((resourceCard) => (
+                <CardGridItem
+                    card={resourceCard}
+                    key={resourceCard.id}
+                    hasOnClick
+                    zoomLevel={0.6}
+                />
+            ))}
+        </div>
+    );
     return (
         <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer}>
-            <div>
-                {units.map((unitCard) => (
-                    <CardGridItem
-                        card={unitCard}
-                        key={unitCard.id}
-                        hasOnClick
-                        isOnBoard
-                    />
-                ))}
-            </div>
-            <div>
-                {resources.map((resourceCard) => (
-                    <CardGridItem
-                        card={resourceCard}
-                        key={resourceCard.id}
-                        hasOnClick
-                    />
-                ))}
-            </div>
+            {!isSelfPlayer && resourcesSection}
+            {/* for other players, display resources above units */}
+            {unitsSection}
+            {isSelfPlayer && resourcesSection}
         </PlayerBoardSectionContainer>
     );
 };

--- a/src/client/components/ResourceCardGridItem/ResourceCardGridItem.tsx
+++ b/src/client/components/ResourceCardGridItem/ResourceCardGridItem.tsx
@@ -8,11 +8,13 @@ import { CastingCostFrame } from '../CastingCost';
 interface ResourceCardGridItemProps {
     card: ResourceCard;
     onClick?: () => void;
+    zoomLevel?: number;
 }
 
 export const ResourceCardGridItem: React.FC<ResourceCardGridItemProps> = ({
     card,
     onClick,
+    zoomLevel,
 }) => {
     const { name, icon, primaryColor } = RESOURCE_GLOSSARY[card.resourceType];
     return (
@@ -21,6 +23,7 @@ export const ResourceCardGridItem: React.FC<ResourceCardGridItemProps> = ({
             data-testid="ResourceCard-GridItem"
             onClick={onClick}
             isRotated={card.isUsed}
+            zoomLevel={zoomLevel}
         >
             <CardHeader>
                 <NameCell>{name}</NameCell>

--- a/src/client/components/SpellGridItem/SpellGridItem.tsx
+++ b/src/client/components/SpellGridItem/SpellGridItem.tsx
@@ -17,11 +17,13 @@ import { getColorForCard } from '@/transformers/getColorForCard';
 interface SpellGridItemProps {
     card: SpellCard;
     onClick?: () => void;
+    zoomLevel?: number;
 }
 
 export const SpellGridItem: React.FC<SpellGridItemProps> = ({
     card,
     onClick,
+    zoomLevel,
 }) => {
     const { cost, imgSrc, name, effects } = card;
 
@@ -30,6 +32,7 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({
             data-testid="SpellGridItem"
             primaryColor={getColorForCard(card)}
             onClick={onClick}
+            zoomLevel={zoomLevel}
         >
             <CardHeader>
                 <NameCell>{name}</NameCell>

--- a/src/client/components/UnitGridItem/UnitGridItem.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.tsx
@@ -23,12 +23,14 @@ interface UnitGridItemProps {
     card: UnitCard;
     isOnBoard?: boolean;
     onClick?: () => void;
+    zoomLevel?: number;
 }
 
 export const UnitGridItem: React.FC<UnitGridItemProps> = ({
     card,
     isOnBoard = false,
     onClick,
+    zoomLevel,
 }) => {
     const attackUnitId = useSelector(getAttackingUnit);
     const {
@@ -58,6 +60,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
             data-testid="UnitGridItem"
             primaryColor={getColorForCard(card)}
             onClick={onClick}
+            zoomLevel={zoomLevel}
         >
             <CardHeader>
                 <NameCell>{name}</NameCell>


### PR DESCRIPTION
Closes: #130

Made it so that CardGridItem is where all tooltip display handling will be handled (rather than HandOfCards).  This allows us to extend the tooltips to the cards rendered on PlayerBoardSection

Demo:

https://user-images.githubusercontent.com/1839462/158034300-f210070c-95f9-4e88-bfe9-e453aca43728.mov


