### PR TITLE
Make deck list selection redux-based

### DIFF
--- a/src/client/components/DeckListSelector/DeckListSelector.spec.tsx
+++ b/src/client/components/DeckListSelector/DeckListSelector.spec.tsx
@@ -9,18 +9,6 @@ import { DeckListSelections } from '@/constants/lobbyConstants';
 describe('DeckListSelector', () => {
     it('chooses a deck', () => {
         const preloadedState: Partial<RootState> = {
-            lobby: {
-                rooms: [
-                    {
-                        roomName: 'Room 6',
-                        players: ['Kimmy', 'Jimmy', 'Timmy'],
-                    },
-                    {
-                        roomName: 'Room 7',
-                        players: ['Peter', 'Paul', 'Mary'],
-                    },
-                ],
-            },
             user: {
                 name: 'Jimmy',
             },
@@ -32,5 +20,19 @@ describe('DeckListSelector', () => {
         expect(webSocket.chooseDeck).toHaveBeenCalledWith(
             DeckListSelections.MAGES_FIRE
         );
+    });
+
+    it('displays the current deck list', () => {
+        const preloadedState: Partial<RootState> = {
+            user: {
+                name: 'Jimmy',
+            },
+            deckList: {
+                premadeDecklist: DeckListSelections.GENIES,
+            },
+        };
+        render(<DeckListSelector />, { preloadedState });
+        const select = screen.getByLabelText('Choose a Deck');
+        expect(select).toHaveValue(DeckListSelections.GENIES);
     });
 });

--- a/src/client/components/DeckListSelector/DeckListSelector.tsx
+++ b/src/client/components/DeckListSelector/DeckListSelector.tsx
@@ -1,10 +1,15 @@
 import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
 
 import { DeckListSelections } from '@/constants/lobbyConstants';
 import { WebSocketContext } from '../WebSockets';
+import { RootState } from '@/client/redux/store';
 
 export const DeckListSelector: React.FC = () => {
     const webSocket = useContext(WebSocketContext);
+    const currentDeckList = useSelector<RootState, DeckListSelections>(
+        (state) => state.deckList.premadeDecklist
+    );
 
     const chooseDeck = (deckListSelection: string) => {
         if (
@@ -27,7 +32,7 @@ export const DeckListSelector: React.FC = () => {
                 onChange={(event) => {
                     chooseDeck(event.target.value);
                 }}
-                defaultValue={DeckListSelections.MONKS}
+                value={currentDeckList}
             >
                 {Object.values(DeckListSelections).map((deckListSelection) => (
                     <option value={deckListSelection} key={deckListSelection}>

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/types';
 import { GameAction } from '@/types/gameActions';
 import { DeckListSelections } from '@/constants/lobbyConstants';
+import { confirmPremadeDecklist } from '@/client/redux/deckList';
 
 export const WebSocketContext = createContext<WebSocketValue>(null);
 
@@ -53,6 +54,13 @@ export const WebSocketProvider: React.FC = ({ children }) => {
         newSocket.on('confirmName', (name: string) => {
             dispatch(chooseNameReducer({ name }));
         });
+
+        newSocket.on(
+            'confirmPremadeDeckList',
+            (premadeDeck: DeckListSelections) => {
+                dispatch(confirmPremadeDecklist(premadeDeck));
+            }
+        );
 
         newSocket.on('connect', () => {
             dispatch(initializeUser({ id: newSocket.id }));

--- a/src/client/redux/deckList/deckList.ts
+++ b/src/client/redux/deckList/deckList.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
+import { DetailedRoom } from '@/types';
+import { DeckListSelections } from '@/constants/lobbyConstants';
+
+type DeckListState = {
+    premadeDecklist: DeckListSelections;
+};
+
+const initialState: DeckListState = {
+    premadeDecklist: DeckListSelections.MONKS,
+};
+
+export const deckListSlice = createSlice({
+    name: 'deckList',
+    initialState,
+    reducers: {
+        confirmPremadeDecklist(
+            state,
+            action: PayloadAction<DeckListSelections>
+        ) {
+            state.premadeDecklist = action.payload;
+        },
+    },
+});
+
+export const deckListReducer: Reducer<DeckListState> = deckListSlice.reducer;
+
+export const { confirmPremadeDecklist } = deckListSlice.actions;

--- a/src/client/redux/deckList/index.ts
+++ b/src/client/redux/deckList/index.ts
@@ -1,0 +1,1 @@
+export * from './deckList';

--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -7,6 +7,7 @@ import { boardReducer } from './board';
 import { lobbyReducer } from './lobby';
 import { userReducer, userSlice } from './user';
 import { clientSideGameExtrasReducer } from './clientSideGameExtras';
+import { deckListReducer, deckListSlice } from './deckList';
 
 const { createReduxHistory, routerMiddleware, routerReducer } =
     createReduxHistoryContext({
@@ -17,6 +18,7 @@ export const createRootReducer = () =>
     combineReducers({
         board: boardReducer,
         clientSideGameExtras: clientSideGameExtrasReducer,
+        deckList: deckListReducer,
         router: routerReducer,
         lobby: lobbyReducer,
         user: userReducer,
@@ -24,8 +26,10 @@ export const createRootReducer = () =>
 
 const preloadedState = {
     user: userSlice.getInitialState(),
+    deckList: deckListSlice.getInitialState(),
 };
 
+// Used for production
 export const store = configureStore({
     reducer: createRootReducer(),
     devTools: true,
@@ -33,6 +37,7 @@ export const store = configureStore({
     preloadedState,
 });
 
+// Used only for tests
 export const configureStoreWithMiddlewares = (
     stateOverrides = {},
     routerMiddlewareOveride = routerMiddleware

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -166,6 +166,7 @@ export const configureIo = (server: HttpServer) => {
                 const name = idsToNames.get(socket.id);
                 if (!name) return;
                 nameToDeckListSelection.set(name, deckListSelection);
+                socket.emit('confirmPremadeDeckList', deckListSelection);
             });
 
             socket.on('chooseName', (name: string) => {
@@ -176,6 +177,8 @@ export const configureIo = (server: HttpServer) => {
                     if (roomName) socket.leave(roomName);
                     io.emit('listRooms', getDetailedRooms());
                     socket.emit('confirmName', '');
+                    // remove decklist on client
+                    socket.emit('confirmPremadeDeckList', undefined);
                     return;
                 }
                 if (!namesToIds.has(name)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import { GameAction } from './types/gameActions';
 
 export interface ServerToClientEvents {
     confirmName: (name: string) => void;
+    confirmPremadeDeckList: (deckListSelection?: DeckListSelections) => void;
     gameChatMessage: (message: ChatMessage) => void;
     listRooms: (rooms: DetailedRoom[]) => void;
     startGame: () => void;


### PR DESCRIPTION
Puts the decklist selection into a new slice called decklist.  In the future, this will include custom decklists, but for now, it just has the premade decklist

Part of #197 - we need this so that we have a sense of what decklist to display for the top-level router component that displays the decklist