### PR TITLE
Refactor: don't store chats in-memory (server)

### DIFF
--- a/src/client/components/GameDisplay/GameDisplay.spec.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.spec.tsx
@@ -6,7 +6,7 @@ import { GameDisplay } from './GameDisplay';
 import { RootState } from '@/client/redux/store';
 import { makeNewBoard } from '@/factories/board';
 import { EffectType } from '@/types/effects';
-import { makeSystemChatMsg } from '@/factories/chat';
+import { makeSystemChatMessage } from '@/factories/chat';
 
 describe('GameDisplay', () => {
     it('renders player names', () => {
@@ -25,7 +25,7 @@ describe('GameDisplay', () => {
         const board = makeNewBoard({
             playerNames: ['Tommy', 'Timmy'],
         });
-        board.chatLog = [makeSystemChatMsg('Tommy played [[Lancer]]')];
+        board.chatLog = [makeSystemChatMessage('Tommy played [[Lancer]]')];
 
         const preloadedState: Partial<RootState> = {
             user: {

--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -94,7 +94,7 @@ export const GameDisplay: React.FC = () => {
         getLastEffectForActivePlayer
     );
     const chats = useSelector<RootState, ChatLog>(
-        (state) => state.board.chatLog
+        (state) => state.board.chatLog || []
     );
 
     return (

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/client/redux/user';
 import { updateRoomsAndPlayers } from '@/client/redux/lobby';
 import { AppDispatch } from '@/client/redux/store';
-import { updateBoardState } from '@/client/redux/board';
+import { addChatLog, updateBoardState } from '@/client/redux/board';
 import {
     ClientToServerEvents,
     ResolveEffectParams,
@@ -56,6 +56,10 @@ export const WebSocketProvider: React.FC = ({ children }) => {
 
         newSocket.on('connect', () => {
             dispatch(initializeUser({ id: newSocket.id }));
+        });
+
+        newSocket.on('gameChatMessage', (chatMessage) => {
+            dispatch(addChatLog(chatMessage));
         });
 
         newSocket.on('listRooms', (detailedRooms) => {

--- a/src/client/redux/board/board.ts
+++ b/src/client/redux/board/board.ts
@@ -1,12 +1,19 @@
 import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
 import { Board } from '@/types/board';
+import { ChatMessage } from '@/types/chat';
 
 export const boardSlice = createSlice({
     name: 'board',
     initialState: {} as Board,
     reducers: {
+        addChatLog(state, action: PayloadAction<ChatMessage>) {
+            if (!state.chatLog) {
+                state.chatLog = [action.payload];
+            } else {
+                state.chatLog.push(action.payload);
+            }
+        },
         updateBoardState(state, action: PayloadAction<Board>) {
-            state.chatLog = action.payload.chatLog;
             state.gameState = action.payload.gameState;
             state.players = action.payload.players;
         },
@@ -15,4 +22,4 @@ export const boardSlice = createSlice({
 
 export const boardReducer: Reducer<Board> = boardSlice.reducer;
 
-export const { updateBoardState } = boardSlice.actions;
+export const { addChatLog, updateBoardState } = boardSlice.actions;

--- a/src/factories/chat/index.ts
+++ b/src/factories/chat/index.ts
@@ -1,1 +1,1 @@
-export * from './makeChatMsg';
+export * from './makeChatMessage';

--- a/src/factories/chat/makeChatMessage.spec.ts
+++ b/src/factories/chat/makeChatMessage.spec.ts
@@ -1,13 +1,13 @@
-import { makeSystemChatMsg } from './makeChatMsg';
+import { makeSystemChatMessage } from './makeChatMessage';
 
 describe('Make chat message', () => {
     it('makes a chat message', () => {
-        const msg = makeSystemChatMsg(
+        const message = makeSystemChatMessage(
             'Make sure to walk around outside and drink water'
         );
-        expect(msg.message).toBe(
+        expect(message.message).toBe(
             'Make sure to walk around outside and drink water'
         );
-        expect(msg.isFromSystem).toBe(true);
+        expect(message.isFromSystem).toBe(true);
     });
 });

--- a/src/factories/chat/makeChatMessage.ts
+++ b/src/factories/chat/makeChatMessage.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { SystemChat } from '@/types/chat';
 
-export const makeSystemChatMsg = (message: string): SystemChat => {
+export const makeSystemChatMessage = (message: string): SystemChat => {
     return {
         message,
         isFromSystem: true,

--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -33,21 +33,26 @@ describe('Game Action', () => {
         });
 
         it('displays chat messages', () => {
-            let newBoardState = applyGameAction({
+            const mockAddChatMessage = jest.fn();
+            const newBoardState = applyGameAction({
                 board,
                 gameAction: { type: GameActionTypes.ACCEPT_MULLIGAN },
                 playerName: 'Timmy',
+                addChatMessage: mockAddChatMessage,
             });
-            newBoardState = applyGameAction({
+            applyGameAction({
                 board: newBoardState,
                 gameAction: { type: GameActionTypes.REJECT_MULLIGAN },
                 playerName: 'Tommy',
+                addChatMessage: mockAddChatMessage,
             });
 
-            expect(newBoardState.chatLog[0].message).toBe(
+            expect(mockAddChatMessage).toHaveBeenNthCalledWith(
+                1,
                 'Timmy has accepted a hand of 7 cards'
             );
-            expect(newBoardState.chatLog[1].message).toBe(
+            expect(mockAddChatMessage).toHaveBeenNthCalledWith(
+                2,
                 'Tommy has thrown back a hand of 7 cards and is going down to 6 cards'
             );
         });
@@ -323,6 +328,7 @@ describe('Game Action', () => {
         });
 
         it('emits a chat message', () => {
+            const mockAddChatMessage = jest.fn();
             const unitCard = makeCard(UnitCards.CANNON);
             board.players[0].hand = [unitCard];
             board.players[0].numCardsInHand = 1;
@@ -330,18 +336,19 @@ describe('Game Action', () => {
                 [Resource.FIRE]: 2,
                 [Resource.IRON]: 3,
             };
-            const newBoardState = applyGameAction({
+
+            applyGameAction({
                 board,
                 gameAction: {
                     type: GameActionTypes.DEPLOY_UNIT,
                     cardId: unitCard.id,
                 },
                 playerName: 'Timmy',
+                addChatMessage: mockAddChatMessage,
             });
-            expect(newBoardState.chatLog[0]).toMatchObject({
-                isFromSystem: true,
-                message: 'Timmy played [[Cannon]]',
-            });
+            expect(mockAddChatMessage).toHaveBeenCalledWith(
+                'Timmy played [[Cannon]]'
+            );
         });
 
         it('causes an "enter the board" effect', () => {
@@ -406,12 +413,14 @@ describe('Game Action', () => {
         });
 
         it('broadcasts a chat message (attacking another unit)', () => {
+            const mockAddChatMessage = jest.fn();
             const attacker = makeCard(UnitCards.LANCER);
             attacker.numAttacksLeft = 1;
             const defender = makeCard(UnitCards.SQUIRE);
             board.players[0].units = [attacker];
             board.players[1].units = [defender];
-            const newBoardState = applyGameAction({
+
+            applyGameAction({
                 board,
                 gameAction: {
                     type: GameActionTypes.PERFORM_ATTACK,
@@ -419,11 +428,15 @@ describe('Game Action', () => {
                     unitTarget: defender.id,
                 },
                 playerName: 'Timmy',
+                addChatMessage: mockAddChatMessage,
             });
-            expect(newBoardState.chatLog[0].message).toBe(
+
+            expect(mockAddChatMessage).toHaveBeenNthCalledWith(
+                1,
                 '[[Lancer]] (Timmy) ⚔️⚔️ [[Squire]] (Tommy)'
             );
-            expect(newBoardState.chatLog[1].message).toBe(
+            expect(mockAddChatMessage).toHaveBeenNthCalledWith(
+                2,
                 '[[Lancer]] (Timmy) went to the cemetery'
             );
         });
@@ -704,11 +717,13 @@ describe('Game Action', () => {
             expect(newBoardState.players[0].units[0].numAttacksLeft).toEqual(0);
         });
 
-        it('broadccast that it attacks the opposing player in chat', () => {
+        it('broadcasts that it attacks the opposing player in chat', () => {
+            const mockAddChatMessage = jest.fn();
             const attacker = makeCard(UnitCards.WATER_GUARDIAN);
             attacker.numAttacksLeft = 1;
             board.players[0].units = [attacker];
-            const newBoardState = applyGameAction({
+
+            applyGameAction({
                 board,
                 gameAction: {
                     type: GameActionTypes.PERFORM_ATTACK,
@@ -716,8 +731,10 @@ describe('Game Action', () => {
                     playerTarget: 'Tommy',
                 },
                 playerName: 'Timmy',
+                addChatMessage: mockAddChatMessage,
             });
-            expect(newBoardState.chatLog[0].message).toEqual(
+
+            expect(mockAddChatMessage).toHaveBeenCalledWith(
                 '[[Water Guardian]] (Timmy) 🪄🪄 Tommy'
             );
         });
@@ -869,6 +886,7 @@ describe('Game Action', () => {
         });
 
         it('broadcasts the spell to chat', () => {
+            const mockAddChatMessage = jest.fn();
             const spellCard = makeCard(SpellCards.A_THOUSAND_WINDS);
             board.players[0].hand.push(spellCard);
             board.players[0].resourcePool = {
@@ -876,16 +894,17 @@ describe('Game Action', () => {
                 [Resource.WATER]: 1,
             };
 
-            const newBoardState = applyGameAction({
+            applyGameAction({
                 board,
                 gameAction: {
                     type: GameActionTypes.CAST_SPELL,
                     cardId: spellCard.id,
                 },
                 playerName: 'Timmy',
+                addChatMessage: mockAddChatMessage,
             });
 
-            expect(newBoardState.chatLog[0].message).toEqual(
+            expect(mockAddChatMessage).toHaveBeenCalledWith(
                 'Timmy cast [[A Thousand Winds]]'
             );
         });

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -65,15 +65,19 @@ describe('resolve effect', () => {
     });
 
     it('displays chat (auto-target)', () => {
+        const mockAddSystemChat = jest.fn();
         const effect = { type: EffectType.DRAW, strength: 1 };
         board.players[0].effectQueue = [effect];
-        const newBoard = resolveEffect(board, { effect }, 'Timmy');
-        expect(newBoard.chatLog[0].message).toBe(
+
+        resolveEffect(board, { effect }, 'Timmy', false, mockAddSystemChat);
+
+        expect(mockAddSystemChat).toHaveBeenCalledWith(
             'Timmy resolved "draw 1 cards"'
         );
     });
 
     it('displays chat (target)', () => {
+        const mockAddSystemChat = jest.fn();
         const effect = {
             type: EffectType.DEAL_DAMAGE,
             strength: 1,
@@ -82,15 +86,19 @@ describe('resolve effect', () => {
         board.players[0].effectQueue = [effect];
         const squire = makeCard(UnitCards.SQUIRE);
         board.players[0].units = [squire];
-        const newBoard = resolveEffect(
+
+        resolveEffect(
             board,
             {
                 effect,
                 unitCardIds: [squire.id],
             },
-            'Timmy'
+            'Timmy',
+            false,
+            mockAddSystemChat
         );
-        expect(newBoard.chatLog[0].message).toBe(
+
+        expect(mockAddSystemChat).toHaveBeenCalledWith(
             'Timmy resolved "deal 1 damage to any target" ➡️ [[Squire]]'
         );
     });
@@ -411,11 +419,12 @@ describe('resolve effect', () => {
         });
 
         it('broadcasts what was discarded', () => {
+            const mockAddSystemChat = jest.fn();
             board.players[0].hand = [
                 makeCard(UnitCards.ASSASSIN),
                 makeCard(UnitCards.ASSASSIN),
             ];
-            const newBoard = resolveEffect(
+            resolveEffect(
                 board,
                 {
                     effect: {
@@ -424,9 +433,12 @@ describe('resolve effect', () => {
                         target: TargetTypes.SELF_PLAYER,
                     },
                 },
-                'Timmy'
+                'Timmy',
+                false,
+                mockAddSystemChat
             );
-            expect(newBoard.chatLog[1].message).toEqual(
+            expect(mockAddSystemChat).toHaveBeenNthCalledWith(
+                2,
                 'Timmy discarded [[Assassin]], [[Assassin]]'
             );
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
 import { DeckListSelections } from './constants/lobbyConstants';
 import { Board } from './types/board';
 import { Effect } from './types/cards';
+import { ChatMessage } from './types/chat';
 import { GameAction } from './types/gameActions';
 
 export interface ServerToClientEvents {
     confirmName: (name: string) => void;
+    gameChatMessage: (message: ChatMessage) => void;
     listRooms: (rooms: DetailedRoom[]) => void;
     startGame: () => void;
     updateBoard: (board: Board) => void;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -13,4 +13,6 @@ interface PlayerChat extends Chat {
     playerName: string;
 }
 
-export type ChatLog = (SystemChat | PlayerChat)[];
+export type ChatMessage = SystemChat | PlayerChat;
+
+export type ChatLog = ChatMessage[];


### PR DESCRIPTION
1. Change everything from Msg to Message (code clarity)

2. Move chats from being a server-side store into being client-side only.

In preparation for: #167 as players could potentially send a large number of chats to each other