### PR TITLE
Fix implicit target chat messages (effects)

### DIFF
--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -103,6 +103,32 @@ describe('resolve effect', () => {
         );
     });
 
+    it('displays chat (implicit target)', () => {
+        const mockAddSystemChat = jest.fn();
+        const effect = {
+            type: EffectType.DEAL_DAMAGE,
+            strength: 1,
+        };
+        board.players[0].effectQueue = [effect];
+        const squire = makeCard(UnitCards.SQUIRE);
+        board.players[0].units = [squire];
+
+        resolveEffect(
+            board,
+            {
+                effect,
+                unitCardIds: [squire.id],
+            },
+            'Timmy',
+            false,
+            mockAddSystemChat
+        );
+
+        expect(mockAddSystemChat).toHaveBeenCalledWith(
+            'Timmy resolved "deal 1 damage to any target" ➡️ [[Squire]]'
+        );
+    });
+
     describe('Bounce units', () => {
         it('bounces a unit back to hand', () => {
             const squire = makeCard(UnitCards.SQUIRE);

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -58,7 +58,6 @@ export const resolveEffect = (
     // Determine targets to apply effects to
     let playerTargets: Player[];
     let unitTargets: { player: Player; unitCard: UnitCard }[] = [];
-    const originalTarget = effect.target;
     const target = effect.target || getDefaultTargetForEffect(effect.type);
     let targetText;
 

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -152,7 +152,9 @@ export const resolveEffect = (
     const addSystemChat = (message: string) => addChatMessage?.(message);
     addSystemChat(
         `${activePlayer.name} resolved "${rulesText}"${
-            targetText && originalTarget ? ` ➡️ ${targetText}` : ''
+            targetText && target !== TargetTypes.SELF_PLAYER
+                ? ` ➡️ ${targetText}`
+                : ''
         }`
     );
 


### PR DESCRIPTION
When effects had an implicit target (e.g. 'ANY' for dealing damage), the previous system would not be good about displaying the target in the chat.

This is b/c we wanted to simplify originally the target of 'you' for drawing cards, e.g. we don't want to display `resolved: draw 2 cards -> you`.  when we could just say `resolved: draw 2 cards`

This led to shorthanded cards with real targets, e.g. `deal 2 damage` not having a proper chat message