### PR TITLE
Bug: handle # of cards in hand / level at the `obscureBoardInfo` level

### DIFF
--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -83,12 +83,6 @@ describe('Game Action', () => {
 
             const nextPlayer = newBoardState.players[1];
 
-            expect(nextPlayer.numCardsInDeck).toEqual(
-                cardsInDeckBefore.length - 1
-            );
-            expect(nextPlayer.numCardsInHand).toEqual(
-                cardsInHandBefore.length + 1
-            );
             expect(nextPlayer.deck).toEqual(
                 cardsInDeckBefore.slice(0, cardsInDeckBefore.length - 1)
             );
@@ -116,7 +110,7 @@ describe('Game Action', () => {
                 gameAction: { type: GameActionTypes.PASS_TURN },
                 playerName: 'Timmy',
             });
-            expect(newBoardState.players[2].numCardsInDeck).toEqual(
+            expect(newBoardState.players[2].deck.length).toEqual(
                 cardsInDeckBefore.length - 1
             );
         });
@@ -157,7 +151,7 @@ describe('Game Action', () => {
                 playerName: 'Timmy',
             });
             expect(newBoardState.players[0].resources).toHaveLength(1);
-            expect(newBoardState.players[0].numCardsInHand).toEqual(0);
+            expect(newBoardState.players[0].hand).toHaveLength(0);
             expect(newBoardState.players[0].resourcesLeftToDeploy).toBe(0);
         });
 
@@ -240,7 +234,6 @@ describe('Game Action', () => {
                 playerName: 'Timmy',
             });
             expect(newBoardState.players[0].hand).toEqual([]);
-            expect(newBoardState.players[0].numCardsInHand).toBe(0);
             expect(newBoardState.players[0].units[0]).toEqual(unitCard);
         });
 
@@ -682,9 +675,6 @@ describe('Game Action', () => {
                 spellCard.effects
             );
             expect(newBoardState.players[0].cemetery).toEqual([spellCard]);
-            expect(newBoardState.players[0].numCardsInHand).toEqual(
-                PlayerConstants.STARTING_HAND_SIZE - 1
-            );
         });
 
         it("won't cast a spell that's too expensive", () => {
@@ -702,9 +692,6 @@ describe('Game Action', () => {
 
             expect(newBoardState.players[0].effectQueue).toHaveLength(0);
             expect(newBoardState.players[0].cemetery).toHaveLength(0);
-            expect(newBoardState.players[0].numCardsInHand).toEqual(
-                PlayerConstants.STARTING_HAND_SIZE
-            );
         });
     });
 });

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -119,8 +119,6 @@ export const applyGameAction = ({
                     activePlayer = nextPlayer;
                 } else {
                     // proceed to next turn
-                    nextPlayer.numCardsInDeck -= 1;
-                    nextPlayer.numCardsInHand += 1;
                     nextPlayer.resourcesLeftToDeploy = 1;
                     nextPlayer.hand.push(nextPlayer.deck.pop());
                     return clonedBoard;
@@ -140,7 +138,6 @@ export const applyGameAction = ({
             if (resourcesLeftToDeploy <= 0) {
                 return clonedBoard;
             }
-            activePlayer.numCardsInHand -= 1;
             activePlayer.resourcesLeftToDeploy -= 1;
 
             resources.push(
@@ -183,7 +180,6 @@ export const applyGameAction = ({
                 activePlayer.effectQueue = activePlayer.effectQueue.concat(
                     cloneDeep(matchingCard.enterEffects)
                 );
-                activePlayer.numCardsInHand -= 1;
                 activePlayer.hand.splice(matchingCardIndex, 1);
             }
             return clonedBoard;
@@ -296,7 +292,6 @@ export const applyGameAction = ({
             activePlayer.effectQueue = activePlayer.effectQueue.concat(
                 cloneDeep(matchingCard.effects)
             );
-            activePlayer.numCardsInHand -= 1;
             cemetery.push(hand.splice(matchingCardIndex, 1)[0]);
 
             return clonedBoard;

--- a/src/server/obscureBoardInfo/obscureBoardInfo.spec.ts
+++ b/src/server/obscureBoardInfo/obscureBoardInfo.spec.ts
@@ -1,10 +1,30 @@
+import { PlayerConstants } from '@/constants/gameConstants';
 import { makeNewBoard } from '@/factories/board';
 import { obscureBoardInfo } from './obscureBoardInfo';
 
 describe('Obscure board info', () => {
+    it('provides hints as to the number of cards in hand / deck', () => {
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tommy'] });
+        const boardTommySees = obscureBoardInfo(board, 'Tommy');
+        const timmy = boardTommySees.players.find(
+            (player) => player.name === 'Timmy'
+        );
+        const tommy = boardTommySees.players.find(
+            (player) => player.name === 'Tommy'
+        );
+        expect(timmy.numCardsInDeck).not.toEqual(0);
+        expect(tommy.numCardsInDeck).not.toEqual(0);
+        expect(timmy.numCardsInHand).toEqual(
+            PlayerConstants.STARTING_HAND_SIZE
+        );
+        expect(tommy.numCardsInHand).toEqual(
+            PlayerConstants.STARTING_HAND_SIZE
+        );
+    });
+
     it("hides other players' hands", () => {
-        const board = makeNewBoard({ playerNames: ['Timmy', 'Tom'] });
-        const boardTommySees = obscureBoardInfo(board, 'Tom');
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tommy'] });
+        const boardTommySees = obscureBoardInfo(board, 'Tommy');
         expect(
             boardTommySees.players.find((player) => player.name === 'Timmy')
                 .hand
@@ -12,18 +32,20 @@ describe('Obscure board info', () => {
     });
 
     it('does not hide your own hand', () => {
-        const board = makeNewBoard({ playerNames: ['Timmy', 'Tom'] });
-        const boardTommySees = obscureBoardInfo(board, 'Tom');
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tommy'] });
+        const boardTommySees = obscureBoardInfo(board, 'Tommy');
         expect(
-            boardTommySees.players.find((player) => player.name === 'Tom').hand
+            boardTommySees.players.find((player) => player.name === 'Tommy')
+                .hand
         ).not.toEqual([]);
     });
 
     it('hides decks', () => {
-        const board = makeNewBoard({ playerNames: ['Timmy', 'Tom'] });
-        const boardTommySees = obscureBoardInfo(board, 'Tom');
+        const board = makeNewBoard({ playerNames: ['Timmy', 'Tommy'] });
+        const boardTommySees = obscureBoardInfo(board, 'Tommy');
         expect(
-            boardTommySees.players.find((player) => player.name === 'Tom').deck
+            boardTommySees.players.find((player) => player.name === 'Tommy')
+                .deck
         ).toEqual([]);
 
         expect(

--- a/src/server/obscureBoardInfo/obscureBoardInfo.ts
+++ b/src/server/obscureBoardInfo/obscureBoardInfo.ts
@@ -12,14 +12,17 @@ export const obscureBoardInfo = (
 ): Board => {
     const obscuredBoard = cloneDeep(board);
 
+    obscuredBoard.players.forEach((player) => {
+        player.numCardsInHand = player.hand.length;
+        player.numCardsInDeck = player.deck.length;
+        player.deck = [];
+    });
+
     obscuredBoard.players
         .filter((player) => player.name !== forPlayerName)
         .forEach((player) => {
             player.hand = [];
         });
 
-    obscuredBoard.players.forEach((player) => {
-        player.deck = [];
-    });
     return obscuredBoard;
 };

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -166,14 +166,8 @@ describe('resolve effect', () => {
             expect(newBoard.players[0].hand).toHaveLength(
                 PlayerConstants.STARTING_HAND_SIZE + 2
             );
-            expect(newBoard.players[0].numCardsInHand).toEqual(
-                PlayerConstants.STARTING_HAND_SIZE + 2
-            );
             expect(newBoard.players[0].deck).toHaveLength(deckLength - 2);
             expect(newBoard.players[1].hand).toHaveLength(
-                PlayerConstants.STARTING_HAND_SIZE + 2
-            );
-            expect(newBoard.players[1].numCardsInHand).toEqual(
                 PlayerConstants.STARTING_HAND_SIZE + 2
             );
         });
@@ -189,11 +183,7 @@ describe('resolve effect', () => {
             expect(newBoard.players[0].hand).toHaveLength(
                 PlayerConstants.STARTING_HAND_SIZE + deckLength
             );
-            expect(newBoard.players[0].numCardsInHand).toEqual(
-                PlayerConstants.STARTING_HAND_SIZE + deckLength
-            );
             expect(newBoard.players[0].deck).toEqual([]);
-            expect(newBoard.players[0].numCardsInDeck).toEqual(0);
             expect(newBoard.players[0].isAlive).toEqual(false);
         });
     });

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -169,8 +169,6 @@ export const resolveEffect = (
                     player.isAlive = false;
                 }
                 player.hand = hand.concat(deck.splice(-effectStrength));
-                player.numCardsInHand = player.hand.length;
-                player.numCardsInDeck = player.deck.length;
             });
             return clonedBoard;
         }


### PR DESCRIPTION
We previously manually calculated the number of cards in hand /deck to show to each player manually and it was tedious to maintain / sometimes inaccurate

This removes that logic in favor of calculating at the point where the server needs to send down obscured board information