### PR TITLE
Fixes: room joining/rejoining logic

### DIFF
--- a/src/client/components/CenterPromptBox/CenterPromptBox.tsx
+++ b/src/client/components/CenterPromptBox/CenterPromptBox.tsx
@@ -16,7 +16,7 @@ export const REJECT_MULLIGAN_COPY = 'No, send it back (but have 1 fewer card)';
 const MulliganPrompt: React.FC = () => {
     const { takeGameAction } = useContext(WebSocketContext);
 
-    const selfPlayer = useSelector<RootState, Player>(getSelfPlayer);
+    const selfPlayer: Player = useSelector<RootState, Player>(getSelfPlayer);
     const otherPlayers = useSelector<RootState, Player[]>(getOtherPlayers);
     const isMulliganing = useSelector<RootState, boolean>(
         (state) => state.board.gameState === GameState.MULLIGANING
@@ -34,7 +34,7 @@ const MulliganPrompt: React.FC = () => {
     };
 
     if (!isMulliganing) return null;
-    if (selfPlayer.isActivePlayer) {
+    if (selfPlayer?.isActivePlayer) {
         return (
             <>
                 <div>
@@ -54,7 +54,9 @@ const MulliganPrompt: React.FC = () => {
     const mulliganingPlayer = otherPlayers.find(
         (player) => player.isActivePlayer
     );
-    return <>{mulliganingPlayer.name} is deciding whether to keep their hand</>;
+    return (
+        <>{mulliganingPlayer?.name} is deciding whether to keep their hand</>
+    );
 };
 
 const CenterPromptBoxContainer = styled.div`

--- a/src/client/components/TopNavBar/TopNavBar.tsx
+++ b/src/client/components/TopNavBar/TopNavBar.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { RootState } from '@/client/redux/store';
 import { WebSocketContext } from '../WebSockets';
+import { SecondaryColorButton } from '../Button';
 
 // TODO: rename IntroScreen to LoginBar: https://github.com/lijim/monks-and-mages/issues/28
 
@@ -26,11 +27,8 @@ export const TopNavBar: React.FC = () => {
     };
     return (
         <NameDisplayer>
-            👤 <b>{name}</b> (
-            <a href="#" type="button" onClick={logOut}>
-                Logout
-            </a>
-            )
+            👤 <b>{name}</b>{' '}
+            <SecondaryColorButton onClick={logOut}>Logout</SecondaryColorButton>
         </NameDisplayer>
     );
 };

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/client/redux/user';
 import { updateRoomsAndPlayers } from '@/client/redux/lobby';
 import { AppDispatch } from '@/client/redux/store';
-import { addChatLog, updateBoardState } from '@/client/redux/board';
+import { addChatLog, clearChat, updateBoardState } from '@/client/redux/board';
 import {
     ClientToServerEvents,
     ResolveEffectParams,
@@ -67,6 +67,7 @@ export const WebSocketProvider: React.FC = ({ children }) => {
         });
 
         newSocket.on('startGame', () => {
+            dispatch(clearChat());
             dispatch(push('/ingame'));
         });
 

--- a/src/client/redux/board/board.ts
+++ b/src/client/redux/board/board.ts
@@ -13,6 +13,9 @@ export const boardSlice = createSlice({
                 state.chatLog.push(action.payload);
             }
         },
+        clearChat(state) {
+            state.chatLog = [];
+        },
         updateBoardState(state, action: PayloadAction<Board>) {
             state.gameState = action.payload.gameState;
             state.players = action.payload.players;
@@ -22,4 +25,4 @@ export const boardSlice = createSlice({
 
 export const boardReducer: Reducer<Board> = boardSlice.reducer;
 
-export const { addChatLog, updateBoardState } = boardSlice.actions;
+export const { addChatLog, clearChat, updateBoardState } = boardSlice.actions;

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -17,7 +17,6 @@ import {
 } from '@/types';
 import { applyGameAction } from '../gameEngine';
 import { resolveEffect } from '../resolveEffect';
-import { ChatMessage } from '@/types/chat';
 import { makeSystemChatMessage } from '@/factories/chat';
 
 export const configureIo = (server: HttpServer) => {
@@ -129,6 +128,35 @@ export const configureIo = (server: HttpServer) => {
         return detailedRooms;
     };
 
+    const disconnectFromGame = (
+        socket: Socket<ClientToServerEvents, ServerToClientEvents>,
+        shouldClearName = true
+    ) => {
+        const board = getBoardForSocket(socket);
+        const roomName = getRoomForSocket(socket);
+        const name = idsToNames.get(socket.id);
+        if (shouldClearName) clearName(socket.id);
+        if (board) {
+            const player = board.players.find((p) => p.name === name);
+
+            if (player) {
+                sendChatMessageForRoom(socket)(
+                    `${player.name} has left the game`
+                );
+                player.health = 0;
+                player.isAlive = false;
+            }
+
+            const playerLeft = board.players.find((p) => p.isAlive);
+            if (!playerLeft) {
+                startedBoards.delete(roomName);
+            } else {
+                sendBoardForRoom(roomName);
+            }
+        }
+        io.emit('listRooms', getDetailedRooms());
+    };
+
     io.on(
         'connection',
         (socket: Socket<ClientToServerEvents, ServerToClientEvents>) => {
@@ -142,13 +170,14 @@ export const configureIo = (server: HttpServer) => {
 
             socket.on('chooseName', (name: string) => {
                 if (!name) {
-                    clearName(socket.id);
+                    disconnectFromGame(socket);
                     socket.rooms.forEach((room) => socket.leave(room));
                     io.emit('listRooms', getDetailedRooms());
                     socket.emit('confirmName', '');
                     return;
                 }
                 if (!namesToIds.has(name)) {
+                    clearName(socket.id);
                     namesToIds.set(name, socket.id);
                     idsToNames.set(socket.id, name);
                     socket.emit('confirmName', name);
@@ -162,7 +191,10 @@ export const configureIo = (server: HttpServer) => {
             socket.on('joinRoom', (roomName) => {
                 if (!roomName) return; // blank-string room name not allowed
                 const prevRoom = getRoomForSocket(socket);
-                if (prevRoom) socket.leave(prevRoom);
+                if (prevRoom) {
+                    disconnectFromGame(socket, false);
+                    socket.leave(prevRoom);
+                }
                 socket.join(`public-${roomName}`);
                 io.emit('listRooms', getDetailedRooms());
             });
@@ -224,25 +256,7 @@ export const configureIo = (server: HttpServer) => {
             });
 
             socket.on('disconnecting', () => {
-                const board = getBoardForSocket(socket);
-                const roomName = getRoomForSocket(socket);
-                const name = idsToNames.get(socket.id);
-                clearName(socket.id);
-                if (board) {
-                    const player = board.players.find((p) => p.name === name);
-                    if (player) {
-                        player.health = 0;
-                        player.isAlive = false;
-                    }
-
-                    const playerLeft = board.players.find((p) => p.isAlive);
-                    if (!playerLeft) {
-                        startedBoards.delete(roomName);
-                    } else {
-                        sendBoardForRoom(roomName);
-                    }
-                }
-                io.emit('listRooms', getDetailedRooms());
+                disconnectFromGame(socket);
             });
         }
     );


### PR DESCRIPTION
Covers some of the 'sad paths' for joining / rejoining games

B/c of websockets being hard to test (async issues), we had many small little bugs that could cause rooms to be locked up in a 'started' state, or for players to see nothing when rejoining when using various combinations of the forward/back history buttons / log out / etc.

Fixed:
- type safety bugs where the CenterPromptBox (mulligan box) would cause crashes under various circumstances

- player disconnects by going back via browser tab history, switching rooms, and then leaving (whenever a player logs out / starts a new game / ) => game persists as started in room

- player logs out, rejoins a game, starts and sees a blank screen (this was just b/c the link was '#') Closes: #112 

- players both log out, and rejoin under new names (previously was seeing names of players, but no hand)

- chats from old games hanging around

These bugs makes me see a need for:
- a rejoin button #195 
- a leave game button #196