### PR TITLE
balance patch (farmer deck)

### DIFF
--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -278,7 +278,7 @@ const WIND_MAGE: UnitCard = makeCard({
     cost: {
         [Resource.FIRE]: 1,
         [Resource.WATER]: 1,
-        [Resource.GENERIC]: 3,
+        [Resource.GENERIC]: 4,
     },
     description: '',
     enterEffects: [
@@ -385,7 +385,7 @@ const TEMPLE_GUARDIAN: UnitCard = makeCard({
     name: 'Temple Guardian',
     imgSrc: 'https://images.unsplash.com/photo-1570998050878-44c852cf2246',
     cost: {
-        [Resource.IRON]: 2,
+        [Resource.IRON]: 1,
         [Resource.GENERIC]: 5,
     },
     description: '',
@@ -463,7 +463,7 @@ const STONE_SLINGER: UnitCard = makeCard({
     },
     description: '',
     enterEffects: [],
-    totalHp: 1,
+    totalHp: 2,
     attack: 1,
     numAttacks: 1,
     isRanged: true,
@@ -557,7 +557,7 @@ const BAMBOO_FARMER: UnitCard = makeCard({
             strength: 1,
         },
     ],
-    totalHp: 1,
+    totalHp: 2,
     attack: 1,
     numAttacks: 1,
     isRanged: false,

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -100,7 +100,7 @@ export const SAMPLE_DECKLIST_4: DeckList = [
     { card: SpellCards.A_THOUSAND_WINDS, quantity: 2 },
 ];
 
-// Bamboo + Iron - revised version (not used in mocks)
+// Bamboo + Iron - Farmer deck
 export const SAMPLE_DECKLIST_5: DeckList = [
     // Resources
     { card: makeResourceCard(Resource.BAMBOO), quantity: 12 },
@@ -109,13 +109,14 @@ export const SAMPLE_DECKLIST_5: DeckList = [
     { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
     // Soldiers
     { card: UnitCards.LANCER, quantity: 4 },
-    { card: UnitCards.TEMPLE_GUARDIAN, quantity: 4 },
+    { card: UnitCards.TEMPLE_GUARDIAN, quantity: 2 },
     // Ranged
     { card: UnitCards.LONGBOWMAN, quantity: 4 },
     { card: UnitCards.JAVELINEER, quantity: 4 },
     { card: UnitCards.STONE_SLINGER, quantity: 4 },
     // Spells
     { card: SpellCards.FEED_TEAM, quantity: 4 },
+    { card: SpellCards.RAIN_OF_ARROWS, quantity: 2 },
 ];
 
 // Crystal + Iron - (Genie Deck)


### PR DESCRIPTION
tweaks for:
Temple guardian 7 => 6 cost
Bamboo farmer (+1 health)
Stone slinger (+1 health)
wind mage (+1 cost)

farmer deck
(Add 2 rain of arrows, remove 2 temple guardian)