### PR TITLE
Add 'extract card' effect

### DIFF
--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -693,6 +693,30 @@ const RELAXED_ROWBOATER: UnitCard = makeCard({
     passiveEffects: [],
 });
 
+const QUARRY_WORKER: UnitCard = makeCard({
+    name: 'Quarry Worker',
+    imgSrc: 'https://images.unsplash.com/photo-1623438803816-1f7456b240fa',
+    cost: {
+        [Resource.IRON]: 1,
+    },
+    description: '',
+    enterEffects: [
+        {
+            type: EffectType.EXTRACT_CARD,
+            cardName: 'Iron',
+            strength: 1,
+            target: TargetTypes.PLAYER,
+        },
+    ],
+    totalHp: 1,
+    attack: 1,
+    numAttacks: 1,
+    isRanged: false,
+    isMagical: false,
+    isSoldier: false,
+    passiveEffects: [],
+});
+
 // Saharan Units
 const FORTUNE_PREDICTOR: UnitCard = makeCard({
     name: 'Fortune Predictor',
@@ -814,6 +838,7 @@ export const UnitCards = {
     // MISC
     BAMBOO_FARMER,
     RELAXED_ROWBOATER,
+    QUARRY_WORKER,
     // SAHARAN
     FORTUNE_PREDICTOR,
     CAPTAIN_OF_THE_GUARD,

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -178,3 +178,20 @@ export const SAMPLE_DECKLIST_8: DeckList = [
     { card: SpellCards.BUBBLE_BLAST, quantity: 1 },
     { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
 ];
+
+// Iron + Fire (Cannoneers)
+export const SAMPLE_DECKLIST_9: DeckList = [
+    // Resources
+    { card: makeResourceCard(Resource.IRON), quantity: 10 },
+    { card: makeResourceCard(Resource.FIRE), quantity: 10 },
+    // Units
+    { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
+    { card: UnitCards.QUARRY_WORKER, quantity: 4 },
+    { card: UnitCards.SQUIRE, quantity: 4 },
+    { card: UnitCards.MARTIAL_TRAINER, quantity: 4 },
+    { card: UnitCards.FIRE_MAGE, quantity: 4 },
+    { card: UnitCards.CANNON, quantity: 4 },
+
+    // Spells
+    { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+];

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -7,6 +7,7 @@ import {
     SAMPLE_DECKLIST_6,
     SAMPLE_DECKLIST_7,
     SAMPLE_DECKLIST_8,
+    SAMPLE_DECKLIST_9,
 } from '@/constants/deckLists';
 import { DeckList } from '@/types/cards';
 
@@ -17,6 +18,7 @@ export const DEFAULT_ROOM_NAMES = [
 ];
 
 export enum DeckListSelections {
+    CANNONEER = 'cannoneers 🧨',
     DIVERS = 'divers 🤿',
     FARMERS = 'farmers 👩‍🌾',
     GENIES = 'genies 🧞‍♀️',
@@ -30,6 +32,7 @@ export enum DeckListSelections {
 export const PREMADE_DECKLIST_DEFAULT = DeckListSelections.MONKS;
 
 export const deckListMappings: Record<DeckListSelections, DeckList> = {
+    [DeckListSelections.CANNONEER]: SAMPLE_DECKLIST_9,
     [DeckListSelections.DIVERS]: SAMPLE_DECKLIST_8,
     [DeckListSelections.GENIES]: SAMPLE_DECKLIST_6,
     [DeckListSelections.MONKS]: SAMPLE_DECKLIST_0,

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -4,7 +4,7 @@ import { makeNewBoard } from '@/factories/board';
 import { Board } from '@/types/board';
 import { EffectType, TargetTypes } from '@/types/effects';
 import { resolveEffect } from './resolveEffect';
-import { makeCard } from '@/factories/cards';
+import { makeCard, makeResourceCard } from '@/factories/cards';
 import { Tokens, UnitCards } from '@/mocks/units';
 import { UnitCard } from '@/types/cards';
 import { Resource } from '@/types/resources';
@@ -484,6 +484,29 @@ describe('resolve effect', () => {
             expect(mockAddSystemChat).toHaveBeenNthCalledWith(
                 2,
                 'Timmy discarded [[Assassin]], [[Assassin]]'
+            );
+        });
+    });
+
+    describe('Extract', () => {
+        it('extracts cards from a deck', () => {
+            board.players[0].deck.push(makeResourceCard(Resource.WATER));
+            board.players[0].deck.push(makeResourceCard(Resource.WATER));
+            board.players[1].deck.push(makeResourceCard(Resource.WATER));
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.EXTRACT_CARD,
+                        cardName: 'Water',
+                        strength: 2,
+                        target: TargetTypes.ALL_PLAYERS,
+                    },
+                },
+                'Timmy'
+            );
+            expect(newBoard.players[0].hand).toHaveLength(
+                PlayerConstants.STARTING_HAND_SIZE + 3
             );
         });
     });

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -255,6 +255,23 @@ export const resolveEffect = (
             });
             return clonedBoard;
         }
+        case EffectType.EXTRACT_CARD: {
+            playerTargets.forEach((player) => {
+                const cardsToExtractPopulation = player.deck.filter(
+                    (card) => card.name === cardName
+                );
+                const cardsToExtractSample = sampleSize(
+                    cardsToExtractPopulation,
+                    effectStrength
+                );
+                player.deck = player.deck.filter(
+                    (card) => cardsToExtractSample.indexOf(card) === -1
+                );
+                activePlayer.hand =
+                    activePlayer.hand.concat(cardsToExtractSample);
+            });
+            return clonedBoard;
+        }
         case EffectType.HEAL: {
             playerTargets.forEach((player) => {
                 player.health += effectStrength;

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -19,6 +19,22 @@ const TARGET_TYPES_TO_RULES_TEXT = {
     [TargetTypes.UNIT]: 'any unit',
 };
 
+const TARGET_TYPES_TO_RULES_TEXT_POSSESIVE = {
+    [TargetTypes.ALL_OPPONENTS]: "all opponents'",
+    [TargetTypes.ALL_OPPOSING_UNITS]: "all opposing units'",
+    [TargetTypes.ALL_PLAYERS]: "all players'",
+    [TargetTypes.ALL_SELF_UNITS_GRAVEYARD]: "all your graveyard units'",
+    [TargetTypes.ALL_SELF_UNITS]: "all your units'",
+    [TargetTypes.ALL_UNITS]: "all units'",
+    [TargetTypes.ANY]: "any target's",
+    [TargetTypes.OPPONENT]: "any opponent's",
+    [TargetTypes.OPPOSING_UNIT]: "any unit controlled by an opponent's",
+    [TargetTypes.OWN_UNIT]: "any of your unit's",
+    [TargetTypes.PLAYER]: "any player's",
+    [TargetTypes.SELF_PLAYER]: 'your',
+    [TargetTypes.UNIT]: "any unit's",
+};
+
 const PLURAL_TARGET_TYPES = [
     TargetTypes.ALL_OPPONENTS,
     TargetTypes.ALL_OPPOSING_UNITS,
@@ -36,6 +52,9 @@ const titleize = (str: string): string => {
 export const transformEffectToRulesText = (effect: Effect): string => {
     const { cardName, strength, target, resourceType, summonType } = effect;
     const targetName = TARGET_TYPES_TO_RULES_TEXT[target || TargetTypes.ANY];
+    const targetNamePossessive =
+        TARGET_TYPES_TO_RULES_TEXT_POSSESIVE[target || TargetTypes.ANY];
+    const pluralizationEffectStrength = strength > 1 ? 's' : '';
     switch (effect.type) {
         case EffectType.BOUNCE: {
             return `Return ${targetName} back to ${
@@ -84,6 +103,12 @@ export const transformEffectToRulesText = (effect: Effect): string => {
                 isTargetTypePlural(target) ? '' : 's'
             } a card for every unit owned on board`;
         }
+        case EffectType.EXTRACT_CARD: {
+            if (!target) {
+                return `Extract ${strength} ${cardName} card${pluralizationEffectStrength} from your deck`;
+            }
+            return `Extract ${strength} ${cardName} card${pluralizationEffectStrength} from ${targetNamePossessive} deck`;
+        }
         case EffectType.HEAL: {
             return `Restore ${strength} HP to ${targetName}`;
         }
@@ -106,9 +131,7 @@ export const transformEffectToRulesText = (effect: Effect): string => {
             return `Revive ${targetName}`;
         }
         case EffectType.SUMMON_UNITS: {
-            return `Summon ${strength} ${summonType.name}${
-                strength > 1 ? 's' : ''
-            } - ${summonType.attack} ⚔️ ${summonType.totalHp} 💙`;
+            return `Summon ${strength} ${summonType.name}${pluralizationEffectStrength} - ${summonType.attack} ⚔️ ${summonType.totalHp} 💙`;
         }
         default: {
             return '';

--- a/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
@@ -158,6 +158,18 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
+    it('displays rules for extracting cards from a deck', () => {
+        const effect: Effect = {
+            type: EffectType.EXTRACT_CARD,
+            strength: 2,
+            cardName: 'Iron',
+            target: TargetTypes.OPPONENT,
+        };
+        expect(transformEffectToRulesText(effect)).toEqual(
+            `Extract 2 Iron cards from any opponent's deck`
+        );
+    });
+
     it('displays rules for healing', () => {
         const effect: Effect = {
             type: EffectType.HEAL,

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -38,6 +38,7 @@ export enum EffectType {
     DISCARD_HAND = 'Discard Hand', // discard X cards at random
     DRAW = 'Draw',
     DRAW_PER_UNIT = 'Draw Per Unit',
+    EXTRACT_CARD = 'Extract Card', // extract X of {cardName} card from deck
     HEAL = 'Heal', // to any target
     LEARN = 'Learn', // add spells / units to hand
     RAMP = 'Ramp',
@@ -62,6 +63,7 @@ export const getDefaultTargetForEffect = (
         [EffectType.DISCARD_HAND]: TargetTypes.OPPONENT,
         [EffectType.DRAW_PER_UNIT]: TargetTypes.SELF_PLAYER,
         [EffectType.DRAW]: TargetTypes.SELF_PLAYER,
+        [EffectType.EXTRACT_CARD]: TargetTypes.SELF_PLAYER,
         [EffectType.HEAL]: TargetTypes.ALL_SELF_UNITS_GRAVEYARD,
         [EffectType.LEARN]: TargetTypes.SELF_PLAYER,
         [EffectType.RAMP]: TargetTypes.SELF_PLAYER,


### PR DESCRIPTION
The extract card effect can extract a card (or multiple cards) of a specific name and remove it from a deck (or decks)

- added a 'cannoneers' deck to go along with the new card (Quarry Miner)

<img width="1208" alt="Screen Shot 2022-03-22 at 10 43 05 PM" src="https://user-images.githubusercontent.com/1839462/159613500-a9a7f43c-1ed5-4d46-92c3-560898650d73.png">

