### PR TITLE
Balance tweaks

### DIFF
--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -41,7 +41,7 @@ const LIGHTNING_SLICK = makeCard({
 const CURSE_HAND = makeCard({
     name: 'Curse Hand',
     imgSrc: 'https://images.unsplash.com/photo-1571931468289-38ebb2c5a1c2?',
-    cost: { [Resource.FIRE]: 2 },
+    cost: { [Resource.FIRE]: 1, [Resource.GENERIC]: 1 },
     effects: [
         {
             type: EffectType.CURSE_HAND,
@@ -203,11 +203,33 @@ const SPECTRAL_GENESIS = makeCard({
     ],
 });
 
+const DISTORT_REALITY = makeCard({
+    name: 'Distort Reality',
+    imgSrc: 'https://images.pexels.com/photos/6492151/pexels-photo-6492151.jpeg',
+    cost: { [Resource.CRYSTAL]: 1 },
+    effects: [
+        {
+            type: EffectType.DISCARD_HAND,
+            target: TargetTypes.ALL_PLAYERS,
+            strength: 1,
+        },
+        {
+            type: EffectType.DEAL_DAMAGE,
+            target: TargetTypes.UNIT,
+            strength: 1,
+        },
+    ],
+});
+
 const OPEN_NEBULA = makeCard({
     name: 'Open Nebula',
     imgSrc: 'https://images.unsplash.com/photo-1484589065579-248aad0d8b13',
-    cost: { [Resource.CRYSTAL]: 3, [Resource.GENERIC]: 1 },
+    cost: { [Resource.CRYSTAL]: 3, [Resource.GENERIC]: 3 },
     effects: [
+        {
+            type: EffectType.BOUNCE,
+            strength: 1,
+        },
         {
             type: EffectType.DISCARD_HAND,
             target: TargetTypes.ALL_PLAYERS,
@@ -222,10 +244,6 @@ const OPEN_NEBULA = makeCard({
             type: EffectType.DRAW,
             target: TargetTypes.SELF_PLAYER,
             strength: 3,
-        },
-        {
-            type: EffectType.BOUNCE,
-            strength: 1,
         },
         {
             type: EffectType.DEAL_DAMAGE,
@@ -287,6 +305,38 @@ const RAIN_OF_ARROWS = makeCard({
     ],
 });
 
+// Cannon
+const IGNITE_SPARKS = makeCard({
+    name: 'Ignite Sparks',
+    imgSrc: 'https://images.pexels.com/photos/1098402/pexels-photo-1098402.jpeg',
+    cost: { [Resource.IRON]: 1, [Resource.FIRE]: 1 },
+    effects: [
+        {
+            type: EffectType.DEAL_DAMAGE,
+            target: TargetTypes.ANY,
+            strength: 2,
+        },
+        {
+            type: EffectType.LEARN,
+            cardName: 'SPARK_JOY',
+            strength: 1,
+        },
+    ],
+});
+
+const SPARK_JOY = makeCard({
+    name: 'Spark Joy',
+    imgSrc: 'https://images.pexels.com/photos/668254/pexels-photo-668254.jpeg',
+    cost: { [Resource.IRON]: 1 },
+    effects: [
+        {
+            type: EffectType.DEAL_DAMAGE,
+            target: TargetTypes.ANY,
+            strength: 1,
+        },
+    ],
+});
+
 export const SpellCards = {
     // Fire
     EMBER_SPEAR,
@@ -307,6 +357,7 @@ export const SpellCards = {
     HOLY_REVIVAL,
 
     // Crystal
+    DISTORT_REALITY,
     SPECTRAL_GENESIS,
     OPEN_NEBULA,
 
@@ -316,4 +367,8 @@ export const SpellCards = {
     // Bamboo
     FEED_TEAM,
     RAIN_OF_ARROWS,
+
+    // Cannon
+    IGNITE_SPARKS,
+    SPARK_JOY,
 };

--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -184,14 +184,14 @@ const FIRE_MAGE: UnitCard = makeCard({
     passiveEffects: [],
 });
 
-const PRACTICAL_SCHOLAR: UnitCard = makeCard({
-    name: 'Practical Scholar',
+const BRIGHT_SCHOLAR: UnitCard = makeCard({
+    name: 'Bright Scholar',
     imgSrc: 'https://images.pexels.com/photos/8390504/pexels-photo-8390504.jpeg',
     cost: {
         [Resource.FIRE]: 1,
         [Resource.WATER]: 1,
         [Resource.CRYSTAL]: 1,
-        [Resource.GENERIC]: 1,
+        [Resource.GENERIC]: 2,
     },
     description: '',
     enterEffects: [
@@ -226,7 +226,7 @@ const INFERNO_SORCEROR: UnitCard = makeCard({
     cost: {
         [Resource.CRYSTAL]: 1,
         [Resource.FIRE]: 3,
-        [Resource.GENERIC]: 2,
+        [Resource.GENERIC]: 1,
     },
     description: '',
     enterEffects: [
@@ -661,7 +661,7 @@ const BAMBOO_FARMER: UnitCard = makeCard({
             strength: 1,
         },
     ],
-    totalHp: 2,
+    totalHp: 1,
     attack: 1,
     numAttacks: 1,
     isRanged: false,
@@ -777,7 +777,7 @@ const DEEP_SEA_EXPLORER: UnitCard = makeCard({
     cost: {
         [Resource.BAMBOO]: 1,
         [Resource.WATER]: 1,
-        [Resource.GENERIC]: 3,
+        [Resource.GENERIC]: 4,
     },
     description: '',
     enterEffects: [
@@ -843,7 +843,7 @@ export const UnitCards = {
     FORTUNE_PREDICTOR,
     CAPTAIN_OF_THE_GUARD,
     // SOCEROR
-    PRACTICAL_SCHOLAR,
+    BRIGHT_SCHOLAR,
     // CORAL
     DEEP_SEA_EXPLORER,
 };

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -10,8 +10,8 @@ export const SAMPLE_DECKLIST_0: DeckList = [
     { card: makeResourceCard(Resource.BAMBOO), quantity: 10 },
     { card: makeResourceCard(Resource.IRON), quantity: 10 },
     // Soldiers
-    { card: UnitCards.SQUIRE, quantity: 3 },
-    { card: UnitCards.LANCER, quantity: 2 },
+    { card: UnitCards.SQUIRE, quantity: 2 },
+    { card: UnitCards.LANCER, quantity: 3 },
     { card: UnitCards.MARTIAL_TRAINER, quantity: 2 },
     { card: UnitCards.KNIGHT_TEMPLAR, quantity: 2 },
     { card: UnitCards.TEMPLE_GUARDIAN, quantity: 1 },
@@ -22,9 +22,9 @@ export const SAMPLE_DECKLIST_0: DeckList = [
     // Ranged
     { card: UnitCards.LONGBOWMAN, quantity: 2 },
     { card: UnitCards.JAVELINEER, quantity: 2 },
-    { card: UnitCards.MERRY_RALLIER, quantity: 3 },
+    { card: UnitCards.MERRY_RALLIER, quantity: 4 },
     // Spells
-    { card: SpellCards.THROW_SHURIKEN, quantity: 3 },
+    { card: SpellCards.THROW_SHURIKEN, quantity: 2 },
     { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
 ];
 
@@ -53,13 +53,14 @@ export const SAMPLE_DECKLIST_2: DeckList = [
     { card: makeResourceCard(Resource.FIRE), quantity: 13 },
     { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
     // Units
-    { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
+    { card: UnitCards.FIRE_TECHNICIAN, quantity: 3 },
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
     { card: UnitCards.FIRE_MAGE, quantity: 4 },
     { card: UnitCards.INFERNO_SORCEROR, quantity: 2 },
     // Spells
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
-    { card: SpellCards.LIGHTNING_SLICK, quantity: 3 },
+    { card: SpellCards.LIGHTNING_SLICK, quantity: 2 },
+    { card: SpellCards.VOLCANIC_INFERNO, quantity: 2 },
     { card: SpellCards.CURSE_HAND, quantity: 2 },
     { card: SpellCards.SUMMON_DEMONS, quantity: 4 },
 ];
@@ -134,9 +135,10 @@ export const SAMPLE_DECKLIST_6: DeckList = [
     // Soldiers
     { card: UnitCards.CAPTAIN_OF_THE_GUARD, quantity: 4 },
     { card: UnitCards.LANCER, quantity: 4 },
-    { card: UnitCards.KNIGHT_TEMPLAR, quantity: 3 },
+    { card: UnitCards.KNIGHT_TEMPLAR, quantity: 1 },
     // Spells
-    { card: SpellCards.OPEN_NEBULA, quantity: 4 },
+    { card: SpellCards.DISTORT_REALITY, quantity: 4 },
+    { card: SpellCards.OPEN_NEBULA, quantity: 2 },
     { card: SpellCards.SPECTRAL_GENESIS, quantity: 4 },
 ];
 
@@ -150,7 +152,7 @@ export const SAMPLE_DECKLIST_7: DeckList = [
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
     { card: UnitCards.FIRE_MAGE, quantity: 3 },
     { card: UnitCards.WATER_MAGE, quantity: 1 },
-    { card: UnitCards.PRACTICAL_SCHOLAR, quantity: 3 },
+    { card: UnitCards.BRIGHT_SCHOLAR, quantity: 3 },
     { card: UnitCards.INFERNO_SORCEROR, quantity: 1 },
     { card: UnitCards.WIND_MAGE, quantity: 1 },
     // Spells
@@ -185,13 +187,14 @@ export const SAMPLE_DECKLIST_9: DeckList = [
     { card: makeResourceCard(Resource.IRON), quantity: 10 },
     { card: makeResourceCard(Resource.FIRE), quantity: 10 },
     // Units
-    { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
+    { card: UnitCards.FIRE_TECHNICIAN, quantity: 3 },
     { card: UnitCards.QUARRY_WORKER, quantity: 4 },
-    { card: UnitCards.SQUIRE, quantity: 4 },
-    { card: UnitCards.MARTIAL_TRAINER, quantity: 4 },
+    { card: UnitCards.SQUIRE, quantity: 3 },
+    { card: UnitCards.MARTIAL_TRAINER, quantity: 2 },
     { card: UnitCards.FIRE_MAGE, quantity: 4 },
     { card: UnitCards.CANNON, quantity: 4 },
 
     // Spells
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+    { card: SpellCards.IGNITE_SPARKS, quantity: 4 },
 ];

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -307,7 +307,9 @@ export const resolveEffect = (
             if (!resourceType) return clonedBoard;
             playerTargets.forEach((player) => {
                 for (let i = 0; i < Math.min(50, effectStrength); i += 1) {
-                    player.resources.push(makeResourceCard(resourceType));
+                    const resourceCard = makeResourceCard(resourceType);
+                    resourceCard.isUsed = true;
+                    player.resources.push(resourceCard);
                 }
             });
             return clonedBoard;


### PR DESCRIPTION
In playtesting, divers and farmers were head and shoulders above the rest of the decks, with fire mage and genies being the least competitive.

Nerfs to farmers / divers:
- ramp effect comes in tapped
- nerfed divers by increasing deep sea explorer by 1
- bamboo farmer (most OP unit) reduced health to 1

Monks:
- tweaked monks deck to have more draw

Fire mage deck:
- tweaked fire mages deck to have more board clears
- reduced cost of inferno sorceror by 1
- made 'curse hand' easier to cast

Genies deck:
- added 'distort reality'
- made open nebula more powerful, but more expensive (has a hard removal aspect now)

Misc:
- renamed Practical scholar to bright scholar to fit the card better

- cannoneers gets a new card 'ignite sparks' that allows flexible removal