### PR TITLE
Make effects go from top to bottom

### DIFF
--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -340,7 +340,7 @@ describe('Game Action', () => {
                 playerName: 'Timmy',
             });
             expect(newBoardState.players[0].effectQueue).toEqual(
-                unitCard.enterEffects
+                unitCard.enterEffects.reverse()
             );
         });
 
@@ -782,9 +782,12 @@ describe('Game Action', () => {
 
     describe('cast spell', () => {
         it('casts a spell', () => {
-            const spellCard = makeCard(SpellCards.EMBER_SPEAR);
+            const spellCard = makeCard(SpellCards.A_THOUSAND_WINDS);
             board.players[0].hand.push(spellCard);
-            board.players[0].resourcePool = { [Resource.FIRE]: 1 };
+            board.players[0].resourcePool = {
+                [Resource.FIRE]: 2,
+                [Resource.WATER]: 1,
+            };
 
             const newBoardState = applyGameAction({
                 board,
@@ -795,8 +798,11 @@ describe('Game Action', () => {
                 playerName: 'Timmy',
             });
 
-            expect(newBoardState.players[0].effectQueue).toEqual(
-                spellCard.effects
+            expect(newBoardState.players[0].effectQueue[0]).toEqual(
+                spellCard.effects[1]
+            );
+            expect(newBoardState.players[0].effectQueue[1]).toEqual(
+                spellCard.effects[0]
             );
             expect(newBoardState.players[0].cemetery).toEqual([spellCard]);
         });

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -250,7 +250,7 @@ export const applyGameAction = ({
                 ).resourcePool;
                 activePlayer.units.push(matchingCard);
                 activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                    cloneDeep(matchingCard.enterEffects)
+                    cloneDeep(matchingCard.enterEffects).reverse()
                 );
                 activePlayer.hand.splice(matchingCardIndex, 1);
                 addSystemChat(
@@ -365,7 +365,7 @@ export const applyGameAction = ({
                 matchingCard
             ).resourcePool;
             activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                cloneDeep(matchingCard.effects)
+                cloneDeep(matchingCard.effects).reverse()
             );
             cemetery.push(hand.splice(matchingCardIndex, 1)[0]);
 


### PR DESCRIPTION
Bugfix (it was previously going in reverse order).  Reversing at the point of putting effects on the stack as I want the stack to just be able to pop() the latest effect off.  This way, the first effect on the stack is the first to pop off and execute

https://user-images.githubusercontent.com/1839462/158517136-87e3fca3-0358-4400-90d8-f27b5d6d3638.mov

