### PR TITLE
Handle overflow of cards on board

### DIFF
--- a/src/client/components/HandOfCards/HandOfCards.tsx
+++ b/src/client/components/HandOfCards/HandOfCards.tsx
@@ -36,6 +36,17 @@ type WidthLessContainerProps = {
 // This widthless parent container is a CSS trick to prevent the 1fr units from expanding completely
 const WidthLessContainer = styled.div<WidthLessContainerProps>`
     width: 0;
+
+    animation: fadein 1s;
+
+    @keyframes fadein {
+        from {
+            opacity: 0.01;
+        }
+        to {
+            opacity: 1;
+        }
+    }
 `;
 
 const isCardDeployable = (card: Card, selfPlayer: Player) => {

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
@@ -20,6 +20,18 @@ const PlayerBoardSectionContainer = styled.div<PlayerBoardSectionContainerProps>
     background-color: ${({ isSelfPlayer }) =>
         isSelfPlayer ? Colors.FELT_GREEN_ALT : Colors.FELT_GREEN};
     box-shadow: 0 2px 2px rgb(0 0 0 / 50%);
+    display: grid;
+    align-items: center;
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+`;
+
+const PlayerBoardSectionRow = styled.div`
+    display: grid;
+    grid-gap: 8px;
+    padding: 0 12px;
+    grid-template-columns: repeat(auto-fill, 117px);
+    grid-auto-flow: column;
+    overflow-x: auto;
 `;
 
 export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
@@ -33,7 +45,7 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
     }
     const { units, resources } = player;
     const unitsSection = (
-        <div>
+        <PlayerBoardSectionRow>
             {units.map((unitCard) => (
                 <CardGridItem
                     card={unitCard}
@@ -45,10 +57,10 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
                     zoomLevel={0.6}
                 />
             ))}
-        </div>
+        </PlayerBoardSectionRow>
     );
     const resourcesSection = (
-        <div>
+        <PlayerBoardSectionRow>
             {resources.map((resourceCard) => (
                 <CardGridItem
                     card={resourceCard}
@@ -57,7 +69,7 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
                     zoomLevel={0.6}
                 />
             ))}
-        </div>
+        </PlayerBoardSectionRow>
     );
     return (
         <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer}>

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -45,12 +45,16 @@ describe('resolve effect', () => {
         board.players[0].effectQueue = [effect];
         const newBoard = resolveEffect(board, { effect }, 'Timmy');
         expect(newBoard.chatLog[0].message).toBe(
-            'Timmy resolved "draw 1 cards" ➡️ theirself'
+            'Timmy resolved "draw 1 cards"'
         );
     });
 
     it('displays chat (target)', () => {
-        const effect = { type: EffectType.DEAL_DAMAGE, strength: 1 };
+        const effect = {
+            type: EffectType.DEAL_DAMAGE,
+            strength: 1,
+            target: TargetTypes.ANY,
+        };
         board.players[0].effectQueue = [effect];
         const squire = makeCard(UnitCards.SQUIRE);
         board.players[0].units = [squire];

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -35,6 +35,7 @@ export const resolveEffect = (
     // Determine targets to apply effects to
     let playerTargets: Player[];
     let unitTargets: { player: Player; unitCard: UnitCard }[] = [];
+    const originalTarget = effect.target;
     const target = effect.target || getDefaultTargetForEffect(effect.type);
     let targetText;
 
@@ -128,7 +129,7 @@ export const resolveEffect = (
     clonedBoard.chatLog.push(
         makeSystemChatMsg(
             `${activePlayer.name} resolved "${rulesText}"${
-                targetText ? ` ➡️ ${targetText}` : ''
+                targetText && originalTarget ? ` ➡️ ${targetText}` : ''
             }`
         )
     );


### PR DESCRIPTION
https://user-images.githubusercontent.com/1839462/158714242-f53eeb07-3565-4071-84a1-0ca2f5c8a1bc.mov

Also:
- animate card drawing

https://user-images.githubusercontent.com/1839462/158714225-b46dc5be-85e6-48a1-aa2a-9e2aa6a2edf2.mov



- make resolveEffect gloss over the target if it was inferred from a default in the chat messages for resolveEffect

Future 4 player demo possibilities:
<img width="1510" alt="4 player demo" src="https://user-images.githubusercontent.com/1839462/158714215-6af37744-32bc-4d61-ac74-ff154e96b783.png">

