### PR TITLE
Refactor: split out IntroScreen component

### DIFF
--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -52,8 +52,7 @@ export const RouterRoutes: React.FC = () => {
                 path="/"
                 element={
                     <LobbyBackground>
-                        <IntroScreen />
-                        {isUserPastIntroScreen && <Rooms />}
+                        {isUserPastIntroScreen ? <Rooms /> : <IntroScreen />}
                     </LobbyBackground>
                 }
             />

--- a/src/client/components/IntroScreen/IntroScreen.spec.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { render } from '@/test-utils';
+import { IntroScreen } from './IntroScreen';
+
+describe('Intro Screen', () => {
+    it('submits a name', () => {
+        const { webSocket } = render(<IntroScreen />);
+        const { chooseName } = webSocket;
+
+        fireEvent.change(screen.getByRole('textbox'), {
+            target: { value: 'Trogzor' },
+        });
+        fireEvent.click(screen.getByRole('button'));
+
+        expect(chooseName).toHaveBeenCalledWith('Trogzor');
+    });
+});

--- a/src/client/components/IntroScreen/IntroScreen.tsx
+++ b/src/client/components/IntroScreen/IntroScreen.tsx
@@ -1,18 +1,52 @@
 import React, { useContext } from 'react';
-import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
-import { RootState } from '@/client/redux/store';
 import { NameChanger } from '../NameChanger';
 import { WebSocketContext } from '../WebSockets';
 
-// TODO: rename IntroScreen to LoginBar: https://github.com/lijim/monks-and-mages/issues/28
+const IntroScreenContainer = styled.div`
+    width: 700px;
+    margin: auto;
+    height: 100vh;
+    display: grid;
+    place-items: center;
+    animation: fadein 1s;
 
-const NameDisplayer = styled.div`
-    padding-left: 50px;
-    padding-top: 10px;
-    background-color: rgb(255, 255, 255, 0.8);
-    padding-bottom: 10px;
+    @keyframes fadein {
+        from {
+            opacity: 0.01;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+    @-moz-keyframes fadein {
+        /* Firefox */
+        from {
+            opacity: 0.01;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+    @-webkit-keyframes fadein {
+        /* Safari and Chrome */
+        from {
+            opacity: 0.01;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+    @-o-keyframes fadein {
+        /* Opera */
+        from {
+            opacity: 0.01;
+        }
+        to {
+            opacity: 1;
+        }
+    }
 `;
 
 /**
@@ -21,29 +55,15 @@ const NameDisplayer = styled.div`
  * @returns {JSX.Element} Intro screen component
  */
 export const IntroScreen: React.FC = () => {
-    const name = useSelector<RootState, string>((state) => state.user.name);
     const webSocket = useContext(WebSocketContext);
 
     const handleSubmit = (newName: string) => {
         webSocket.chooseName(newName.trim());
     };
 
-    const logOut = () => {
-        webSocket.chooseName('');
-    };
     return (
-        <>
-            {name ? (
-                <NameDisplayer>
-                    👤 <b>{name}</b> (
-                    <a href="#" type="button" onClick={logOut}>
-                        Logout
-                    </a>
-                    )
-                </NameDisplayer>
-            ) : (
-                <NameChanger handleSubmit={handleSubmit} />
-            )}
-        </>
+        <IntroScreenContainer>
+            <NameChanger handleSubmit={handleSubmit} />
+        </IntroScreenContainer>
     );
 };

--- a/src/client/components/NameChanger/NameChanger.tsx
+++ b/src/client/components/NameChanger/NameChanger.tsx
@@ -7,51 +7,6 @@ interface NameChangerProps {
     handleSubmit: (name: string) => void;
 }
 
-const NameChangerContainer = styled.div`
-    width: 700px;
-    margin: auto;
-    height: 100vh;
-    display: grid;
-    place-items: center;
-    animation: fadein 1s;
-
-    @keyframes fadein {
-        from {
-            opacity: 0.01;
-        }
-        to {
-            opacity: 1;
-        }
-    }
-    @-moz-keyframes fadein {
-        /* Firefox */
-        from {
-            opacity: 0.01;
-        }
-        to {
-            opacity: 1;
-        }
-    }
-    @-webkit-keyframes fadein {
-        /* Safari and Chrome */
-        from {
-            opacity: 0.01;
-        }
-        to {
-            opacity: 1;
-        }
-    }
-    @-o-keyframes fadein {
-        /* Opera */
-        from {
-            opacity: 0.01;
-        }
-        to {
-            opacity: 1;
-        }
-    }
-`;
-
 const NameChangerForm = styled.form`
     display: grid;
     grid-gap: 12px;
@@ -84,33 +39,31 @@ export const NameChanger: React.FC<NameChangerProps> = ({ handleSubmit }) => {
         handleSubmit(name);
     };
     return (
-        <NameChangerContainer>
-            <NameChangerForm onSubmit={onSubmit}>
-                <div>
-                    <label htmlFor="name-selector">Choose a Name</label>
-                    <input
-                        id="name-selector"
-                        role="textbox"
-                        maxLength={MAX_PLAYER_NAME_LENGTH}
-                        autoFocus
-                        autoComplete="off" // ignore for password managers
-                        data-lpignore="true" // ignore for lastPass
-                        data-form-type="other" // ignore for dashlane
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                    />
-                </div>
-                <div>
-                    <PrimaryColorButton
-                        emoji="▶️"
-                        role="button"
-                        type="submit"
-                        disabled={!name}
-                    >
-                        Start
-                    </PrimaryColorButton>
-                </div>
-            </NameChangerForm>
-        </NameChangerContainer>
+        <NameChangerForm onSubmit={onSubmit}>
+            <div>
+                <label htmlFor="name-selector">Choose a Name</label>
+                <input
+                    id="name-selector"
+                    role="textbox"
+                    maxLength={MAX_PLAYER_NAME_LENGTH}
+                    autoFocus
+                    autoComplete="off" // ignore for password managers
+                    data-lpignore="true" // ignore for lastPass
+                    data-form-type="other" // ignore for dashlane
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+            </div>
+            <div>
+                <PrimaryColorButton
+                    emoji="▶️"
+                    role="button"
+                    type="submit"
+                    disabled={!name}
+                >
+                    Start
+                </PrimaryColorButton>
+            </div>
+        </NameChangerForm>
     );
 };

--- a/src/client/components/RoomSquare/index.ts
+++ b/src/client/components/RoomSquare/index.ts
@@ -1,0 +1,1 @@
+export * from './RoomSquare';

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -2,7 +2,8 @@ import React, { useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
-import { RoomSquare } from '../RoomSquare/RoomSquare';
+import { TopNavBar } from '../TopNavBar';
+import { RoomSquare } from '../RoomSquare';
 import { RootState } from '@/client/redux/store';
 import { WebSocketContext } from '../WebSockets';
 import { DetailedRoom } from '@/types';
@@ -105,92 +106,95 @@ export const Rooms: React.FC = () => {
     };
 
     return (
-        <RoomsContainer>
-            <LeftColumn>
-                <form
-                    onSubmit={(event) => {
-                        event.preventDefault();
-                        joinRoom(newRoomName);
-                    }}
-                >
-                    <label htmlFor="newRoomName">
-                        <b>Create New Room</b>{' '}
-                    </label>
-                    <input
-                        value={newRoomName}
-                        maxLength={MAX_ROOM_NAME_LENGTH}
-                        id="newRoomName"
-                        type="text"
-                        placeholder="The Training Grounds"
-                        onChange={(event) => {
-                            setNewRoomName(event.target.value);
+        <>
+            <TopNavBar />
+            <RoomsContainer>
+                <LeftColumn>
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            joinRoom(newRoomName);
                         }}
-                    />
-                    <Spacer />
-                    <span>
-                        <PrimaryColorButton
-                            onClick={() => {
-                                joinRoom(newRoomName);
-                            }}
-                            disabled={!newRoomName}
-                            type="submit"
-                        >
-                            Create
-                        </PrimaryColorButton>
-                    </span>
-                </form>
-
-                <div>
-                    <hr />
-                    <label htmlFor="deckSelection">
-                        <b>Choose a Deck</b>{' '}
-                    </label>
-                    <select
-                        id="deckSelection"
-                        onChange={(event) => {
-                            chooseDeck(event.target.value);
-                        }}
-                        defaultValue={DeckListSelections.MONKS}
                     >
-                        {Object.values(DeckListSelections).map(
-                            (deckListSelection) => (
-                                <option
-                                    value={deckListSelection}
-                                    key={deckListSelection}
-                                >
-                                    {deckListSelection}
-                                </option>
-                            )
-                        )}
-                    </select>
-                </div>
-            </LeftColumn>
-            <MiddleColumn>
-                <RoomsTab>Rooms</RoomsTab>
-                {rooms &&
-                    [...rooms]
-                        .sort((roomA, roomB) =>
-                            roomA.roomName
-                                .toLowerCase()
-                                .localeCompare(roomB.roomName.toLowerCase())
-                        )
-                        .map((detailedRoom) => (
-                            <RoomSquare
-                                hasJoined={joinedRoom === detailedRoom}
-                                joinRoom={() => {
-                                    const normalizedRoomName =
-                                        detailedRoom.roomName.replace(
-                                            'public-',
-                                            ''
-                                        );
-                                    joinRoom(normalizedRoomName);
+                        <label htmlFor="newRoomName">
+                            <b>Create New Room</b>{' '}
+                        </label>
+                        <input
+                            value={newRoomName}
+                            maxLength={MAX_ROOM_NAME_LENGTH}
+                            id="newRoomName"
+                            type="text"
+                            placeholder="The Training Grounds"
+                            onChange={(event) => {
+                                setNewRoomName(event.target.value);
+                            }}
+                        />
+                        <Spacer />
+                        <span>
+                            <PrimaryColorButton
+                                onClick={() => {
+                                    joinRoom(newRoomName);
                                 }}
-                                detailedRoom={detailedRoom}
-                                key={detailedRoom.roomName}
-                                onStartGameClicked={startGame}
-                            />
-                        ))}
-            </MiddleColumn>
-        </RoomsContainer>
+                                disabled={!newRoomName}
+                                type="submit"
+                            >
+                                Create
+                            </PrimaryColorButton>
+                        </span>
+                    </form>
+
+                    <div>
+                        <hr />
+                        <label htmlFor="deckSelection">
+                            <b>Choose a Deck</b>{' '}
+                        </label>
+                        <select
+                            id="deckSelection"
+                            onChange={(event) => {
+                                chooseDeck(event.target.value);
+                            }}
+                            defaultValue={DeckListSelections.MONKS}
+                        >
+                            {Object.values(DeckListSelections).map(
+                                (deckListSelection) => (
+                                    <option
+                                        value={deckListSelection}
+                                        key={deckListSelection}
+                                    >
+                                        {deckListSelection}
+                                    </option>
+                                )
+                            )}
+                        </select>
+                    </div>
+                </LeftColumn>
+                <MiddleColumn>
+                    <RoomsTab>Rooms</RoomsTab>
+                    {rooms &&
+                        [...rooms]
+                            .sort((roomA, roomB) =>
+                                roomA.roomName
+                                    .toLowerCase()
+                                    .localeCompare(roomB.roomName.toLowerCase())
+                            )
+                            .map((detailedRoom) => (
+                                <RoomSquare
+                                    hasJoined={joinedRoom === detailedRoom}
+                                    joinRoom={() => {
+                                        const normalizedRoomName =
+                                            detailedRoom.roomName.replace(
+                                                'public-',
+                                                ''
+                                            );
+                                        joinRoom(normalizedRoomName);
+                                    }}
+                                    detailedRoom={detailedRoom}
+                                    key={detailedRoom.roomName}
+                                    onStartGameClicked={startGame}
+                                />
+                            ))}
+                </MiddleColumn>
+            </RoomsContainer>
+        </>
     );
 };

--- a/src/client/components/TopNavBar/TopNavBar.spec.tsx
+++ b/src/client/components/TopNavBar/TopNavBar.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { render } from '@/test-utils';
+import { TopNavBar } from './TopNavBar';
+import { RootState } from '@/client/redux/store';
+
+describe('TopNavBar', () => {
+    it('logs out', () => {
+        const preloadedState: Partial<RootState> = {
+            user: { name: 'Squidcake' },
+        };
+        const { webSocket } = render(<TopNavBar />, { preloadedState });
+
+        fireEvent.click(screen.getByText('Logout'));
+
+        expect(webSocket.chooseName).toHaveBeenCalledWith('');
+    });
+});

--- a/src/client/components/TopNavBar/TopNavBar.tsx
+++ b/src/client/components/TopNavBar/TopNavBar.tsx
@@ -1,0 +1,40 @@
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+import { RootState } from '@/client/redux/store';
+import { WebSocketContext } from '../WebSockets';
+
+// TODO: rename IntroScreen to LoginBar: https://github.com/lijim/monks-and-mages/issues/28
+
+const NameDisplayer = styled.div`
+    padding-left: 50px;
+    padding-top: 10px;
+    background-color: rgb(255, 255, 255, 0.8);
+    padding-bottom: 10px;
+`;
+
+/**
+ * Top nav bar on the rooms page
+ */
+export const TopNavBar: React.FC = () => {
+    const name = useSelector<RootState, string>((state) => state.user.name);
+    const webSocket = useContext(WebSocketContext);
+
+    const logOut = () => {
+        webSocket.chooseName('');
+    };
+    return (
+        <>
+            (
+            <NameDisplayer>
+                👤 <b>{name}</b> (
+                <a href="#" type="button" onClick={logOut}>
+                    Logout
+                </a>
+                )
+            </NameDisplayer>
+            )
+        </>
+    );
+};

--- a/src/client/components/TopNavBar/index.ts
+++ b/src/client/components/TopNavBar/index.ts
@@ -1,0 +1,1 @@
+export * from './TopNavBar';

--- a/src/client/components/UnitGridItem/UnitGridItem.spec.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.spec.tsx
@@ -58,7 +58,7 @@ describe('Unit Grid Item', () => {
         expect(screen.queryByText('💤')).not.toBeInTheDocument();
     });
 
-    it('renders unit name + casting cost', () => {
+    it('renders attack and hp buffs', () => {
         const unitCard = makeCard(UnitCards.SQUIRE);
         unitCard.attackBuff = 5;
         unitCard.hpBuff = 6;


### PR DESCRIPTION
Closes: #28 

- Moves all concerns about the top nav bar (first screenshot below) away from the intro screen component (second screenshot below).  New component is called 'TopNavBar'

<img width="1488" alt="Screen Shot 2022-03-18 at 10 37 41 PM" src="https://user-images.githubusercontent.com/1839462/159103735-bc9e29a1-3032-4ee4-ba88-3c62b4abd4db.png">

<img width="1499" alt="Screen Shot 2022-03-18 at 10 38 12 PM" src="https://user-images.githubusercontent.com/1839462/159103742-721ba104-6ede-4775-aa14-82d6a12cef3b.png">


- added component tests to IntroScreen

- fixed the barrel file for RoomsSquare