### PR TITLE
Implement 'curse hand' effect

### DIFF
--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash.clonedeep';
+
 import { CardType, SpellBase, SpellCard } from '@/types/cards';
 import { EffectType, TargetTypes } from '@/types/effects';
 import { Resource } from '@/types/resources';
@@ -7,6 +9,7 @@ export const makeCard = (spellBase: SpellBase): SpellCard => ({
     ...spellBase,
     cardType: CardType.SPELL,
     isSelected: false,
+    originalCost: cloneDeep(spellBase.cost),
 });
 
 // Fire Magic

--- a/src/cardDb/units/units.spec.ts
+++ b/src/cardDb/units/units.spec.ts
@@ -29,10 +29,11 @@ describe('Unit Cards', () => {
         const unitCard = makeCard(unitBase);
         expect(unitCard.name).toBe(unitBase.name);
         expect(unitCard.attack).toBe(unitBase.attack);
+        expect(unitCard.attackBuff).toBe(0);
         expect(unitCard.numAttacksLeft).toBe(0);
         expect(unitCard.hp).toBe(10);
         expect(unitCard.hpBuff).toBe(0);
-        expect(unitCard.attackBuff).toBe(0);
+        expect(unitCard.originalCost).toEqual(unitBase.cost);
         expect(unitCard.cardType).toBe(CardType.UNIT);
         expect(unitCard.isSelected).toBe(false);
     });

--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash.clonedeep';
 import { CardType, UnitBase, UnitCard } from '@/types/cards';
 import { EffectType, PassiveEffect, TargetTypes } from '@/types/effects';
 import { Resource } from '@/types/resources';
@@ -12,6 +13,7 @@ export const makeCard = (unitBase: UnitBase): UnitCard => {
         isSelected: false,
         hpBuff: 0,
         attackBuff: 0,
+        originalCost: cloneDeep(unitBase.cost),
     };
 };
 

--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -35,7 +35,7 @@ export const CardFrame = styled.div<CardFrameProps>`
     cursor: pointer;
     font-size: 14px;
     display: inline-grid;
-    grid-template-rows: 20px 1fr 20px 120px auto;
+    grid-template-rows: auto 1fr 20px 120px auto;
     width: 220px;
     height: 320px;
     border: 10px solid #240503;

--- a/src/client/components/CastingCost/CastingCost.tsx
+++ b/src/client/components/CastingCost/CastingCost.tsx
@@ -7,13 +7,16 @@ import {
     Resource,
     RESOURCE_GLOSSARY,
 } from '@/types/resources';
+import { Colors } from '@/constants/colors';
 
 interface CastingCostProps {
     cost: PartialRecord<Resource, number>;
+    originalCost?: PartialRecord<Resource, number>;
 }
 
 interface CastingCostFrameProps {
     hasNoMargin?: boolean;
+    isGenericIncreased?: boolean;
     shouldCollapseLeft?: boolean;
 }
 
@@ -21,6 +24,8 @@ export const CastingCostFrame = styled.span<CastingCostFrameProps>`
     background: rgb(100, 100, 100);
     border: 1px solid rgb(255, 255, 255);
     border-radius: 100%;
+    ${({ isGenericIncreased }) =>
+        isGenericIncreased ? `color: ${Colors.DEBUFF_RED};` : ''}
     width: 20px;
     height: 20px;
     display: inline-grid;
@@ -34,9 +39,13 @@ export const CastingCostFrame = styled.span<CastingCostFrameProps>`
     }
 `;
 
-export const CastingCost: React.FC<CastingCostProps> = ({ cost }) => {
+export const CastingCost: React.FC<CastingCostProps> = ({
+    cost,
+    originalCost,
+}) => {
     const costs: JSX.Element[] = [];
     let key = 0;
+    const originalGenericCost = originalCost?.Generic || 0;
     ORDERED_RESOURCES.forEach((resource) => {
         if (!(resource in cost)) {
             return;
@@ -45,7 +54,15 @@ export const CastingCost: React.FC<CastingCostProps> = ({ cost }) => {
         const castingSymbol = RESOURCE_GLOSSARY[resource].icon;
         if (resource === Resource.GENERIC) {
             key += 1;
-            costs.push(<CastingCostFrame key={key}>{number}</CastingCostFrame>);
+            // render the generic symbol
+            costs.push(
+                <CastingCostFrame
+                    key={key}
+                    isGenericIncreased={number > originalGenericCost}
+                >
+                    {number}
+                </CastingCostFrame>
+            );
         } else {
             [...new Array(number)].forEach((_, i) => {
                 key += 1;

--- a/src/client/components/SpellGridItem/SpellGridItem.tsx
+++ b/src/client/components/SpellGridItem/SpellGridItem.tsx
@@ -25,7 +25,7 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({
     onClick,
     zoomLevel,
 }) => {
-    const { cost, imgSrc, name, effects } = card;
+    const { cost, imgSrc, name, effects, originalCost } = card;
 
     return (
         <CardFrame
@@ -37,7 +37,7 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({
             <CardHeader>
                 <NameCell>{name}</NameCell>
                 <CostHeaderCell>
-                    <CastingCost cost={cost} />
+                    <CastingCost cost={cost} originalCost={originalCost} />
                 </CostHeaderCell>
             </CardHeader>
             <CardImageContainer>

--- a/src/client/components/UnitGridItem/UnitGridItem.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.tsx
@@ -46,6 +46,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
         isRanged,
         isSoldier,
         name,
+        originalCost,
         passiveEffects,
         totalHp,
     } = card;
@@ -65,7 +66,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
             <CardHeader>
                 <NameCell>{name}</NameCell>
                 <CostHeaderCell>
-                    <CastingCost cost={cost} />
+                    <CastingCost cost={cost} originalCost={originalCost} />
                 </CostHeaderCell>
             </CardHeader>
             <CardImageContainer>

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -44,6 +44,7 @@ export const resetUnitCard = (unitCard: UnitCard) => {
     unitCard.hpBuff = 0;
     unitCard.attackBuff = 0;
     unitCard.numAttacksLeft = hasQuick ? unitCard.numAttacks : 0;
+    unitCard.cost = cloneDeep(unitCard.originalCost);
 };
 
 /**

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -83,6 +83,30 @@ describe('resolve effect', () => {
             expect(lastCardInHand.attackBuff).toEqual(0);
             expect(lastCardInHand.hpBuff).toEqual(0);
         });
+
+        it("resets a unit's costs", () => {
+            const squire = makeCard(UnitCards.SQUIRE);
+            squire.attackBuff = 2;
+            squire.hpBuff = 2;
+            squire.cost.Generic = 5;
+            board.players[0].units = [squire];
+
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: { type: EffectType.BOUNCE },
+                    unitCardIds: [squire.id],
+                },
+                'Timmy'
+            );
+
+            const lastCardInHand = newBoard.players[0].hand.splice(
+                -1
+            )[0] as UnitCard;
+            expect(lastCardInHand.attackBuff).toEqual(0);
+            expect(lastCardInHand.hpBuff).toEqual(0);
+            expect(lastCardInHand.cost.Generic).toEqual(1);
+        });
     });
 
     describe('Buff units', () => {
@@ -144,6 +168,34 @@ describe('resolve effect', () => {
             expect(newBoard.players[0].units[0].attackBuff).toEqual(0);
             expect(newBoard.players[0].units[1].attackBuff).toEqual(0);
             expect(newBoard.players[0].units[2].attackBuff).toEqual(2);
+        });
+    });
+
+    describe('Curse Hand', () => {
+        it('increases costs for cards', () => {
+            board.players[1].hand = [
+                makeCard(UnitCards.SQUIRE),
+                makeCard(UnitCards.LANCER),
+            ];
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.CURSE_HAND,
+                        strength: 2,
+                        target: TargetTypes.OPPONENT,
+                    },
+                    playerNames: ['Tommy'],
+                },
+                'Timmy'
+            );
+
+            expect((newBoard.players[1].hand[0] as UnitCard).cost.Generic).toBe(
+                3
+            );
+            expect((newBoard.players[1].hand[1] as UnitCard).cost.Generic).toBe(
+                2
+            );
         });
     });
 

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -9,7 +9,7 @@ import {
 } from '@/types/effects';
 import { CardType, UnitCard } from '@/types/cards';
 import { makeCard } from '@/factories/cards';
-import { processBoardToCemetery } from '../gameEngine';
+import { processBoardToCemetery, resetUnitCard } from '../gameEngine';
 
 export const resolveEffect = (
     board: Board,
@@ -112,9 +112,7 @@ export const resolveEffect = (
             unitTargets.forEach(({ player, unitCard }) => {
                 player.units = player.units.filter((card) => card !== unitCard);
                 player.hand.push(unitCard);
-                unitCard.hp = unitCard.totalHp;
-                unitCard.attackBuff = 0;
-                unitCard.hpBuff = 0;
+                resetUnitCard(unitCard);
             });
             return clonedBoard;
         }
@@ -143,6 +141,17 @@ export const resolveEffect = (
                 player.units.forEach((unit) => {
                     if (unit.isMagical) {
                         unit.attackBuff += effectStrength;
+                    }
+                });
+            });
+            return clonedBoard;
+        }
+        case EffectType.CURSE_HAND: {
+            playerTargets.forEach((player) => {
+                player.hand.forEach((card) => {
+                    if (card.cardType !== CardType.RESOURCE) {
+                        card.cost.Generic =
+                            (card.cost.Generic || 0) + effectStrength;
                     }
                 });
             });

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -42,6 +42,7 @@ export type UnitBase = {
     name: string;
     // how much damage is inflicted per attack
     numAttacks: number;
+    originalCost?: PartialRecord<Resource, number>;
     // all units except magic must attack soldiers first 🛡️
     passiveEffects: PassiveEffect[];
     totalHp: number;
@@ -64,6 +65,7 @@ export type SpellBase = {
     effects: Effect[];
     imgSrc?: string;
     name: string;
+    originalCost?: PartialRecord<Resource, number>;
 };
 
 export interface SpellCard extends SpellBase {


### PR DESCRIPTION
Closes: #84

Implements the powerful 'curse hand' ability that makes cards for a target player cost X more in their hand.

When cards are reset (e.g. go to cemetary, bounced, etc.) they get their original costs back.  In addition, an 'originalCost' was added to do on-the-fly calcuations of if costs were costing more than they did originally