### PR TITLE
Search by unit type

### DIFF
--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -272,5 +272,39 @@ describe('DeckBuilder', () => {
                 screen.queryByText(AdvancedResourceCards.TANGLED_RUINS.name)
             ).toBeInTheDocument();
         });
+
+        it('filters by unit type', () => {
+            render(<DeckBuilder />, { useRealDispatch: true });
+
+            fireEvent.click(screen.getByText('⚔️'));
+            fireEvent.click(screen.getByText('🪄'));
+
+            // expect soldiers + magical units
+            expect(
+                screen.queryByText(UnitCards.LANCER.name)
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByText(UnitCards.DRAGON_MIST_WARRIOR.name)
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByText(UnitCards.MAGICIANS_APPRENTICE.name)
+            ).toBeInTheDocument();
+
+            // don't expect other unit types
+            expect(
+                screen.queryByText(UnitCards.PASTURE_EXPLORER.name)
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(UnitCards.LONGBOWMAN.name)
+            ).not.toBeInTheDocument();
+
+            // don't expect spells
+            expect(
+                screen.queryByText(AdvancedResourceCards.TANGLED_RUINS.name)
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(SpellCards.EMBER_SPEAR.name)
+            ).not.toBeInTheDocument();
+        });
     });
 });

--- a/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
+++ b/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
@@ -4,6 +4,7 @@ import {
     searchFreeTextFilter,
     selectResourceMatchStrategy,
     toggleResourceFilter,
+    toggleUnitTypeFilter,
 } from '@/client/redux/deckBuilderFilters';
 import { AppDispatch, RootState } from '@/client/redux/store';
 import { Filters, MatchStrategy } from '@/types/deckBuilder';
@@ -13,6 +14,7 @@ import {
     RESOURCE_GLOSSARY,
 } from '@/types/resources';
 import { CastingCostFrame } from '../CastingCost';
+import { UnitType } from '@/types/cards';
 
 export const FreeTextFilters: React.FC = () => {
     const dispatch = useDispatch<AppDispatch>();
@@ -56,7 +58,7 @@ export const ResourceFilter: React.FC = () => {
                         <CastingCostFrame
                             key={r}
                             hasNoMargin
-                            isMuted={resources.indexOf(r) === -1}
+                            isMuted={!resources.includes(r)}
                             onClick={() => {
                                 dispatch(toggleResourceFilter(r));
                             }}
@@ -89,6 +91,43 @@ export const ResourceFilter: React.FC = () => {
     );
 };
 
+const ALL_UNIT_TYPES: UnitType[] = ['Soldier', 'Ranged', 'Magical', 'None'];
+const UNIT_TYPE_SYMBOL: Record<UnitType, string> = {
+    Soldier: '⚔️',
+    Ranged: '🏹',
+    Magical: '🪄',
+    None: '🚫',
+};
+
+export const UnitTypeFilter: React.FC = () => {
+    const dispatch = useDispatch<AppDispatch>();
+    const unitTypes = useSelector<RootState, UnitType[]>(
+        (state) => state.deckBuilderFilters.unitTypes
+    );
+
+    return (
+        <div>
+            <span style={{ zoom: 2, fontSize: '72%' }}>
+                {ALL_UNIT_TYPES.map((unitType) => (
+                    <CastingCostFrame
+                        key={unitType}
+                        hasNoMargin
+                        isMuted={!unitTypes.includes(unitType)}
+                        onClick={() => {
+                            dispatch(toggleUnitTypeFilter(unitType));
+                        }}
+                        style={{ cursor: 'pointer' }}
+                        data-testid={`Filters-UnitType-${unitType}`}
+                        tabIndex={0}
+                    >
+                        {UNIT_TYPE_SYMBOL[unitType]}
+                    </CastingCostFrame>
+                ))}
+            </span>
+        </div>
+    );
+};
+
 /**
  * Note: unit tests omitted temporarily in favor of an integration test on DeckBuilder
  * @returns Filters component for DeckBuilder
@@ -98,6 +137,7 @@ export const DeckBuilderFilters: React.FC = () => {
         <>
             <FreeTextFilters />
             <ResourceFilter />
+            <UnitTypeFilter />
         </>
     );
 };

--- a/src/client/redux/deckBuilderFilters/deckBuilderFilters.ts
+++ b/src/client/redux/deckBuilderFilters/deckBuilderFilters.ts
@@ -1,11 +1,13 @@
 import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
 import { Filters, MatchStrategy } from '@/types/deckBuilder';
 import { Resource } from '@/types/resources';
+import { UnitType } from '@/types/cards';
 
 const initialState: Filters = {
     freeText: '',
     resources: [],
     resourceMatchStrategy: MatchStrategy.EXACT,
+    unitTypes: [],
 };
 
 export const deckBuilderFiltersSlice = createSlice({
@@ -35,6 +37,17 @@ export const deckBuilderFiltersSlice = createSlice({
         ) {
             state.resourceMatchStrategy = action.payload;
         },
+        toggleUnitTypeFilter(state, action: PayloadAction<UnitType>) {
+            if (state.unitTypes.indexOf(action.payload) > -1) {
+                // deselect the unit type
+                state.unitTypes = state.unitTypes.filter(
+                    (r) => r !== action.payload
+                );
+                return;
+            }
+            // select the unit type
+            state.unitTypes.push(action.payload);
+        },
     },
 });
 
@@ -46,4 +59,5 @@ export const {
     clearFreeTextFilter,
     toggleResourceFilter,
     selectResourceMatchStrategy,
+    toggleUnitTypeFilter,
 } = deckBuilderFiltersSlice.actions;

--- a/src/transformers/getTypeForUnitCard/getTypeForUnitCard.spec.ts
+++ b/src/transformers/getTypeForUnitCard/getTypeForUnitCard.spec.ts
@@ -1,0 +1,20 @@
+import { UnitCards } from '@/mocks/units';
+import { getTypeForUnitCard } from './getTypeForUnitCard';
+
+describe('get type for unit card', () => {
+    it('returns soldier', () => {
+        expect(getTypeForUnitCard(UnitCards.LANCER)).toEqual('Soldier');
+    });
+
+    it('returns ranged', () => {
+        expect(getTypeForUnitCard(UnitCards.LONGBOWMAN)).toEqual('Ranged');
+    });
+
+    it('returns magical', () => {
+        expect(getTypeForUnitCard(UnitCards.FIRE_MAGE)).toEqual('Magical');
+    });
+
+    it('returns none', () => {
+        expect(getTypeForUnitCard(UnitCards.BOUNTY_COLLECTOR)).toEqual('None');
+    });
+});

--- a/src/transformers/getTypeForUnitCard/getTypeForUnitCard.ts
+++ b/src/transformers/getTypeForUnitCard/getTypeForUnitCard.ts
@@ -1,0 +1,8 @@
+import { UnitCard, UnitType } from '@/types/cards';
+
+export const getTypeForUnitCard = (unitCard: UnitCard): UnitType => {
+    if (unitCard.isMagical) return 'Magical';
+    if (unitCard.isRanged) return 'Ranged';
+    if (unitCard.isSoldier) return 'Soldier';
+    return 'None';
+};

--- a/src/transformers/getTypeForUnitCard/index.ts
+++ b/src/transformers/getTypeForUnitCard/index.ts
@@ -1,0 +1,1 @@
+export * from './getTypeForUnitCard';

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -72,6 +72,8 @@ export interface UnitCard extends UnitBase {
     numAttacksLeft: number;
 }
 
+export type UnitType = 'Magical' | 'Soldier' | 'Ranged' | 'None';
+
 export type SpellBase = {
     cost: PartialRecord<Resource, number>;
     effects: Effect[];

--- a/src/types/deckBuilder.ts
+++ b/src/types/deckBuilder.ts
@@ -1,3 +1,4 @@
+import { UnitType } from './cards';
 import { Resource } from './resources';
 
 // Using filter by resource as an example:
@@ -14,4 +15,5 @@ export type Filters = {
     freeText?: string;
     resourceMatchStrategy?: MatchStrategy;
     resources?: Resource[];
+    unitTypes?: UnitType[];
 };


### PR DESCRIPTION
Introduces the search filter for unit type to the deck building UI
Closes: #309

Also: refactoring some of the helpers (e.g. getTypeForUnitCard)

Learning: use .includes instead of ".indexOf(x) > -1" - way more readable

https://user-images.githubusercontent.com/1839462/165686399-54fa5b9c-c18a-4405-bc9c-c433c810947c.mov


