### PR TITLE
Fixes for sending units to cemetary properly

### DIFF
--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -29,8 +29,13 @@ const LeftColumn = styled.div`
     box-shadow: 0 1px 3px rgb(0 0 0 / 50%);
     height: 45%;
 
+    label {
+        margin-bottom: 4px;
+        display: block;
+    }
     input {
-        zoom: 1.4;
+        width: 90%;
+        height: 30px;
     }
     select {
         zoom: 1.7;

--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -449,6 +449,7 @@ describe('Game Action', () => {
             const attacker = makeCard(UnitCards.BOUNTY_COLLECTOR);
             attacker.numAttacksLeft = 1;
             const defender = makeCard(UnitCards.SQUIRE);
+            defender.hpBuff = 3;
             board.players[0].units = [attacker];
             board.players[1].units = [defender];
             const newBoardState = applyGameAction({

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -56,16 +56,17 @@ export const processBoardToCemetery = (board: Board) => {
     const { players } = board;
     if (!players?.length) return;
     players.forEach((player) => {
-        const { units } = player;
-        units.forEach((unitCard) => {
-            const { hp, hpBuff } = unitCard;
-            if (hp + hpBuff <= 0) {
-                resetUnitCard(unitCard);
-                player.cemetery.push(
-                    units.splice(units.indexOf(unitCard), 1)[0]
-                );
-            }
-        });
+        const unitsHeadedToCemetery = player.units.filter(
+            (unit) => unit.hp + unit.hpBuff <= 0
+        );
+
+        const unitsLeft = player.units.filter(
+            (unit) => unit.hp + unit.hpBuff > 0
+        );
+
+        player.units = unitsLeft;
+        player.cemetery = player.cemetery.concat(unitsHeadedToCemetery);
+        unitsHeadedToCemetery.forEach(resetUnitCard);
     });
 };
 
@@ -240,11 +241,11 @@ export const applyGameAction = ({
                     !attacker.isRanged
                 ) {
                     attacker.hp = defenderHasPoisonous
-                        ? 0
+                        ? -Number.MAX_SAFE_INTEGER
                         : hp - defenderAttack - defenderAttackBuff;
                 }
                 defender.hp = attackerHasPoisonous
-                    ? 0
+                    ? -Number.MAX_SAFE_INTEGER
                     : defenderHp - attack - attackBuff;
 
                 // Resolve units going to the cemetery

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -215,23 +215,22 @@ describe('resolve effect', () => {
             );
         });
 
-        it('deals damage to all opposing unit', () => {
+        it('deals lethal damage (all opposing units)', () => {
             const squire = makeCard(UnitCards.SQUIRE);
-            board.players[1].units = [squire];
+            const squire2 = makeCard(UnitCards.SQUIRE);
+            board.players[1].units = [squire, squire2];
             const newBoard = resolveEffect(
                 board,
                 {
                     effect: {
                         type: EffectType.DEAL_DAMAGE,
-                        strength: 2,
+                        strength: 4,
                         target: TargetTypes.ALL_OPPOSING_UNITS,
                     },
                 },
                 'Timmy'
             );
-            expect(newBoard.players[1].units[0].hp).toEqual(
-                UnitCards.SQUIRE.hp - 2
-            );
+            expect(newBoard.players[1].units).toHaveLength(0);
         });
 
         it('deals damage to a player', () => {


### PR DESCRIPTION
- If a unit with poisonous attacks a buffed unit, it will now properly send it to the grave
- Boardwipe spells (rain of arrows) should properly wipe units out now (before only half were being sent to cemetary).  Closes: #144
- Make rooms "choose a name" input fit on Windows browsers (hopefully)