### PR TITLE
Remove pull_request from CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 
 name: Install / Build / Test
 
-on: [pull_request, push]
+on: [push]
 
 jobs:
     pre_job:


### PR DESCRIPTION
push is good enough and the CI check on pull request is often superfluous / slowing me down when it already does CI checks with every push