### PR TITLE
Minor gameplay bug fixes

### DIFF
--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -1002,11 +1002,13 @@ describe('Game Action', () => {
     describe('Passive Effects', () => {
         describe('Hearty', () => {
             it('survives lethal damage', () => {
-                const attacker = makeCard(UnitCards.LANCER);
-                attacker.passiveEffects = [PassiveEffect.HEARTY];
-                attacker.numAttacksLeft = 1;
-                const defender = makeCard(UnitCards.MARTIAL_TRAINER);
-                board.players[0].units = [attacker];
+                const attacker = makeCard(UnitCards.BOUNTY_COLLECTOR);
+                attacker.passiveEffects.push(PassiveEffect.HEARTY);
+                const defender = makeCard(UnitCards.BOUNTY_COLLECTOR);
+                board.players[0].units = [
+                    attacker,
+                    makeCard(UnitCards.BOUNTY_COLLECTOR),
+                ];
                 board.players[1].units = [defender];
                 const newBoardState = applyGameAction({
                     board,
@@ -1018,9 +1020,10 @@ describe('Game Action', () => {
                     playerName: 'Timmy',
                 });
                 expect(newBoardState.players[0].cemetery).toHaveLength(0);
+                console.log(newBoardState.players[0].units);
                 expect(
                     newBoardState.players[0].units[0].passiveEffects
-                ).toEqual([]);
+                ).toEqual([PassiveEffect.POISONED, PassiveEffect.QUICK]);
                 expect(newBoardState.players[0].units[0].hp).toEqual(1);
             });
         });

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -108,7 +108,11 @@ export const processBoardToCemetery = (
             unit.hp = 1;
         });
 
-        player.units = [...unitsLeft, ...unitsSurvivingViaHearty];
+        player.units = player.units.filter(
+            (unit) =>
+                unitsLeft.includes(unit) ||
+                unitsSurvivingViaHearty.includes(unit)
+        );
         if (unitsNotSurvivingViaHearty.length > 0) {
             addSystemChat(
                 `${unitsNotSurvivingViaHearty

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -71,6 +71,12 @@ export const transformEffectToRulesText = (effect: Effect): string => {
             target || getDefaultTargetForEffect(type)
         ];
     const pluralizationEffectStrength = strength > 1 ? 's' : '';
+
+    let forText = '';
+    if (target && target !== TargetTypes.SELF_PLAYER) {
+        forText = ` for ${targetName}`;
+    }
+
     switch (effect.type) {
         case EffectType.BOUNCE: {
             return `Return ${targetName} back to ${
@@ -173,7 +179,7 @@ export const transformEffectToRulesText = (effect: Effect): string => {
             return `Turn ${targetName} into a [${summonType.name}]`;
         }
         case EffectType.RAMP: {
-            return `Increase ${resourceType.toLowerCase()} resources by ${strength}`;
+            return `Increase ${resourceType.toLowerCase()} resources by ${strength}${forText}`;
         }
         case EffectType.RAMP_FOR_TURN: {
             return `Add ${strength} ${RESOURCE_GLOSSARY[resourceType].icon} this turn`;
@@ -188,18 +194,9 @@ export const transformEffectToRulesText = (effect: Effect): string => {
             return `Revive ${targetName}`;
         }
         case EffectType.SUMMON_UNITS: {
-            let forText = '';
-            if (target && target !== TargetTypes.SELF_PLAYER) {
-                forText = ` for ${targetName}`;
-            }
             return `Summon ${strength} ${summonType.name}${pluralizationEffectStrength} - ${summonType.attack} ⚔️ ${summonType.totalHp} 💙${forText}`;
         }
         case EffectType.TRANSMUTE: {
-            let forText = '';
-            if (target && target !== TargetTypes.SELF_PLAYER) {
-                forText = ` for ${targetName}`;
-            }
-
             return `Turn ${
                 strength || 'all'
             } [${cardName}] card${pluralizationEffectStrength} in hand into [${secondaryCardName}]${forText}`;

--- a/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectstoRulesText.spec.ts
@@ -319,47 +319,15 @@ describe('transformEffectstoRulesText', () => {
             );
         });
 
-        it('displays rules for ramping crystal', () => {
+        it('displays rules for ramping crystal for opponents', () => {
             const effect: Effect = {
                 type: EffectType.RAMP,
                 resourceType: Resource.CRYSTAL,
+                target: TargetTypes.ALL_OPPONENTS,
                 strength: 1,
             };
             expect(transformEffectToRulesText(effect)).toEqual(
-                `Increase crystal resources by 1`
-            );
-        });
-
-        it('displays rules for ramping fire', () => {
-            const effect: Effect = {
-                type: EffectType.RAMP,
-                resourceType: Resource.FIRE,
-                strength: 3,
-            };
-            expect(transformEffectToRulesText(effect)).toEqual(
-                `Increase fire resources by 3`
-            );
-        });
-
-        it('displays rules for ramping iron', () => {
-            const effect: Effect = {
-                type: EffectType.RAMP,
-                resourceType: Resource.IRON,
-                strength: 3,
-            };
-            expect(transformEffectToRulesText(effect)).toEqual(
-                `Increase iron resources by 3`
-            );
-        });
-
-        it('displays rules for ramping water', () => {
-            const effect: Effect = {
-                type: EffectType.RAMP,
-                resourceType: Resource.WATER,
-                strength: 2,
-            };
-            expect(transformEffectToRulesText(effect)).toEqual(
-                `Increase water resources by 2`
+                `Increase crystal resources by 1 for all opponents`
             );
         });
     });

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -98,7 +98,7 @@ export enum PassiveEffect {
         STRONG_VS_SOLDIER, // deal double damage to soldier units
         HEARTY, // cannot be taken down in 1 hit
     */
-    HEARTY = 'Hearty (if this unit would take lethal damage, instead lose hearty permanently and go to 1 hp)',
+    HEARTY = 'Hearty (if this unit would take lethal damage, instead lose hearty and go to 1 hp)',
     POISONED = 'Poisonous (deals lethal damage)', // deals lethal dmg to enemy units
     QUICK = 'Quick (can attack right away)', // no summoning sickness
 }


### PR DESCRIPTION
1. Hearty should not re-order units on losing hearty

used red-green to properly set up the test first for this scenario, then re-worked the logic to account for

2. hearty doesn't get permanently lost - updated wording

3. Chad no longer misleadingly says 'increase water resources by 1' but instead 'increase water resources by 1 for all opponents'