### PR TITLE
Fix bugs with deck builder

### DIFF
--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -5,7 +5,10 @@ import { Card, CardType } from '@/types/cards';
 import { splitDeckListToPiles } from '@/transformers/splitDeckListToPiles';
 import { QuantitySelector } from '../QuantitySelector';
 import { CastingCost } from '../CastingCost';
-import { getColorForCard } from '@/transformers/getColorForCard';
+import {
+    getColorForCard,
+    getSecondaryColorForCard,
+} from '@/transformers/getColorForCard';
 import { RESOURCE_GLOSSARY } from '@/types/resources';
 
 interface CompactDeckListProps {
@@ -36,11 +39,20 @@ const MiniCardFrame = styled.div<MiniCardFrameProps>`
 
 type NameCellProps = {
     primaryColor?: string;
+    secondaryColor?: string;
 };
 
 export const NameCell = styled.span<NameCellProps>`
     font-style: italic;
-    background: ${({ primaryColor }) => primaryColor || 'rgba(0, 0, 0, 0.2)'};
+    ${({ primaryColor, secondaryColor }) => {
+        if (!primaryColor) {
+            return `background-color: rgba(0, 0, 0, 0.2);`;
+        }
+        if (!secondaryColor) {
+            return `background-color: ${primaryColor};`;
+        }
+        return `background-image: linear-gradient(to right, ${primaryColor}, ${secondaryColor});`;
+    }};
     border-radius: 2px;
     font-weight: 500;
     padding: 3px 6px;
@@ -87,6 +99,9 @@ export const CompactDeckList: React.FC<CompactDeckListProps> = ({
                                               ].primaryColor
                                             : undefined
                                     }
+                                    secondaryColor={getSecondaryColorForCard(
+                                        card
+                                    )}
                                 >
                                     {card.name}
                                 </NameCell>

--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -21,7 +21,9 @@ describe('DeckBuilder', () => {
             fireEvent.click(within(cardPool).getByText('Lancer'));
         }
         expect(within(myDeck).queryByText('5')).not.toBeInTheDocument();
+        expect(within(myDeck).getByText('4')).toBeInTheDocument();
     });
+
     it('allows more than 4 basic resources (constructed)', () => {
         render(<DeckBuilder />);
         const cardPool = screen.getByTestId('CardPool');

--- a/src/client/components/DeckBuilder/DeckBuilder.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.tsx
@@ -54,7 +54,8 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
         if (
             isConstructed &&
             isCardNotBasicResource &&
-            (matchingCardSlot?.quantity || 0 >= 4)
+            matchingCardSlot &&
+            matchingCardSlot.quantity >= 4
         )
             return;
 

--- a/src/client/components/DeckList/DeckList.tsx
+++ b/src/client/components/DeckList/DeckList.tsx
@@ -63,6 +63,9 @@ export const DeckList: React.FC<DeckListProps> = ({
     shouldShowQuantity = true,
     shouldShowSummary = true,
 }) => {
+    if (deck.length === 0) {
+        return <Centering />;
+    }
     const piles = splitDeckListToPiles(deck);
     return (
         <Centering>

--- a/src/transformers/getColorForCard/getColorForCard.spec.ts
+++ b/src/transformers/getColorForCard/getColorForCard.spec.ts
@@ -1,8 +1,14 @@
+import { AdvancedResourceCards } from '@/cardDb/resources/advancedResources';
 import { SpellCards } from '@/cardDb/spells';
 import { UnitCards } from '@/cardDb/units';
 import { makeCard, makeResourceCard } from '@/factories/cards';
 import { Resource, RESOURCE_GLOSSARY } from '@/types/resources';
-import { getColorForCard, GOLD_COLOR, RESOURCE_COLOR } from './getColorForCard';
+import {
+    getColorForCard,
+    getSecondaryColorForCard,
+    GOLD_COLOR,
+    RESOURCE_COLOR,
+} from './getColorForCard';
 
 describe('getColorForCard', () => {
     it('returns white for a resource card', () => {
@@ -34,4 +40,10 @@ describe('getColorForCard', () => {
             RESOURCE_GLOSSARY[Resource.FIRE].primaryColor
         );
     });
+});
+
+describe('Secondary color for card', () => {
+    expect(
+        getSecondaryColorForCard(makeCard(AdvancedResourceCards.LUSH_REEF))
+    ).toEqual(RESOURCE_GLOSSARY[Resource.BAMBOO].primaryColor);
 });

--- a/src/transformers/getColorForCard/getColorForCard.ts
+++ b/src/transformers/getColorForCard/getColorForCard.ts
@@ -41,3 +41,11 @@ export const getColorForCard = (card: Card): string => {
     // Otherwise, return gold
     return GOLD_COLOR;
 };
+
+export const getSecondaryColorForCard = (card: Card): string => {
+    // Case: resource card
+    if (card.cardType === CardType.RESOURCE && card.isAdvanced) {
+        return RESOURCE_GLOSSARY[card.secondaryResourceType].primaryColor;
+    }
+    return '';
+};


### PR DESCRIPTION
1. Dual colors on CompactDeckList advanced resource cards
2. Fix bug with not being able to add more than 1 of any card (except for basic resources)
3. Make DeckList return blank component if no cards are in it yet