### PR TITLE
Draw per card effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Unit testing is covered via [Jest](https://jestjs.io/) and [React Testing Librar
 
 -   the game has 5 resources with separate identities:
 
-    -   Bamboo 🎋: resource generation, minor healing effects, ranged units and ranged damage spells
-    -   Iron 🛠: soldiers, sturdy units, minor damage spells
-    -   Fire 🔥: direct damage, conjuration, curses (e.g. cursing an opponents' hand)
+    -   Bamboo 🎋: resource generation, minor healing effects, buffing hp, ranged units and ranged damage spells
+    -   Iron 🛠: soldiers, sturdy units, minor damage spells, buffing attack and hp
+    -   Fire 🔥: direct damage, conjuration, curses (e.g. cursing an opponents' hand), buffing attack
     -   Water 🌊: drawing cards, conjuration, returning units to hands (bounce)
     -   Crystal 🔮: drawing cards (minor), resurrection, augmenting other forms of magic
 

--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -100,6 +100,11 @@ const GENEROUS_GEYSER = makeCard({
             type: EffectType.DRAW,
             strength: 2,
         },
+        {
+            type: EffectType.HEAL,
+            target: TargetTypes.SELF_PLAYER,
+            strength: 2,
+        },
     ],
 });
 
@@ -136,15 +141,11 @@ const A_GENTLE_GUST = makeCard({
     effects: [
         {
             type: EffectType.BUFF_TEAM_ATTACK,
-            strength: 1,
+            strength: 2,
         },
         {
             type: EffectType.BUFF_TEAM_MAGIC,
-            strength: 1,
-        },
-        {
-            type: EffectType.BUFF_TEAM_HP,
-            strength: 1,
+            strength: 2,
         },
     ],
 });

--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -187,7 +187,7 @@ const INFERNO_SORCEROR: UnitCard = makeCard({
         },
     ],
     totalHp: 5,
-    attack: 4,
+    attack: 1,
     numAttacks: 1,
     isRanged: true,
     isMagical: true,
@@ -422,8 +422,9 @@ const BOUNTY_COLLECTOR: UnitCard = makeCard({
     name: 'Bounty Collector',
     imgSrc: 'https://images.unsplash.com/photo-1614882914068-3b235f59cb38',
     cost: {
-        [Resource.IRON]: 2,
+        [Resource.IRON]: 1,
         [Resource.BAMBOO]: 1,
+        [Resource.GENERIC]: 1,
     },
     description: '',
     enterEffects: [],
@@ -441,7 +442,8 @@ const SHADOW_STRIKER: UnitCard = makeCard({
     imgSrc: 'https://images.unsplash.com/photo-1518740028517-36c686a4a001',
     cost: {
         [Resource.IRON]: 1,
-        [Resource.BAMBOO]: 2,
+        [Resource.BAMBOO]: 1,
+        [Resource.GENERIC]: 1,
     },
     description: '',
     enterEffects: [],
@@ -511,7 +513,8 @@ const CAVALRY_ARCHER: UnitCard = makeCard({
     name: 'Cavalry Archer',
     imgSrc: 'https://images.unsplash.com/photo-1560884854-6c1de51e4e15',
     cost: {
-        [Resource.BAMBOO]: 2,
+        [Resource.BAMBOO]: 1,
+        [Resource.GENERIC]: 2,
     },
     description: '',
     enterEffects: [],
@@ -522,6 +525,28 @@ const CAVALRY_ARCHER: UnitCard = makeCard({
     isMagical: false,
     isSoldier: false,
     passiveEffects: [PassiveEffect.QUICK],
+});
+
+const MERRY_RALLIER: UnitCard = makeCard({
+    name: 'Merry Rallier',
+    imgSrc: 'https://images.pexels.com/photos/9935713/pexels-photo-9935713.jpeg',
+    cost: {
+        [Resource.BAMBOO]: 2,
+        [Resource.GENERIC]: 2,
+    },
+    description: '',
+    enterEffects: [
+        {
+            type: EffectType.DRAW_PER_UNIT,
+        },
+    ],
+    totalHp: 2,
+    attack: 3,
+    numAttacks: 1,
+    isRanged: true,
+    isMagical: false,
+    isSoldier: false,
+    passiveEffects: [],
 });
 
 const CANNON: UnitCard = makeCard({
@@ -646,6 +671,7 @@ export const UnitCards = {
     JAVELINEER,
     LONGBOWMAN,
     CAVALRY_ARCHER,
+    MERRY_RALLIER,
     CANNON,
     // MISC
     BAMBOO_FARMER,

--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -105,6 +105,8 @@ export const AttackHPFooter = styled.div`
     display: grid;
     grid-template-columns: auto auto auto;
     background: rgba(0, 0, 0, 0.5);
+    zoom: 1.2;
+    font-size: 17px;
 `;
 
 interface BuffedTextProps {

--- a/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
+++ b/src/client/components/PlayerBoardSection/PlayerBoardSection.tsx
@@ -6,6 +6,7 @@ import { Player } from '@/types/board';
 import { Colors } from '@/constants/colors';
 import { CardGridItem } from '../CardGridItem';
 import { getHighlightableCards } from '@/client/redux/selectors/getHighlightableCards';
+import { ORDERED_RESOURCES } from '@/types/resources';
 
 interface PlayerBoardSectionProps {
     isSelfPlayer?: boolean;
@@ -44,6 +45,11 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
         return <PlayerBoardSectionContainer isSelfPlayer={isSelfPlayer} />;
     }
     const { units, resources } = player;
+    const sortedResources = [...resources].sort(
+        (a, b) =>
+            ORDERED_RESOURCES.indexOf(a.resourceType) -
+            ORDERED_RESOURCES.indexOf(b.resourceType)
+    );
     const unitsSection = (
         <PlayerBoardSectionRow>
             {units.map((unitCard) => (
@@ -61,7 +67,7 @@ export const PlayerBoardSection: React.FC<PlayerBoardSectionProps> = ({
     );
     const resourcesSection = (
         <PlayerBoardSectionRow>
-            {resources.map((resourceCard) => (
+            {sortedResources.map((resourceCard) => (
                 <CardGridItem
                     card={resourceCard}
                     key={resourceCard.id}

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { push } from 'redux-first-history';
 import styled from 'styled-components';
 
 import { TopNavBar } from '../TopNavBar';
@@ -11,7 +12,6 @@ import { PrimaryColorButton } from '../Button';
 import { MAX_ROOM_NAME_LENGTH } from '@/constants/lobbyConstants';
 import { Colors } from '@/constants/colors';
 import { DeckListSelector } from '../DeckListSelector';
-import { push } from 'redux-first-history';
 
 const RoomsContainer = styled.div`
     display: grid;

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -7,8 +7,8 @@ import { makeResourceCard } from '@/factories/cards';
 // Bamboo + Iron - revised version (not used in mocks)
 export const SAMPLE_DECKLIST_0: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 11 },
-    { card: makeResourceCard(Resource.IRON), quantity: 12 },
+    { card: makeResourceCard(Resource.BAMBOO), quantity: 10 },
+    { card: makeResourceCard(Resource.IRON), quantity: 10 },
     // Soldiers
     { card: UnitCards.SQUIRE, quantity: 3 },
     { card: UnitCards.LANCER, quantity: 2 },
@@ -22,6 +22,7 @@ export const SAMPLE_DECKLIST_0: DeckList = [
     // Ranged
     { card: UnitCards.LONGBOWMAN, quantity: 2 },
     { card: UnitCards.JAVELINEER, quantity: 2 },
+    { card: UnitCards.MERRY_RALLIER, quantity: 3 },
     // Spells
     { card: SpellCards.THROW_SHURIKEN, quantity: 3 },
     { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
@@ -108,15 +109,15 @@ export const SAMPLE_DECKLIST_5: DeckList = [
     // Other
     { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
     // Soldiers
-    { card: UnitCards.LANCER, quantity: 4 },
-    { card: UnitCards.TEMPLE_GUARDIAN, quantity: 2 },
+    { card: UnitCards.TEMPLE_GUARDIAN, quantity: 3 },
     // Ranged
-    { card: UnitCards.LONGBOWMAN, quantity: 4 },
+    { card: UnitCards.LONGBOWMAN, quantity: 3 },
     { card: UnitCards.JAVELINEER, quantity: 4 },
-    { card: UnitCards.STONE_SLINGER, quantity: 4 },
+    { card: UnitCards.CAVALRY_ARCHER, quantity: 3 },
+    { card: UnitCards.MERRY_RALLIER, quantity: 4 },
     // Spells
     { card: SpellCards.FEED_TEAM, quantity: 4 },
-    { card: SpellCards.RAIN_OF_ARROWS, quantity: 2 },
+    { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
 ];
 
 // Crystal + Iron - (Genie Deck)
@@ -142,16 +143,18 @@ export const SAMPLE_DECKLIST_6: DeckList = [
 export const SAMPLE_DECKLIST_7: DeckList = [
     // Resources
     { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
-    { card: makeResourceCard(Resource.WATER), quantity: 7 },
+    { card: makeResourceCard(Resource.WATER), quantity: 5 },
     { card: makeResourceCard(Resource.FIRE), quantity: 7 },
     // Magicians
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
     { card: UnitCards.FIRE_MAGE, quantity: 4 },
-    { card: UnitCards.WATER_MAGE, quantity: 4 },
+    { card: UnitCards.WATER_MAGE, quantity: 1 },
+    { card: UnitCards.INFERNO_SORCEROR, quantity: 1 },
+    { card: UnitCards.WIND_MAGE, quantity: 1 },
     // Spells
-    { card: SpellCards.HOLY_REVIVAL, quantity: 4 },
+    { card: SpellCards.HOLY_REVIVAL, quantity: 3 },
     { card: SpellCards.CONSTANT_REFILL, quantity: 3 },
-    { card: SpellCards.SUMMON_DEMONS, quantity: 2 },
+    { card: SpellCards.SUMMON_DEMONS, quantity: 4 },
     { card: SpellCards.VOLCANIC_INFERNO, quantity: 3 },
-    { card: SpellCards.EMBER_SPEAR, quantity: 3 },
+    { card: SpellCards.EMBER_SPEAR, quantity: 4 },
 ];

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -49,7 +49,7 @@ const getNextPlayer = (board: Board): Player => {
     return activePlayer;
 };
 
-const applyWinState = (board: Board): Board => {
+export const applyWinState = (board: Board): Board => {
     const { players } = board;
     if (players.filter((player) => player.isAlive).length === 1) {
         board.gameState = GameState.WIN;

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -304,6 +304,50 @@ describe('resolve effect', () => {
         });
     });
 
+    describe('Draw Cards Per Unit', () => {
+        it('draws cards for players', () => {
+            const deckLength = board.players[0].deck.length;
+
+            board.players[0].units = [makeCard(UnitCards.SHADOW_STRIKER)];
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.DRAW_PER_UNIT,
+                    },
+                },
+                'Timmy'
+            );
+
+            expect(newBoard.players[0].hand).toHaveLength(
+                PlayerConstants.STARTING_HAND_SIZE + 1
+            );
+            expect(newBoard.players[0].deck).toHaveLength(deckLength - 1);
+        });
+
+        it('makes the player draw out of cards and lose', () => {
+            board.players[0].deck = board.players[0].deck.splice(0, 1);
+            const deckLength = board.players[0].deck.length;
+
+            board.players[0].units = [
+                makeCard(UnitCards.SHADOW_STRIKER),
+                makeCard(UnitCards.LONGBOWMAN),
+            ];
+
+            const newBoard = resolveEffect(
+                board,
+                { effect: { type: EffectType.DRAW, strength: deckLength + 1 } },
+                'Timmy'
+            );
+
+            expect(newBoard.players[0].hand).toHaveLength(
+                PlayerConstants.STARTING_HAND_SIZE + deckLength
+            );
+            expect(newBoard.players[0].deck).toEqual([]);
+            expect(newBoard.players[0].isAlive).toEqual(false);
+        });
+    });
+
     describe('Deal Damage', () => {
         it('deals damage to a unit', () => {
             const squire = makeCard(UnitCards.SQUIRE);

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -12,7 +12,11 @@ import {
 } from '@/types/effects';
 import { CardType, UnitCard } from '@/types/cards';
 import { makeCard, makeResourceCard } from '@/factories/cards';
-import { processBoardToCemetery, resetUnitCard } from '../gameEngine';
+import {
+    applyWinState,
+    processBoardToCemetery,
+    resetUnitCard,
+} from '../gameEngine';
 import { transformEffectToRulesText } from '@/transformers/transformEffectsToRulesText';
 
 export const resolveEffect = (
@@ -207,6 +211,7 @@ export const resolveEffect = (
                 player.health -= effectStrength;
                 if (player.health <= 0) player.isAlive = false;
             });
+            applyWinState(clonedBoard);
             return clonedBoard;
         }
         case EffectType.DISCARD_HAND: {
@@ -233,6 +238,18 @@ export const resolveEffect = (
                     player.isAlive = false;
                 }
                 player.hand = hand.concat(deck.splice(-effectStrength));
+            });
+            applyWinState(clonedBoard);
+            return clonedBoard;
+        }
+        case EffectType.DRAW_PER_UNIT: {
+            playerTargets.forEach((player) => {
+                const cardsToDraw = player.units.length;
+                const { hand, deck } = player;
+                if (cardsToDraw > deck.length) {
+                    player.isAlive = false;
+                }
+                player.hand = hand.concat(deck.splice(-cardsToDraw));
             });
             return clonedBoard;
         }

--- a/src/transformers/splitDeckListToPiles/splitDeckListToPiles.ts
+++ b/src/transformers/splitDeckListToPiles/splitDeckListToPiles.ts
@@ -36,13 +36,25 @@ export const splitDeckListToPiles = (deck: Card[]): PileOfCards[] => {
         title: 'Units',
         cards: new Map(),
     };
-    Object.values(UnitCards).forEach((unitCard) => {
-        const unitCards = deck.filter(
+    const unitCards = Object.values(UnitCards);
+    unitCards.sort((a, b) => {
+        const totalCostA = Object.values(a.cost).reduce(
+            (prev, curr) => prev + curr,
+            0
+        );
+        const totalCostB = Object.values(b.cost).reduce(
+            (prev, curr) => prev + curr,
+            0
+        );
+        return totalCostA - totalCostB;
+    });
+    unitCards.forEach((unitCard) => {
+        const matchingCards = deck.filter(
             (card) =>
                 card.cardType === CardType.UNIT && card.name === unitCard.name
         );
-        if (unitCards.length > 0)
-            unitsPile.cards.set(makeCard(unitCards[0]), unitCards.length);
+        if (matchingCards.length > 0)
+            unitsPile.cards.set(makeCard(unitCard), matchingCards.length);
     });
     if (unitsPile.cards.size > 0) piles.push(unitsPile);
 
@@ -51,13 +63,26 @@ export const splitDeckListToPiles = (deck: Card[]): PileOfCards[] => {
         title: 'Spells',
         cards: new Map(),
     };
-    Object.values(SpellCards).forEach((spellCard) => {
-        const spellCards = deck.filter(
+
+    const spellCards = Object.values(SpellCards);
+    spellCards.sort((a, b) => {
+        const totalCostA = Object.values(a.cost).reduce(
+            (prev, curr) => prev + curr,
+            0
+        );
+        const totalCostB = Object.values(b.cost).reduce(
+            (prev, curr) => prev + curr,
+            0
+        );
+        return totalCostA - totalCostB;
+    });
+    spellCards.forEach((spellCard) => {
+        const matchingCards = deck.filter(
             (card) =>
                 card.cardType === CardType.SPELL && card.name === spellCard.name
         );
-        if (spellCards.length > 0)
-            spellsPile.cards.set(makeCard(spellCards[0]), spellCards.length);
+        if (matchingCards.length > 0)
+            spellsPile.cards.set(makeCard(spellCard), matchingCards.length);
     });
     if (spellsPile.cards.size > 0) piles.push(spellsPile);
     return piles;

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -74,6 +74,14 @@ export const transformEffectToRulesText = (effect: Effect): string => {
                 isTargetTypePlural(target) ? '' : 's'
             } ${strength} cards`;
         }
+        case EffectType.DRAW_PER_UNIT: {
+            if (!target) {
+                return `Draw a card for every unit owned on board`;
+            }
+            return `${titleize(targetName)} draw${
+                isTargetTypePlural(target) ? '' : 's'
+            } a card for every unit owned on board`;
+        }
         case EffectType.HEAL: {
             return `Restore ${strength} HP to ${targetName}`;
         }

--- a/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
@@ -149,6 +149,15 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
+    it('displays rules for drawing cards (per unit)', () => {
+        const effect: Effect = {
+            type: EffectType.DRAW_PER_UNIT,
+        };
+        expect(transformEffectToRulesText(effect)).toEqual(
+            `Draw a card for every unit owned on board`
+        );
+    });
+
     it('displays rules for healing', () => {
         const effect: Effect = {
             type: EffectType.HEAL,

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -37,6 +37,7 @@ export enum EffectType {
     DEAL_DAMAGE = 'Deal Damage', // to any target
     DISCARD_HAND = 'Discard Hand', // discard X cards at random
     DRAW = 'Draw',
+    DRAW_PER_UNIT = 'Draw Per Unit',
     HEAL = 'Heal', // to any target
     RAMP = 'Ramp',
     REVIVE = 'Revive',
@@ -51,6 +52,7 @@ export const getDefaultTargetForEffect = (
 ): TargetTypes => {
     return {
         [EffectType.DRAW]: TargetTypes.SELF_PLAYER,
+        [EffectType.DRAW_PER_UNIT]: TargetTypes.SELF_PLAYER,
         [EffectType.DEAL_DAMAGE]: TargetTypes.ANY,
         [EffectType.CURSE_HAND]: TargetTypes.OPPONENT,
         [EffectType.DISCARD_HAND]: TargetTypes.OPPONENT,


### PR DESCRIPTION
added a card called Merry Rallier that draws per unit

https://user-images.githubusercontent.com/1839462/159174448-a7f2b744-8212-4fb3-9ce0-1c757fa827bd.mov

- tweaking the monk deck to have fewer resources and more draw
- made the assassin units easier to cast (more generic resources)
- fixed a bug where spell damage didn't cause a loss for opponents
- made generous geyser heal the player for 2
- made a gentle gust focused on buffing attack of units
- made the attack hp footer bigger and easier to view