### PR TITLE
Nerf bamboo farmer

### DIFF
--- a/src/cardDb/units/units.ts
+++ b/src/cardDb/units/units.ts
@@ -1433,7 +1433,7 @@ const BAMBOO_FARMER: UnitCard = makeCard({
     description: '',
     enterEffects: [
         {
-            type: EffectType.RAMP,
+            type: EffectType.RAMP_FROM_HAND,
             resourceType: Resource.BAMBOO,
             strength: 1,
         },

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -744,6 +744,43 @@ describe('resolve effect', () => {
         });
     });
 
+    describe('Ramp From Hand', () => {
+        it('increases resources deployed', () => {
+            board.players[0].hand = [makeResourceCard(Resource.CRYSTAL)];
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.RAMP_FROM_HAND,
+                        strength: 2,
+                        resourceType: Resource.CRYSTAL,
+                    },
+                },
+                'Timmy'
+            );
+            expect(newBoard.players[0].resources).toHaveLength(1);
+            expect(newBoard.players[0].resources[0].name).toBe(
+                Resource.CRYSTAL
+            );
+        });
+
+        it('comes in tapped', () => {
+            board.players[0].hand = [makeResourceCard(Resource.CRYSTAL)];
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.RAMP_FROM_HAND,
+                        strength: 1,
+                        resourceType: Resource.CRYSTAL,
+                    },
+                },
+                'Timmy'
+            );
+            expect(newBoard.players[0].resources[0].isUsed).toBe(true);
+        });
+    });
+
     describe('Return from cemetery', () => {
         it('returns from cemetery', () => {
             board.players[0].cemetery.push(makeCard(UnitCards.KNIGHT_TEMPLAR));

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -10,7 +10,7 @@ import {
     getDefaultTargetForEffect,
     TargetTypes,
 } from '@/types/effects';
-import { CardType, SpellCard, UnitCard } from '@/types/cards';
+import { CardType, ResourceCard, SpellCard, UnitCard } from '@/types/cards';
 import { makeCard, makeResourceCard } from '@/factories/cards';
 import {
     applyWinState,
@@ -374,6 +374,39 @@ export const resolveEffect = (
                     resourceCard.isUsed = true;
                     player.resources.push(resourceCard);
                 }
+            });
+            return clonedBoard;
+        }
+        case EffectType.RAMP_FROM_HAND: {
+            const { resourceType } = effect;
+            if (!resourceType) return clonedBoard;
+            playerTargets.forEach((player) => {
+                const cardsToExtractPopulation: ResourceCard[] = [];
+
+                player.hand.forEach((card) => {
+                    if (
+                        card.cardType === CardType.RESOURCE &&
+                        card.resourceType === resourceType
+                    )
+                        cardsToExtractPopulation.push(card);
+                });
+                const cardsToExtractSample = sampleSize(
+                    cardsToExtractPopulation,
+                    effectStrength
+                );
+
+                cardsToExtractSample.forEach((resourceCard: ResourceCard) => {
+                    resourceCard.isUsed = true;
+                });
+
+                player.hand = player.hand.filter((card) => {
+                    return !(
+                        card.cardType === CardType.RESOURCE &&
+                        cardsToExtractSample.includes(card)
+                    );
+                });
+                player.resources =
+                    player.resources.concat(cardsToExtractSample);
             });
             return clonedBoard;
         }

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -155,6 +155,9 @@ export const transformEffectToRulesText = (effect: Effect): string => {
         case EffectType.RAMP: {
             return `Increase ${resourceType.toLowerCase()} resources by ${strength}`;
         }
+        case EffectType.RAMP_FROM_HAND: {
+            return `Deploy ${strength} ${resourceType} card${pluralizationEffectStrength} from your hand tapped`;
+        }
         case EffectType.RETURN_FROM_CEMETERY: {
             return `Return ${strength} ${cardName} card${pluralizationEffectStrength} from your cemetery`;
         }

--- a/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
@@ -272,59 +272,74 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
-    it('displays rules for ramping bamboo', () => {
-        const effect: Effect = {
-            type: EffectType.RAMP,
-            resourceType: Resource.BAMBOO,
-            strength: 1,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase bamboo resources by 1`
-        );
+    describe('Ramp', () => {
+        it('displays rules for ramping bamboo', () => {
+            const effect: Effect = {
+                type: EffectType.RAMP,
+                resourceType: Resource.BAMBOO,
+                strength: 1,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase bamboo resources by 1`
+            );
+        });
+
+        it('displays rules for ramping crystal', () => {
+            const effect: Effect = {
+                type: EffectType.RAMP,
+                resourceType: Resource.CRYSTAL,
+                strength: 1,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase crystal resources by 1`
+            );
+        });
+
+        it('displays rules for ramping fire', () => {
+            const effect: Effect = {
+                type: EffectType.RAMP,
+                resourceType: Resource.FIRE,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase fire resources by 3`
+            );
+        });
+
+        it('displays rules for ramping iron', () => {
+            const effect: Effect = {
+                type: EffectType.RAMP,
+                resourceType: Resource.IRON,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase iron resources by 3`
+            );
+        });
+
+        it('displays rules for ramping water', () => {
+            const effect: Effect = {
+                type: EffectType.RAMP,
+                resourceType: Resource.WATER,
+                strength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase water resources by 2`
+            );
+        });
     });
 
-    it('displays rules for ramping crystal', () => {
-        const effect: Effect = {
-            type: EffectType.RAMP,
-            resourceType: Resource.CRYSTAL,
-            strength: 1,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase crystal resources by 1`
-        );
-    });
-
-    it('displays rules for ramping fire', () => {
-        const effect: Effect = {
-            type: EffectType.RAMP,
-            resourceType: Resource.FIRE,
-            strength: 3,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase fire resources by 3`
-        );
-    });
-
-    it('displays rules for ramping iron', () => {
-        const effect: Effect = {
-            type: EffectType.RAMP,
-            resourceType: Resource.IRON,
-            strength: 3,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase iron resources by 3`
-        );
-    });
-
-    it('displays rules for ramping water', () => {
-        const effect: Effect = {
-            type: EffectType.RAMP,
-            resourceType: Resource.WATER,
-            strength: 2,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase water resources by 2`
-        );
+    describe('Ramp from Hand', () => {
+        it('displays rules for ramping bamboo', () => {
+            const effect: Effect = {
+                type: EffectType.RAMP_FROM_HAND,
+                resourceType: Resource.BAMBOO,
+                strength: 1,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Deploy 1 Bamboo card from your hand tapped`
+            );
+        });
     });
 
     it('displays rules for returning from cemetery', () => {

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -45,6 +45,7 @@ export enum EffectType {
     LEARN = 'Learn', // add spells / units to hand
     POLYMORPH = 'Polymorph', // polymorph a unit into a token type
     RAMP = 'Ramp', // add resources (tapped)
+    RAMP_FROM_HAND = 'Ramp from Hand',
     RETURN_FROM_CEMETERY = 'Return from cemetry', // Return X cards from cemetery -> board
     REVIVE = 'Revive', // revive units from the cemetery -> board
     SUMMON_UNITS = 'Summon Units', //
@@ -74,6 +75,7 @@ export const getDefaultTargetForEffect = (
         [EffectType.LEARN]: TargetTypes.SELF_PLAYER,
         [EffectType.POLYMORPH]: TargetTypes.UNIT,
         [EffectType.RAMP]: TargetTypes.SELF_PLAYER,
+        [EffectType.RAMP_FROM_HAND]: TargetTypes.SELF_PLAYER,
         [EffectType.REVIVE]: TargetTypes.ALL_SELF_UNITS_CEMETERY,
         [EffectType.RETURN_FROM_CEMETERY]: TargetTypes.SELF_PLAYER,
         [EffectType.SUMMON_UNITS]: TargetTypes.SELF_PLAYER,


### PR DESCRIPTION
Bamboo farmer was one of the most powerful units in the game that essentially ramped for 1 a single resource and put a 1/1 body on the board.

Now, it's more reasonable, because it has a real deck-building constraint.

It ramps from the hand instead now, greatly increasing non-bamboo design space