### PR TITLE
Indicate eligible attackers / defenders

### DIFF
--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Colors } from '@/constants/colors';
 
 interface CardFrameProps {
+    isHighlighted?: boolean;
     isRaised?: boolean;
     isRotated?: boolean;
     primaryColor?: string;
@@ -38,7 +39,9 @@ export const CardFrame = styled.div<CardFrameProps>`
     grid-template-rows: auto 1fr 20px 120px auto;
     width: 220px;
     height: 320px;
-    border: 10px solid #240503;
+    border: 10px solid
+        ${({ isHighlighted }) =>
+            isHighlighted ? Colors.FOCUS_BLUE : '#240503'};
     border-radius: 4%;
     padding: 10px;
     color: white;
@@ -100,7 +103,7 @@ export const AttackHPFooter = styled.div`
     padding: 8px;
     font-weight: bold;
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto auto auto;
     background: rgba(0, 0, 0, 0.5);
 `;
 
@@ -115,6 +118,12 @@ export const AttackCell = styled.div<BuffedTextProps>`
         if (buffAmount < 0) return `color: ${Colors.DEBUFF_RED}`;
         return '';
     }}
+`;
+
+export const SleepyCell = styled.div<BuffedTextProps>`
+    color: transparent;
+    text-shadow: 0 0 0 white;
+    text-align: center;
 `;
 
 export const HPCell = styled.div<BuffedTextProps>`

--- a/src/client/components/CardGridItem/CardGridItem.tsx
+++ b/src/client/components/CardGridItem/CardGridItem.tsx
@@ -11,6 +11,7 @@ interface CardGridItemProps {
     card: Card;
     hasOnClick?: boolean;
     hasTooltip?: boolean;
+    isHighlighted?: boolean;
     isOnBoard?: boolean;
     zoomLevel?: number;
 }
@@ -21,6 +22,7 @@ interface CardGridItemProps {
 export const CardGridSingleItem: React.FC<CardGridItemProps> = ({
     card,
     hasOnClick,
+    isHighlighted,
     isOnBoard,
     zoomLevel,
 }) => {
@@ -32,6 +34,7 @@ export const CardGridSingleItem: React.FC<CardGridItemProps> = ({
         return (
             <ResourceCardGridItem
                 card={card}
+                isHighlighted={isHighlighted}
                 onClick={hasOnClick ? onClick : undefined}
                 zoomLevel={zoomLevel}
             />
@@ -41,6 +44,7 @@ export const CardGridSingleItem: React.FC<CardGridItemProps> = ({
         return (
             <SpellGridItem
                 card={card}
+                isHighlighted={isHighlighted}
                 onClick={hasOnClick ? onClick : undefined}
                 zoomLevel={zoomLevel}
             />
@@ -50,6 +54,7 @@ export const CardGridSingleItem: React.FC<CardGridItemProps> = ({
         return (
             <UnitGridItem
                 card={card}
+                isHighlighted={isHighlighted}
                 onClick={hasOnClick ? onClick : undefined}
                 isOnBoard={isOnBoard}
                 zoomLevel={zoomLevel}
@@ -63,6 +68,7 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
     card,
     hasTooltip,
     hasOnClick,
+    isHighlighted,
     isOnBoard,
     zoomLevel = 1,
 }) => {
@@ -81,6 +87,7 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
                 <CardGridSingleItem
                     key={card.id}
                     card={card}
+                    isHighlighted={isHighlighted}
                     isOnBoard={isOnBoard}
                     hasOnClick={hasOnClick}
                     zoomLevel={zoomLevel}

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { useSelector } from 'react-redux';
 import { Player } from '@/types/board';
 import { Colors } from '@/constants/colors';
 import { CardGridItem } from '../CardGridItem';
+import { getHighlightableCards } from '@/client/redux/selectors/getHighlightableCards';
 
 interface PlayerBoardSectionProps {
     isSelfPlayer?: boolean;
@@ -24,6 +26,8 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
     isSelfPlayer,
     player,
 }) => {
+    const highlightableUnits = useSelector(getHighlightableCards);
+
     if (!player?.units || !player?.resources) {
         return <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer} />;
     }
@@ -33,6 +37,7 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
             {units.map((unitCard) => (
                 <CardGridItem
                     card={unitCard}
+                    isHighlighted={highlightableUnits.indexOf(unitCard.id) > -1}
                     key={unitCard.id}
                     hasOnClick
                     hasTooltip

--- a/src/client/components/ResourceCardGridItem/ResourceCardGridItem.tsx
+++ b/src/client/components/ResourceCardGridItem/ResourceCardGridItem.tsx
@@ -7,12 +7,14 @@ import { CastingCostFrame } from '../CastingCost';
 
 interface ResourceCardGridItemProps {
     card: ResourceCard;
+    isHighlighted?: boolean;
     onClick?: () => void;
     zoomLevel?: number;
 }
 
 export const ResourceCardGridItem: React.FC<ResourceCardGridItemProps> = ({
     card,
+    isHighlighted,
     onClick,
     zoomLevel,
 }) => {
@@ -22,6 +24,7 @@ export const ResourceCardGridItem: React.FC<ResourceCardGridItemProps> = ({
             primaryColor={primaryColor}
             data-testid="ResourceCard-GridItem"
             onClick={onClick}
+            isHighlighted={isHighlighted}
             isRotated={card.isUsed}
             zoomLevel={zoomLevel}
             className="CardFrame"

--- a/src/client/components/SpellGridItem/SpellGridItem.tsx
+++ b/src/client/components/SpellGridItem/SpellGridItem.tsx
@@ -16,12 +16,14 @@ import { getColorForCard } from '@/transformers/getColorForCard';
 
 interface SpellGridItemProps {
     card: SpellCard;
+    isHighlighted?: boolean;
     onClick?: () => void;
     zoomLevel?: number;
 }
 
 export const SpellGridItem: React.FC<SpellGridItemProps> = ({
     card,
+    isHighlighted = false,
     onClick,
     zoomLevel,
 }) => {
@@ -29,6 +31,7 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({
 
     return (
         <CardFrame
+            isHighlighted={isHighlighted}
             data-testid="SpellGridItem"
             primaryColor={getColorForCard(card)}
             onClick={onClick}

--- a/src/client/components/UnitGridItem/UnitGridItem.spec.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.spec.tsx
@@ -45,17 +45,17 @@ describe('Unit Grid Item', () => {
 
     it('displays sleepiness', () => {
         render(<UnitGridItem card={UnitCards.LANCER} isOnBoard />);
-        expect(screen.getByText('💤💤💤')).toBeInTheDocument();
+        expect(screen.getByText('💤')).toBeInTheDocument();
     });
 
     it('hides sleepiness (not on board)', () => {
         render(<UnitGridItem card={UnitCards.LANCER} />);
-        expect(screen.queryByText('💤💤💤')).not.toBeInTheDocument();
+        expect(screen.queryByText('💤')).not.toBeInTheDocument();
     });
 
     it('hides sleepiness (quick units)', () => {
         render(<UnitGridItem card={UnitCards.KNIGHT_TEMPLAR} isOnBoard />);
-        expect(screen.queryByText('💤💤💤')).not.toBeInTheDocument();
+        expect(screen.queryByText('💤')).not.toBeInTheDocument();
     });
 
     it('renders unit name + casting cost', () => {

--- a/src/client/components/UnitGridItem/UnitGridItem.spec.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import { render } from '@/test-utils';
 
-import { UnitCards } from '@/cardDb/units';
+import { UnitCards } from '@/mocks/units';
 import { UnitGridItem } from './UnitGridItem';
 import { Resource, RESOURCE_GLOSSARY } from '@/types/resources';
 import { makeCard } from '@/factories/cards';
@@ -41,6 +41,21 @@ describe('Unit Grid Item', () => {
         expect(
             screen.getByText('Quick (can attack right away)')
         ).toBeInTheDocument();
+    });
+
+    it('displays sleepiness', () => {
+        render(<UnitGridItem card={UnitCards.LANCER} isOnBoard />);
+        expect(screen.getByText('💤💤💤')).toBeInTheDocument();
+    });
+
+    it('hides sleepiness (not on board)', () => {
+        render(<UnitGridItem card={UnitCards.LANCER} />);
+        expect(screen.queryByText('💤💤💤')).not.toBeInTheDocument();
+    });
+
+    it('hides sleepiness (quick units)', () => {
+        render(<UnitGridItem card={UnitCards.KNIGHT_TEMPLAR} isOnBoard />);
+        expect(screen.queryByText('💤💤💤')).not.toBeInTheDocument();
     });
 
     it('renders unit name + casting cost', () => {

--- a/src/client/components/UnitGridItem/UnitGridItem.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.tsx
@@ -14,6 +14,7 @@ import {
     HPCell,
     NameCell,
     RulesTextArea,
+    SleepyCell,
 } from '../CardFrame';
 import { getColorForCard } from '@/transformers/getColorForCard';
 import { transformEffectToRulesText } from '@/transformers/transformEffectsToRulesText';
@@ -21,6 +22,7 @@ import { getAttackingUnit } from '@/client/redux/selectors';
 
 interface UnitGridItemProps {
     card: UnitCard;
+    isHighlighted?: boolean;
     isOnBoard?: boolean;
     onClick?: () => void;
     zoomLevel?: number;
@@ -28,6 +30,7 @@ interface UnitGridItemProps {
 
 export const UnitGridItem: React.FC<UnitGridItemProps> = ({
     card,
+    isHighlighted = false,
     isOnBoard = false,
     onClick,
     zoomLevel,
@@ -46,6 +49,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
         isRanged,
         isSoldier,
         name,
+        numAttacksLeft,
         originalCost,
         passiveEffects,
         totalHp,
@@ -57,6 +61,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
 
     return (
         <CardFrame
+            isHighlighted={isHighlighted}
             isRaised={attackUnitId === id}
             data-testid="UnitGridItem"
             primaryColor={getColorForCard(card)}
@@ -95,6 +100,9 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
                 <AttackCell data-testid="attack" buffAmount={attackBuff}>
                     {attack + attackBuff} ⚔️
                 </AttackCell>
+                <SleepyCell>
+                    {isOnBoard && numAttacksLeft === 0 && '💤'}
+                </SleepyCell>
                 <HPCell data-testid="hp" buffAmount={hpBuff}>
                     {isOnBoard && `${hp + hpBuff} / `} {totalHp + hpBuff} 💙
                 </HPCell>

--- a/src/client/redux/selectors/getHighlightableCards/getHighlightableCards.spec.ts
+++ b/src/client/redux/selectors/getHighlightableCards/getHighlightableCards.spec.ts
@@ -1,0 +1,164 @@
+import { makeNewBoard } from '@/factories/board';
+import { makeCard } from '@/factories/cards';
+import { UnitCards } from '@/mocks/units';
+import { Board, Player } from '@/types/board';
+import { Effect } from '@/types/cards';
+import { EffectType, TargetTypes } from '@/types/effects';
+import { RootState } from '../../store';
+import { getHighlightableCards } from './getHighlightableCards';
+
+describe('Get Highlightable Cards', () => {
+    let state: Partial<RootState>;
+    let board: Board;
+    let tommy: Player;
+    let timmy: Player;
+    beforeEach(() => {
+        board = makeNewBoard({
+            playerNames: ['Tommy', 'Timmy'],
+            startingPlayerIndex: 0,
+        });
+        [tommy, timmy] = board.players;
+        state = {
+            board,
+            user: {
+                name: 'Tommy',
+            },
+        };
+    });
+
+    it('returns nothing if you are not the active player', () => {
+        const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+        const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+        tommy.units = [unit1, unit2];
+        tommy.isActivePlayer = false;
+        timmy.isActivePlayer = true;
+        expect(getHighlightableCards(state)).toEqual([]);
+    });
+
+    describe('effect targets', () => {
+        it('highlights nothing if a player is being targetted', () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE,
+                target: TargetTypes.PLAYER,
+            };
+            tommy.effectQueue = [effect];
+            const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            tommy.units = [unit1, unit2];
+
+            expect(getHighlightableCards(state)).toEqual([]);
+        });
+
+        it('highlights own units', () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE,
+                target: TargetTypes.OWN_UNIT,
+            };
+            tommy.effectQueue = [effect];
+            const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            const unit3 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit4 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            tommy.units = [unit1, unit2];
+            timmy.units = [unit3, unit4];
+
+            expect(getHighlightableCards(state)).toEqual([unit1.id, unit2.id]);
+        });
+
+        it("highlights other players' units", () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE,
+                target: TargetTypes.OPPOSING_UNIT,
+            };
+            tommy.effectQueue = [effect];
+            const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            const unit3 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit4 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            tommy.units = [unit1, unit2];
+            timmy.units = [unit3, unit4];
+
+            expect(getHighlightableCards(state)).toEqual([unit3.id, unit4.id]);
+        });
+
+        it('highlights all units', () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE,
+            };
+            tommy.effectQueue = [effect];
+            const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            const unit3 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit4 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            tommy.units = [unit1, unit2];
+            timmy.units = [unit3, unit4];
+
+            expect(getHighlightableCards(state)).toEqual([
+                unit1.id,
+                unit2.id,
+                unit3.id,
+                unit4.id,
+            ]);
+        });
+
+        it("highlights only alive players' units", () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE,
+            };
+            tommy.effectQueue = [effect];
+            timmy.isAlive = false;
+            const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            const unit3 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit4 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            tommy.units = [unit1, unit2];
+            timmy.units = [unit3, unit4];
+
+            expect(getHighlightableCards(state)).toEqual([unit1.id, unit2.id]);
+        });
+    });
+
+    describe('attackers', () => {
+        it('highlights eligible attackers', () => {
+            const unit1 = makeCard(UnitCards.LANCER); // cannot attack
+            const unit2 = makeCard(UnitCards.KNIGHT_TEMPLAR); // has quick, can attack
+            tommy.units = [unit1, unit2];
+            expect(getHighlightableCards(state)).toEqual([unit2.id]);
+        });
+    });
+
+    describe('defenders', () => {
+        it('highlights eligible attack targets (magical - highlights all)', () => {
+            const unit1 = makeCard(UnitCards.MAGICIANS_APPRENTICE);
+            const unit2 = makeCard(UnitCards.LANCER);
+            const unit3 = makeCard(UnitCards.LONGBOWMAN);
+
+            tommy.units = [unit1];
+            timmy.units = [unit2, unit3];
+            state.clientSideGameExtras = { attackingUnit: unit1.id };
+            expect(getHighlightableCards(state)).toEqual([unit2.id, unit3.id]);
+        });
+
+        it('highlights eligible attack targets (no soldiers)', () => {
+            const unit1 = makeCard(UnitCards.LANCER);
+            const unit2 = makeCard(UnitCards.LONGBOWMAN);
+            const unit3 = makeCard(UnitCards.LONGBOWMAN);
+
+            tommy.units = [unit1];
+            timmy.units = [unit2, unit3];
+            state.clientSideGameExtras = { attackingUnit: unit1.id };
+            expect(getHighlightableCards(state)).toEqual([unit2.id, unit3.id]);
+        });
+
+        it('highlights eligible attack targets (soldiers tank damage first)', () => {
+            const unit1 = makeCard(UnitCards.LANCER);
+            const unit2 = makeCard(UnitCards.LANCER);
+            const unit3 = makeCard(UnitCards.LONGBOWMAN);
+
+            tommy.units = [unit1];
+            timmy.units = [unit2, unit3];
+            state.clientSideGameExtras = { attackingUnit: unit1.id };
+            expect(getHighlightableCards(state)).toEqual([unit2.id]);
+        });
+    });
+});

--- a/src/client/redux/selectors/getHighlightableCards/getHighlightableCards.ts
+++ b/src/client/redux/selectors/getHighlightableCards/getHighlightableCards.ts
@@ -1,0 +1,77 @@
+import { RootState } from '@/client/redux/store';
+import { getDefaultTargetForEffect, TargetTypes } from '@/types/effects';
+import {
+    getAttackingUnit,
+    getLastEffect,
+    getOtherPlayers,
+    getSelfPlayer,
+    isBoardInteractable,
+} from '../selectors';
+
+// returns highlightable cards, but only the string id's for them
+export const getHighlightableCards = (state: Partial<RootState>): string[] => {
+    if (!isBoardInteractable(state)) return [];
+
+    const lastEffect = getLastEffect(state);
+    const selfPlayer = getSelfPlayer(state);
+    const otherPlayers = getOtherPlayers(state).filter(
+        (player) => player.isAlive
+    );
+    const otherUnits = otherPlayers
+        .flatMap((otherPlayer) => otherPlayer.units)
+        .map((unit) => unit.id);
+
+    if (lastEffect) {
+        const target =
+            lastEffect.target || getDefaultTargetForEffect(lastEffect.type);
+        const ownUnits = selfPlayer.units.map((unit) => unit.id);
+
+        switch (target) {
+            case TargetTypes.OPPOSING_UNIT: {
+                return otherUnits;
+            }
+            case TargetTypes.OWN_UNIT: {
+                return ownUnits;
+            }
+            case TargetTypes.ANY:
+            case TargetTypes.UNIT: {
+                return [...ownUnits, ...otherUnits];
+            }
+            default: {
+                return [];
+            }
+        }
+    }
+
+    const attackingUnit = getAttackingUnit(state);
+    const matchingAttackingUnit = selfPlayer.units.find(
+        (unit) => unit.id === attackingUnit
+    );
+
+    if (matchingAttackingUnit) {
+        if (matchingAttackingUnit.isMagical) {
+            return otherUnits;
+        }
+        return otherPlayers
+            .flatMap((otherPlayer) => {
+                const { units } = otherPlayer;
+                // if there are soldiers, they take defender priority
+                if (units.find((unit) => unit.isSoldier)) {
+                    return units.filter((unit) => unit.isSoldier);
+                }
+                return units;
+            })
+            .map((unit) => unit.id);
+    }
+
+    const ownUnitsWithAttacksLeft = selfPlayer.units
+        .filter(
+            (unit) =>
+                unit.numAttacksLeft > 0 &&
+                // exclude the presently attacking unit in highlight calculations
+                unit.id !== attackingUnit
+        )
+        .map((unit) => unit.id);
+
+    return ownUnitsWithAttacksLeft;
+};

--- a/src/client/redux/selectors/getHighlightableCards/index.ts
+++ b/src/client/redux/selectors/getHighlightableCards/index.ts
@@ -1,0 +1,1 @@
+export * from './getHighlightableCards';

--- a/src/client/redux/selectors/index.ts
+++ b/src/client/redux/selectors/index.ts
@@ -1,0 +1,1 @@
+export * from './selectors';

--- a/src/client/redux/selectors/selectors.spec.ts
+++ b/src/client/redux/selectors/selectors.spec.ts
@@ -33,6 +33,17 @@ describe('selectors', () => {
         });
     });
 
+    describe('getAttackingUnit', () => {
+        it('returns the id of the attacking unit, if any', () => {
+            const state = {
+                clientSideGameExtras: {
+                    attackingUnit: 'a13f2-a2-4nm',
+                },
+            };
+            expect(getAttackingUnit(state)).toBe('a13f2-a2-4nm');
+        });
+    });
+
     describe('getSelfPlayer', () => {
         it('returns the player that matches the name', () => {
             const state = {

--- a/src/client/redux/selectors/selectors.ts
+++ b/src/client/redux/selectors/selectors.ts
@@ -1,7 +1,7 @@
 import { GameState, Player } from '@/types/board';
 import { Effect } from '@/types/cards';
 import { TargetTypes } from '@/types/effects';
-import { RootState } from './store';
+import { RootState } from '../store';
 
 export const isUserInitialized = (state: Partial<RootState>): boolean =>
     !!state.user.name;

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -1,7 +1,7 @@
 import { Server as HttpServer } from 'http';
 import { Server, Socket } from 'socket.io';
 import { instrument } from '@socket.io/admin-ui';
-import { Board, GameState, Player } from '@/types/board';
+import { Board, GameState } from '@/types/board';
 import { makeNewBoard } from '@/factories/board';
 import { obscureBoardInfo } from '../obscureBoardInfo';
 


### PR DESCRIPTION
Closes: #154 (in spirit)

Demos:
<img width="807" alt="Screen Shot 2022-03-15 at 10 41 37 AM" src="https://user-images.githubusercontent.com/1839462/158403090-186c78dd-dc0f-4fa0-9c78-8fcd05b71fe2.png">


Bonus - we now show which units are eligible to attack and which are eligible to defend + which ones can be targets of spells:

https://user-images.githubusercontent.com/1839462/158403219-5aab2a49-aedf-4de8-a833-8891cc8768d1.mov


