### PR TITLE
Disallow advanced resource cards from being ramped

### DIFF
--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -446,7 +446,8 @@ export const resolveEffect = (
                 player.hand.forEach((card) => {
                     if (
                         card.cardType === CardType.RESOURCE &&
-                        card.resourceType === resourceType
+                        card.resourceType === resourceType &&
+                        !card.isAdvanced
                     )
                         cardsToExtractPopulation.push(card);
                 });


### PR DESCRIPTION
Bamboo farmer was able to somehow ramp out bamboo footbridges.  This fixes that