### PR TITLE
Add keyboard a11y

### DIFF
--- a/src/client/components/AdvancedResourceGridItem.tsx/AdvancedResourceGridItem.tsx
+++ b/src/client/components/AdvancedResourceGridItem.tsx/AdvancedResourceGridItem.tsx
@@ -92,12 +92,14 @@ export const AdvancedResourceGridItem: React.FC<
                 </CardHeader>
                 <DecisionFrame
                     onClick={handleClickPrimaryResource}
+                    tabIndex={0}
                     data-testid={`ResourceCard-${resourceType}`}
                 >
                     <CastingCostFrame hasNoMargin>{icon}</CastingCostFrame>
                 </DecisionFrame>
                 <DecisionFrame
                     onClick={handleClickSecondaryResource}
+                    tabIndex={0}
                     data-testid={`ResourceCard-${secondaryResourceType}`}
                 >
                     <CastingCostFrame hasNoMargin>
@@ -114,6 +116,7 @@ export const AdvancedResourceGridItem: React.FC<
             secondaryColor={secondaryResource?.primaryColor}
             data-testid="ResourceCard-GridItem"
             onClick={handleClick}
+            tabIndex={0}
             isHighlighted={isHighlighted}
             isRotated={card.isUsed}
             zoomLevel={zoomLevel}

--- a/src/client/components/App/App.tsx
+++ b/src/client/components/App/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { KeyboardEventHandler, useMemo } from 'react';
 import { useSelector, Provider } from 'react-redux';
 import { HistoryRouter as Router } from 'redux-first-history/rr6';
 import { Route, Routes } from 'react-router-dom';

--- a/src/client/components/CardGridItem/CardGridItem.tsx
+++ b/src/client/components/CardGridItem/CardGridItem.tsx
@@ -94,7 +94,9 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
         setTooltipRef,
         setTriggerRef,
         visible,
-    } = usePopperTooltip();
+    } = usePopperTooltip({
+        trigger: ['focus', 'hover'],
+    });
 
     const cardModifiedForTooltip =
         card.cardType === CardType.RESOURCE ? { ...card, isUsed: false } : card;

--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -83,6 +83,7 @@ export const CompactDeckList: React.FC<CompactDeckListProps> = ({
                             onClick={() => {
                                 onClickCard(card);
                             }}
+                            tabIndex={0}
                         >
                             {shouldShowQuantity && (
                                 <QuantitySelector

--- a/src/client/components/ResourceCardGridItem/ResourceCardGridItem.tsx
+++ b/src/client/components/ResourceCardGridItem/ResourceCardGridItem.tsx
@@ -24,6 +24,7 @@ export const ResourceCardGridItem: React.FC<ResourceCardGridItemProps> = ({
             primaryColor={primaryColor}
             data-testid="ResourceCard-GridItem"
             onClick={onClick}
+            tabIndex={0}
             isHighlighted={isHighlighted}
             isRotated={card.isUsed}
             zoomLevel={zoomLevel}

--- a/src/client/components/SpellGridItem/SpellGridItem.tsx
+++ b/src/client/components/SpellGridItem/SpellGridItem.tsx
@@ -36,6 +36,7 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({
             data-testid="SpellGridItem"
             primaryColor={getColorForCard(card)}
             onClick={onClick}
+            tabIndex={0}
             zoomLevel={zoomLevel}
             className="CardFrame"
         >

--- a/src/client/components/UnitGridItem/UnitGridItem.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.tsx
@@ -67,6 +67,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
             data-testid="UnitGridItem"
             primaryColor={getColorForCard(card)}
             onClick={onClick}
+            tabIndex={0}
             zoomLevel={zoomLevel}
             className="CardFrame"
         >

--- a/src/server/homepage.html
+++ b/src/server/homepage.html
@@ -22,10 +22,21 @@
             button, input {
                 font-family: 'Lato',-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; 
             }
-          </style>
+        </style>
+        <script>
+            const handleEnter = (event) => {
+                if (
+                    event.key === 'Enter' &&
+                    document.activeElement instanceof HTMLElement &&
+                    document.activeElement.tagName.toLowerCase() === 'div'
+                ) {
+                    document.activeElement.click();
+                }
+            };
+        </script>
       
     </head>
-    <body>
+    <body onkeyup="handleEnter(event)">
         <div id="root"></div>
         <!--wavy parchment paper effect: https://codepen.io/AgnusDei/pen/NWPbOxL -->
         <svg style="display: none;">


### PR DESCRIPTION
Closes: #70 

Big accessibility update for keyboard-only users.  The whole game can be played sans mouse now thanks to the magic of `tabIndex` in HTML.

Notes on a11y research:

1. TabIndex's are a good thing (this is a11y 101) => your users should be able to navigate your entire site sans-mouse for a11y reasons and also personal ergonomics
1. A problem arises when you want to do tabIndexes and let users use the Enter key to press on divs (yes, I know buttons/links are better, but sometimes we really do need clickable divs, e.g. the playing cards in this game).
1. To that end I followed [this stack overflow answer](https://stackoverflow.com/questions/42034359/trigger-click-event-on-keypress-for-any-focused-element/62142145#62142145).  I improved upon it by using keyup instead of keypress which is getting deprecated:
```
        <script>
            const handleEnter = (event) => {
                if (
                    event.key === 'Enter' &&
                    document.activeElement instanceof HTMLElement&&
                    document.activeElement.tagName === 'div' // need to do this to prevent double-clicks on buttons + links
                ) {
                    document.activeElement.click();
                }
            };
        </script>

    </head>
    <body onkeyup="handleEnter(event)">
```

This is much easier than having to memoize the handleEnter at the top of the React app and then passing it down there to the first div in the node tree.

4. You have to ensure that the place that you have your onClick on the same element that you have your tabIndex and not a parent element with this hack (as onClick's bubble up, but not down)

5. over in Vue land, it seems like they have some sort of mix-ins that they can use on their elements like this: <div tabindex="0" @keydown.enter="handleClick" @click="handleClick"> ([source](https://stackoverflow.com/questions/65334660/trigger-click-event-by-enter-key-on-div-or-other-non-button-in-vue2))