### PR TITLE
Add 'learn' effect

### DIFF
--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -216,15 +216,20 @@ const OPEN_NEBULA = makeCard({
         {
             type: EffectType.DRAW,
             target: TargetTypes.ALL_PLAYERS,
-            strength: 7,
+            strength: 4,
+        },
+        {
+            type: EffectType.DRAW,
+            target: TargetTypes.SELF_PLAYER,
+            strength: 3,
         },
         {
             type: EffectType.BOUNCE,
             strength: 1,
         },
         {
-            type: EffectType.BUFF_TEAM_MAGIC,
-            target: TargetTypes.ALL_PLAYERS,
+            type: EffectType.DEAL_DAMAGE,
+            target: TargetTypes.ANY,
             strength: 2,
         },
     ],

--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -184,6 +184,42 @@ const FIRE_MAGE: UnitCard = makeCard({
     passiveEffects: [],
 });
 
+const PRACTICAL_SCHOLAR: UnitCard = makeCard({
+    name: 'Practical Scholar',
+    imgSrc: 'https://images.pexels.com/photos/8390504/pexels-photo-8390504.jpeg',
+    cost: {
+        [Resource.FIRE]: 1,
+        [Resource.WATER]: 1,
+        [Resource.CRYSTAL]: 1,
+        [Resource.GENERIC]: 1,
+    },
+    description: '',
+    enterEffects: [
+        {
+            type: EffectType.LEARN,
+            cardName: 'EMBER_SPEAR',
+            strength: 1,
+        },
+        {
+            type: EffectType.LEARN,
+            cardName: 'BUBBLE_BLAST',
+            strength: 1,
+        },
+        {
+            type: EffectType.LEARN,
+            cardName: 'SPECTRAL_GENESIS',
+            strength: 1,
+        },
+    ],
+    totalHp: 2,
+    attack: 2,
+    numAttacks: 1,
+    isRanged: true,
+    isMagical: true,
+    isSoldier: false,
+    passiveEffects: [],
+});
+
 const INFERNO_SORCEROR: UnitCard = makeCard({
     name: 'Inferno Sorceror',
     imgSrc: 'https://images.unsplash.com/photo-1476611550464-4b94f060e1c6',
@@ -634,6 +670,29 @@ const BAMBOO_FARMER: UnitCard = makeCard({
     passiveEffects: [],
 });
 
+const RELAXED_ROWBOATER: UnitCard = makeCard({
+    name: 'Relaxed Rowboater',
+    imgSrc: 'https://images.pexels.com/photos/10178456/pexels-photo-10178456.jpeg',
+    cost: {
+        [Resource.WATER]: 1,
+    },
+    description: '',
+    enterEffects: [
+        {
+            type: EffectType.LEARN,
+            cardName: 'GENEROUS_GEYSER',
+            strength: 1,
+        },
+    ],
+    totalHp: 1,
+    attack: 1,
+    numAttacks: 1,
+    isRanged: false,
+    isMagical: false,
+    isSoldier: false,
+    passiveEffects: [],
+});
+
 // Saharan Units
 const FORTUNE_PREDICTOR: UnitCard = makeCard({
     name: 'Fortune Predictor',
@@ -670,20 +729,55 @@ const CAPTAIN_OF_THE_GUARD: UnitCard = makeCard({
     enterEffects: [
         {
             type: EffectType.DISCARD_HAND,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
         {
             type: EffectType.DRAW,
-            strength: 2,
+            strength: 3,
         },
     ],
-    totalHp: 2,
+    totalHp: 3,
     attack: 2,
     numAttacks: 1,
     isRanged: false,
     isMagical: false,
     isSoldier: true,
+    passiveEffects: [],
+});
+
+// Coral
+const DEEP_SEA_EXPLORER: UnitCard = makeCard({
+    name: 'Deep Sea Explorer',
+    imgSrc: 'https://images.pexels.com/photos/3113226/pexels-photo-3113226.jpeg',
+    cost: {
+        [Resource.BAMBOO]: 1,
+        [Resource.WATER]: 1,
+        [Resource.GENERIC]: 3,
+    },
+    description: '',
+    enterEffects: [
+        {
+            type: EffectType.DRAW,
+            strength: 1,
+        },
+        {
+            type: EffectType.SUMMON_UNITS,
+            summonType: Tokens.MANTA_RAY,
+            strength: 1,
+        },
+        {
+            type: EffectType.SUMMON_UNITS,
+            summonType: Tokens.SHARK,
+            strength: 1,
+        },
+    ],
+    totalHp: 2,
+    attack: 1,
+    numAttacks: 1,
+    isRanged: false,
+    isMagical: false,
+    isSoldier: false,
     passiveEffects: [],
 });
 
@@ -719,7 +813,12 @@ export const UnitCards = {
     CANNON,
     // MISC
     BAMBOO_FARMER,
+    RELAXED_ROWBOATER,
     // SAHARAN
     FORTUNE_PREDICTOR,
     CAPTAIN_OF_THE_GUARD,
+    // SOCEROR
+    PRACTICAL_SCHOLAR,
+    // CORAL
+    DEEP_SEA_EXPLORER,
 };

--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -5,6 +5,7 @@ interface CardFrameProps {
     isHighlighted?: boolean;
     isRaised?: boolean;
     isRotated?: boolean;
+    isUnitCard?: boolean;
     primaryColor?: string;
     zoomLevel?: number;
 }
@@ -36,7 +37,12 @@ export const CardFrame = styled.div<CardFrameProps>`
     cursor: pointer;
     font-size: 14px;
     display: inline-grid;
-    grid-template-rows: auto 1fr 20px 120px auto;
+    grid-template-rows:
+        auto 1fr 20px minmax(
+            ${({ isUnitCard }) => (isUnitCard ? 80 : 120)}px,
+            auto
+        )
+        auto;
     width: 220px;
     height: 320px;
     border: 10px solid

--- a/src/client/components/GameChatMessages/GameChatMessages.tsx
+++ b/src/client/components/GameChatMessages/GameChatMessages.tsx
@@ -18,6 +18,7 @@ const ChatBox = styled.div`
 const ChatContainer = styled.div`
     display: grid;
     grid-template-rows: 1fr auto;
+    overflow-y: hidden;
 `;
 
 const ChatMessages = styled.div`
@@ -47,7 +48,7 @@ export const GameChatMessages: React.FC = () => {
 
     const submitPlayerMessage = (event: FormEvent) => {
         event.preventDefault();
-        sendChatMessage(playerMessage);
+        if (playerMessage) sendChatMessage(playerMessage);
         return false;
     };
 

--- a/src/client/components/UnitGridItem/UnitGridItem.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.tsx
@@ -63,6 +63,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
         <CardFrame
             isHighlighted={isHighlighted}
             isRaised={attackUnitId === id}
+            isUnitCard
             data-testid="UnitGridItem"
             primaryColor={getColorForCard(card)}
             onClick={onClick}

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -50,7 +50,7 @@ export const SAMPLE_DECKLIST_1: DeckList = [
 // Fire + Crystal
 export const SAMPLE_DECKLIST_2: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.FIRE), quantity: 14 },
+    { card: makeResourceCard(Resource.FIRE), quantity: 13 },
     { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
     // Units
     { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
@@ -59,7 +59,7 @@ export const SAMPLE_DECKLIST_2: DeckList = [
     { card: UnitCards.INFERNO_SORCEROR, quantity: 2 },
     // Spells
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
-    { card: SpellCards.LIGHTNING_SLICK, quantity: 2 },
+    { card: SpellCards.LIGHTNING_SLICK, quantity: 3 },
     { card: SpellCards.CURSE_HAND, quantity: 2 },
     { card: SpellCards.SUMMON_DEMONS, quantity: 4 },
 ];
@@ -67,38 +67,39 @@ export const SAMPLE_DECKLIST_2: DeckList = [
 // Water + Crystal
 export const SAMPLE_DECKLIST_3: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.WATER), quantity: 14 },
+    { card: makeResourceCard(Resource.WATER), quantity: 12 },
     { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
     // Units
+    { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
     { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
-    { card: UnitCards.WATER_MAGE, quantity: 4 },
+    { card: UnitCards.WATER_MAGE, quantity: 3 },
     { card: UnitCards.WATER_GUARDIAN, quantity: 2 },
 
     // Spells
     { card: SpellCards.BUBBLE_BLAST, quantity: 3 },
     { card: SpellCards.GENEROUS_GEYSER, quantity: 3 },
-    { card: SpellCards.SUMMON_SHARKS, quantity: 4 },
+    { card: SpellCards.SUMMON_SHARKS, quantity: 3 },
     { card: SpellCards.CONSTANT_REFILL, quantity: 2 },
 ];
 
 // Water + Fire (aka wind)
 export const SAMPLE_DECKLIST_4: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.WATER), quantity: 12 },
+    { card: makeResourceCard(Resource.WATER), quantity: 10 },
     { card: makeResourceCard(Resource.FIRE), quantity: 10 },
     // Units
     { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
     { card: UnitCards.FIRE_MAGE, quantity: 4 },
     { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
-    { card: UnitCards.WATER_MAGE, quantity: 2 },
+    { card: UnitCards.WATER_MAGE, quantity: 3 },
     { card: UnitCards.WIND_MAGE, quantity: 2 },
 
     // Spells
     { card: SpellCards.BUBBLE_BLAST, quantity: 2 },
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
     { card: SpellCards.A_GENTLE_GUST, quantity: 2 },
-    { card: SpellCards.A_THOUSAND_WINDS, quantity: 2 },
+    { card: SpellCards.A_THOUSAND_WINDS, quantity: 3 },
 ];
 
 // Bamboo + Iron - Farmer deck
@@ -125,7 +126,7 @@ export const SAMPLE_DECKLIST_5: DeckList = [
 export const SAMPLE_DECKLIST_6: DeckList = [
     // Resources
     { card: makeResourceCard(Resource.CRYSTAL), quantity: 10 },
-    { card: makeResourceCard(Resource.IRON), quantity: 10 },
+    { card: makeResourceCard(Resource.IRON), quantity: 11 },
     // Other
     { card: UnitCards.FORTUNE_PREDICTOR, quantity: 4 },
     // Magicians
@@ -133,8 +134,7 @@ export const SAMPLE_DECKLIST_6: DeckList = [
     // Soldiers
     { card: UnitCards.CAPTAIN_OF_THE_GUARD, quantity: 4 },
     { card: UnitCards.LANCER, quantity: 4 },
-    { card: UnitCards.SQUIRE, quantity: 3 },
-    { card: UnitCards.KNIGHT_TEMPLAR, quantity: 1 },
+    { card: UnitCards.KNIGHT_TEMPLAR, quantity: 3 },
     // Spells
     { card: SpellCards.OPEN_NEBULA, quantity: 4 },
     { card: SpellCards.SPECTRAL_GENESIS, quantity: 4 },
@@ -148,14 +148,33 @@ export const SAMPLE_DECKLIST_7: DeckList = [
     { card: makeResourceCard(Resource.FIRE), quantity: 7 },
     // Magicians
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    { card: UnitCards.FIRE_MAGE, quantity: 4 },
+    { card: UnitCards.FIRE_MAGE, quantity: 3 },
     { card: UnitCards.WATER_MAGE, quantity: 1 },
+    { card: UnitCards.PRACTICAL_SCHOLAR, quantity: 3 },
     { card: UnitCards.INFERNO_SORCEROR, quantity: 1 },
     { card: UnitCards.WIND_MAGE, quantity: 1 },
     // Spells
     { card: SpellCards.HOLY_REVIVAL, quantity: 3 },
-    { card: SpellCards.CONSTANT_REFILL, quantity: 3 },
-    { card: SpellCards.SUMMON_DEMONS, quantity: 4 },
+    { card: SpellCards.CONSTANT_REFILL, quantity: 2 },
+    { card: SpellCards.SUMMON_DEMONS, quantity: 3 },
     { card: SpellCards.VOLCANIC_INFERNO, quantity: 3 },
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+];
+
+// Water + Bamboo (Coral)
+export const SAMPLE_DECKLIST_8: DeckList = [
+    // Resources
+    { card: makeResourceCard(Resource.WATER), quantity: 10 },
+    { card: makeResourceCard(Resource.BAMBOO), quantity: 10 },
+    // Units
+    { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
+    { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
+    { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
+    { card: UnitCards.FALCON_RIDER, quantity: 4 },
+    { card: UnitCards.MERRY_RALLIER, quantity: 4 },
+    { card: UnitCards.DEEP_SEA_EXPLORER, quantity: 4 },
+
+    // Spells
+    { card: SpellCards.BUBBLE_BLAST, quantity: 1 },
+    { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
 ];

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -6,6 +6,7 @@ import {
     SAMPLE_DECKLIST_5,
     SAMPLE_DECKLIST_6,
     SAMPLE_DECKLIST_7,
+    SAMPLE_DECKLIST_8,
 } from '@/constants/deckLists';
 import { DeckList } from '@/types/cards';
 
@@ -16,6 +17,7 @@ export const DEFAULT_ROOM_NAMES = [
 ];
 
 export enum DeckListSelections {
+    DIVERS = 'divers 🤿',
     FARMERS = 'farmers 👩‍🌾',
     GENIES = 'genies 🧞‍♀️',
     MAGES_FIRE = 'mages 🔥',
@@ -28,6 +30,7 @@ export enum DeckListSelections {
 export const PREMADE_DECKLIST_DEFAULT = DeckListSelections.MONKS;
 
 export const deckListMappings: Record<DeckListSelections, DeckList> = {
+    [DeckListSelections.DIVERS]: SAMPLE_DECKLIST_8,
     [DeckListSelections.GENIES]: SAMPLE_DECKLIST_6,
     [DeckListSelections.MONKS]: SAMPLE_DECKLIST_0,
     [DeckListSelections.MAGES_FIRE]: SAMPLE_DECKLIST_2,

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -528,6 +528,26 @@ describe('resolve effect', () => {
         });
     });
 
+    describe('Learn', () => {
+        it('adds cards to hand', () => {
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.LEARN,
+                        cardName: 'LANCER',
+                        strength: 2,
+                        target: TargetTypes.ALL_PLAYERS,
+                    },
+                },
+                'Timmy'
+            );
+            expect(newBoard.players[0].hand).toHaveLength(
+                PlayerConstants.STARTING_HAND_SIZE + 2
+            );
+        });
+    });
+
     describe('Ramp Player', () => {
         it('increases resources deployed', () => {
             const newBoard = resolveEffect(

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -1,3 +1,5 @@
+import { SpellCards } from '@/cardDb/spells';
+import { Tokens, UnitCards } from '@/cardDb/units';
 import { Effect } from '@/types/cards';
 import { EffectType, TargetTypes } from '@/types/effects';
 
@@ -32,7 +34,7 @@ const titleize = (str: string): string => {
 };
 
 export const transformEffectToRulesText = (effect: Effect): string => {
-    const { strength, target, resourceType, summonType } = effect;
+    const { cardName, strength, target, resourceType, summonType } = effect;
     const targetName = TARGET_TYPES_TO_RULES_TEXT[target || TargetTypes.ANY];
     switch (effect.type) {
         case EffectType.BOUNCE: {
@@ -85,6 +87,18 @@ export const transformEffectToRulesText = (effect: Effect): string => {
         case EffectType.HEAL: {
             return `Restore ${strength} HP to ${targetName}`;
         }
+        case EffectType.LEARN: {
+            let sanitizedCardName = '';
+            const cardPool = { ...SpellCards, ...UnitCards, ...Tokens };
+            Object.entries(cardPool).forEach(([key, card]) => {
+                if (key === cardName) {
+                    sanitizedCardName = card.name;
+                }
+            });
+            return `Add ${strength} ${sanitizedCardName} ${
+                strength > 1 ? 'cards' : 'card'
+            } to your hand`;
+        }
         case EffectType.RAMP: {
             return `Increase ${resourceType.toLowerCase()} resources by ${strength}`;
         }
@@ -92,7 +106,9 @@ export const transformEffectToRulesText = (effect: Effect): string => {
             return `Revive ${targetName}`;
         }
         case EffectType.SUMMON_UNITS: {
-            return `Summon ${strength} ${summonType.name}s (${summonType.attack} Attack, ${summonType.totalHp} HP)`;
+            return `Summon ${strength} ${summonType.name}${
+                strength > 1 ? 's' : ''
+            } - ${summonType.attack} ⚔️ ${summonType.totalHp} 💙`;
         }
         default: {
             return '';

--- a/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
@@ -169,6 +169,28 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
+    it('displays rules for learning a card (spells)', () => {
+        const effect: Effect = {
+            type: EffectType.LEARN,
+            strength: 4,
+            cardName: 'EMBER_SPEAR',
+        };
+        expect(transformEffectToRulesText(effect)).toEqual(
+            `Add 4 Ember Spear cards to your hand`
+        );
+    });
+
+    it('displays rules for learning a card (u its)', () => {
+        const effect: Effect = {
+            type: EffectType.LEARN,
+            strength: 1,
+            cardName: 'LANCER',
+        };
+        expect(transformEffectToRulesText(effect)).toEqual(
+            `Add 1 Lancer card to your hand`
+        );
+    });
+
     it('displays rules for ramping bamboo', () => {
         const effect: Effect = {
             type: EffectType.RAMP,
@@ -240,7 +262,7 @@ describe('transformEffectstoRulesText', () => {
             summonType: Tokens.DEMON,
         };
         expect(transformEffectToRulesText(effect)).toEqual(
-            `Summon 2 Demons (1 Attack, 1 HP)`
+            `Summon 2 Demons - 1 ⚔️ 1 💙`
         );
     });
 });

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -20,6 +20,7 @@ export type ResourceCard = {
  * Needs to be here due to circular dependencies
  */
 export type Effect = {
+    cardName?: string;
     resourceType?: Resource;
     strength?: number;
     summonType?: UnitCard;

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -39,6 +39,7 @@ export enum EffectType {
     DRAW = 'Draw',
     DRAW_PER_UNIT = 'Draw Per Unit',
     HEAL = 'Heal', // to any target
+    LEARN = 'Learn', // add spells / units to hand
     RAMP = 'Ramp',
     REVIVE = 'Revive',
     SUMMON_UNITS = 'Summon Units',
@@ -51,20 +52,21 @@ export const getDefaultTargetForEffect = (
     effectType: EffectType
 ): TargetTypes => {
     return {
-        [EffectType.DRAW]: TargetTypes.SELF_PLAYER,
-        [EffectType.DRAW_PER_UNIT]: TargetTypes.SELF_PLAYER,
-        [EffectType.DEAL_DAMAGE]: TargetTypes.ANY,
+        [EffectType.BOUNCE]: TargetTypes.UNIT,
+        [EffectType.BUFF_HAND_ATTACK]: TargetTypes.SELF_PLAYER,
+        [EffectType.BUFF_TEAM_ATTACK]: TargetTypes.SELF_PLAYER,
+        [EffectType.BUFF_TEAM_HP]: TargetTypes.SELF_PLAYER,
+        [EffectType.BUFF_TEAM_MAGIC]: TargetTypes.SELF_PLAYER,
         [EffectType.CURSE_HAND]: TargetTypes.OPPONENT,
+        [EffectType.DEAL_DAMAGE]: TargetTypes.ANY,
         [EffectType.DISCARD_HAND]: TargetTypes.OPPONENT,
+        [EffectType.DRAW_PER_UNIT]: TargetTypes.SELF_PLAYER,
+        [EffectType.DRAW]: TargetTypes.SELF_PLAYER,
+        [EffectType.HEAL]: TargetTypes.ALL_SELF_UNITS_GRAVEYARD,
+        [EffectType.LEARN]: TargetTypes.SELF_PLAYER,
         [EffectType.RAMP]: TargetTypes.SELF_PLAYER,
         [EffectType.REVIVE]: TargetTypes.ALL_SELF_UNITS_GRAVEYARD,
         [EffectType.SUMMON_UNITS]: TargetTypes.SELF_PLAYER,
-        [EffectType.HEAL]: TargetTypes.ALL_SELF_UNITS_GRAVEYARD,
-        [EffectType.BOUNCE]: TargetTypes.UNIT,
-        [EffectType.BUFF_TEAM_ATTACK]: TargetTypes.SELF_PLAYER,
-        [EffectType.BUFF_TEAM_MAGIC]: TargetTypes.SELF_PLAYER,
-        [EffectType.BUFF_TEAM_HP]: TargetTypes.SELF_PLAYER,
-        [EffectType.BUFF_HAND_ATTACK]: TargetTypes.SELF_PLAYER,
     }[effectType];
 };
 


### PR DESCRIPTION
- fix chat CSS issue (the new send chat box was blocking overflow from being able to scroll)
- sizes the images on unit cards to take up more space
- adds a new 'coral' flavored deck (water + bamboo)
- balanced the open nebula spell to be less symmetrical
- added a new 1-drop unit for water (rowboat rower), a new 5-drop for water/bamboo (deep sea explorer), and a new 4 drop unit for scholars (practical scholar)

New divers deck:
<img width="1497" alt="Screen Shot 2022-03-21 at 7 23 02 PM" src="https://user-images.githubusercontent.com/1839462/159378894-49861750-5fe8-4ee6-b0c6-fab7c50be0c1.png">
