### PR TITLE
Fix crashes in game + add source maps

### DIFF
--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -335,6 +335,8 @@ export const configureIo = (server: HttpServer) => {
                 const roomName = getRoomForSocket(socket);
                 const playerName = idsToNames.get(socket.id);
 
+                if (!board) return;
+
                 const prevGameState = board.gameState;
                 const newBoardState = resolveEffect(
                     board,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const serverConfig = {
     },
     target: 'node',
     mode: 'production',
+    devtool: 'source-map',
     module: {
         rules: [
             {


### PR DESCRIPTION
Turns out that trying to resolve effects for closed boards was a source of several node-server failures. This adds some short-circuit logic to that controller and adds a source-map to better identify future bugs/crashes

Closes:
#239
