### PR TITLE
Feat: Bump decklist size to 60

### DIFF
--- a/src/cardDb/resources/advancedResources.ts
+++ b/src/cardDb/resources/advancedResources.ts
@@ -16,7 +16,7 @@ const STRATOVOLCANO = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -34,7 +34,7 @@ const SEASIDE_COVE = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -52,7 +52,7 @@ const BLACK_MARSH = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -70,7 +70,7 @@ const SAHARAN_DESERT = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -88,7 +88,7 @@ const CLOUD_HAVEN = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -106,7 +106,7 @@ const DRAGONS_NEST = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -124,7 +124,7 @@ const SMELTING_FORGE = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -142,7 +142,7 @@ const LUSH_REEF = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -160,7 +160,7 @@ const HARBOR_TOWN = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],
@@ -178,7 +178,7 @@ const TANGLED_RUINS = makeAdvancedResourceCard({
     enterEffects: [
         {
             type: EffectType.DEAL_DAMAGE,
-            strength: 1,
+            strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },
     ],

--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -176,7 +176,7 @@ describe('DeckBuilder', () => {
         Object.assign(navigator, {
             clipboard: {
                 readText: () =>
-                    `[{"card":"Iron","quantity":44},{"card":"Lancer","quantity":4}]`,
+                    `[{"card":"Iron","quantity":56},{"card":"Lancer","quantity":4}]`,
             },
         });
 
@@ -189,7 +189,7 @@ describe('DeckBuilder', () => {
 
         fireEvent.click(screen.getByText('Submit'));
         expect(webSocket.chooseCustomDeck).toHaveBeenCalledWith([
-            { card: 'Iron', quantity: 44 },
+            { card: 'Iron', quantity: 56 },
             { card: 'Lancer', quantity: 4 },
         ]);
         expect(dispatch).toHaveBeenCalledWith(push('/'));

--- a/src/client/components/InstructionsPage/InstructionsPage.tsx
+++ b/src/client/components/InstructionsPage/InstructionsPage.tsx
@@ -65,7 +65,7 @@ export const InstructionsPage: React.FC = () => {
                     Magic the Gathering, with a blend of unique mechanics.
                     <br />
                     <br />
-                    Players construct 48-card decks, start at 20 life, and work
+                    Players construct 60-card decks, start at 20 life, and work
                     to win by being the last player standing. This game supports
                     2-4 players at once.
                     <br />

--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
@@ -27,7 +27,7 @@ describe('Player Brief Info', () => {
     it('renders the remaining cards / size of hand', () => {
         const player = makeNewPlayer('Grandma Jenkins', SAMPLE_DECKLIST_1);
         render(<PlayerBriefInfo player={player} />);
-        expect(screen.getByText('41')).toBeInTheDocument();
+        expect(screen.getByText('53')).toBeInTheDocument();
         expect(screen.getByText('7')).toBeInTheDocument();
     });
 

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -6,31 +6,35 @@ import { makeResourceCard } from '@/factories/cards';
 import { AdvancedResourceCards } from '@/cardDb/resources/advancedResources';
 
 // Bamboo + Iron - revised version (not used in mocks)
-export const SAMPLE_DECKLIST_0: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 8 },
-    { card: makeResourceCard(Resource.IRON), quantity: 9 },
+export const MONKS_DECKLIST: DeckList = [
+    // 22 Resources
+    { card: makeResourceCard(Resource.BAMBOO), quantity: 7 },
+    { card: makeResourceCard(Resource.IRON), quantity: 7 },
     { card: AdvancedResourceCards.TANGLED_RUINS, quantity: 4 },
-    // Soldiers
-    { card: UnitCards.SQUIRE, quantity: 2 },
+    { card: AdvancedResourceCards.PREFECTURE_CAPITAL, quantity: 4 },
+    // 20 Soldiers
+    { card: UnitCards.PIKEMAN, quantity: 4 },
     { card: UnitCards.LANCER, quantity: 4 },
+    { card: UnitCards.INFANTRY_OFFICER, quantity: 4 },
+    { card: UnitCards.SQUIRE, quantity: 3 },
+    { card: UnitCards.ORCISH_CORPORAL, quantity: 2 },
     { card: UnitCards.MARTIAL_TRAINER, quantity: 3 },
-    // Assassins
+    // 6 Assassins
     { card: UnitCards.ASSASSIN, quantity: 2 },
     { card: UnitCards.SHADOW_STRIKER, quantity: 2 },
     { card: UnitCards.BOUNTY_COLLECTOR, quantity: 2 },
-    // Ranged
+    // 6 Ranged
     { card: UnitCards.JAVELINEER, quantity: 4 },
-    { card: UnitCards.MERRY_RALLIER, quantity: 4 },
-    // Spells
+    { card: UnitCards.MERRY_RALLIER, quantity: 2 },
+    // 6 Spells
     { card: SpellCards.THROW_SHURIKEN, quantity: 2 },
-    { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
+    { card: SpellCards.RAIN_OF_ARROWS, quantity: 4 },
 ];
 
 // Bamboo + Iron (mock version, for mocks only)
 export const SAMPLE_DECKLIST_1: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 11 },
+    { card: makeResourceCard(Resource.BAMBOO), quantity: 23 },
     { card: makeResourceCard(Resource.IRON), quantity: 12 },
     // Soldiers
     { card: UnitCards.SQUIRE, quantity: 3 },
@@ -47,146 +51,179 @@ export const SAMPLE_DECKLIST_1: DeckList = [
 ];
 
 // Fire + Crystal (Fire Mage)
-export const SAMPLE_DECKLIST_2: DeckList = [
+export const FIRE_MAGES_DECKLIST: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.FIRE), quantity: 9 },
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
+    { card: makeResourceCard(Resource.FIRE), quantity: 8 },
+    { card: makeResourceCard(Resource.CRYSTAL), quantity: 6 },
     { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 4 },
+    { card: AdvancedResourceCards.LONE_TOWER, quantity: 4 },
+    { card: AdvancedResourceCards.LAVA_RIVER, quantity: 2 },
     // Units
-    { card: UnitCards.FIRE_TECHNICIAN, quantity: 3 },
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    { card: UnitCards.FIRE_MAGE, quantity: 4 },
-    { card: UnitCards.INFERNO_SORCEROR, quantity: 2 },
+    { card: UnitCards.MIDNIGHT_HELLSPAWN, quantity: 2 },
+    { card: UnitCards.INFERNO_SORCEROR, quantity: 4 },
     // Spells
+    { card: SpellCards.SUPERNOVA, quantity: 4 },
+    { card: SpellCards.BEAM_ME_UP, quantity: 4 },
+    { card: SpellCards.STRIKE_TWICE, quantity: 2 },
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
-    { card: SpellCards.LIGHTNING_SLICK, quantity: 2 },
-    { card: SpellCards.VOLCANIC_INFERNO, quantity: 2 },
-    { card: SpellCards.CURSE_HAND, quantity: 2 },
-    { card: SpellCards.SUMMON_DEMONS, quantity: 4 },
+    { card: SpellCards.SPECTRAL_GENESIS, quantity: 2 },
+    { card: SpellCards.DISTORT_REALITY, quantity: 2 },
+    { card: SpellCards.VOLCANIC_INFERNO, quantity: 4 },
+    { card: SpellCards.CAVE_IMPLOSION, quantity: 4 },
 ];
 
 // Water + Crystal (Water Mage)
-export const SAMPLE_DECKLIST_3: DeckList = [
+export const WATER_MAGES_DECKLIST: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.WATER), quantity: 8 },
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 7 },
-    { card: AdvancedResourceCards.SEASIDE_COVE, quantity: 4 },
+    { card: makeResourceCard(Resource.WATER), quantity: 14 },
+    { card: AdvancedResourceCards.COASTAL_CASTLE, quantity: 4 },
+    { card: AdvancedResourceCards.CHILLY_BERG, quantity: 4 },
     // Units
+    { card: UnitCards.FROST_WYRM, quantity: 1 },
+    { card: UnitCards.GIANT_JELLY, quantity: 4 },
+    { card: UnitCards.LAKE_ZOMBIE, quantity: 4 },
+    { card: UnitCards.MEDITATION_EXPERT, quantity: 2 },
     { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
-    { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    { card: UnitCards.TINY_MERMAID, quantity: 4 },
-    { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
-    { card: UnitCards.WATER_MAGE, quantity: 3 },
-    { card: UnitCards.WATER_GUARDIAN, quantity: 2 },
+    { card: UnitCards.MANTA_RAY_CONJURER, quantity: 2 },
+    { card: UnitCards.RAIN_CHANNELER, quantity: 1 },
+    { card: UnitCards.WAVING_FISHERMAN, quantity: 1 },
+    { card: UnitCards.FROST_WALKER, quantity: 2 },
+    { card: UnitCards.MISBEGOTTEN_MISTWALKER, quantity: 1 },
+    { card: UnitCards.PEACE_BRINGER, quantity: 1 },
+    { card: UnitCards.WATER_MAGE, quantity: 4 },
+    { card: UnitCards.THUNDER_SCHEDULER, quantity: 3 },
+    { card: UnitCards.MAELSTROM_SEEKER, quantity: 1 },
 
     // Spells
-    { card: SpellCards.BUBBLE_BLAST, quantity: 2 },
-    { card: SpellCards.GENEROUS_GEYSER, quantity: 1 },
-    { card: SpellCards.SUMMON_SHARKS, quantity: 2 },
-    { card: SpellCards.RAGING_WHIRLPOOL, quantity: 2 },
-    { card: SpellCards.CONSTANT_REFILL, quantity: 1 },
+    { card: SpellCards.COLD_ISOLATION, quantity: 4 },
+    { card: SpellCards.REFLECTION_OPPORTUNITY, quantity: 1 },
+    { card: SpellCards.PIERCE_THE_HEAVENS, quantity: 2 },
 ];
 
 // Water + Fire (aka wind)
-export const SAMPLE_DECKLIST_4: DeckList = [
+export const WIND_MAGES_DECKLIST: DeckList = [
     // Resources
     { card: makeResourceCard(Resource.WATER), quantity: 8 },
     { card: makeResourceCard(Resource.FIRE), quantity: 8 },
     { card: AdvancedResourceCards.CLOUD_HAVEN, quantity: 4 },
+    { card: AdvancedResourceCards.TROUBLED_PARADISE, quantity: 4 },
+    { card: AdvancedResourceCards.CHILLY_BERG, quantity: 1 },
     // Units
     { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
-    { card: UnitCards.RELAXED_ROWBOATER, quantity: 2 },
-    { card: UnitCards.FIRE_MAGE, quantity: 4 },
-    { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
+    { card: UnitCards.HEAVENLY_FERRIER, quantity: 2 },
+    { card: UnitCards.FLUX_FIGHTER, quantity: 4 },
+    { card: UnitCards.FERRY_OPERATOR, quantity: 4 },
     { card: UnitCards.WATER_MAGE, quantity: 3 },
     { card: UnitCards.WIND_MAGE, quantity: 2 },
+    { card: UnitCards.ARCHANGEL, quantity: 3 },
 
     // Spells
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
     { card: SpellCards.A_GENTLE_GUST, quantity: 2 },
+    { card: SpellCards.SOLFATARA, quantity: 2 },
     { card: SpellCards.A_THOUSAND_WINDS, quantity: 3 },
+    { card: SpellCards.COLLOSAL_TSUNAMI, quantity: 2 },
 ];
 
 // Bamboo + Iron - Farmer deck
-export const SAMPLE_DECKLIST_5: DeckList = [
+export const FARMERS_DECKLIST: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 9 },
-    { card: makeResourceCard(Resource.IRON), quantity: 6 },
+    { card: makeResourceCard(Resource.BAMBOO), quantity: 7 },
+    { card: makeResourceCard(Resource.IRON), quantity: 3 },
     { card: AdvancedResourceCards.TANGLED_RUINS, quantity: 4 },
-    // Other
+    { card: AdvancedResourceCards.PREFECTURE_CAPITAL, quantity: 4 },
+    { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
+    // Units
+    { card: UnitCards.ALERT_FELINE, quantity: 4 },
+    { card: UnitCards.ANGRY_HEN, quantity: 4 },
+    { card: UnitCards.STONE_SLINGER, quantity: 4 },
+    { card: UnitCards.SWORDS_MASTER, quantity: 4 },
+    { card: UnitCards.BOUNTY_COLLECTOR, quantity: 4 },
+    { card: UnitCards.CAVALRY_ARCHER, quantity: 4 },
+    { card: UnitCards.CANYON_ELITE, quantity: 2 },
     { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
-    // Soldiers
-    { card: UnitCards.TEMPLE_GUARDIAN, quantity: 3 },
-    // Ranged
-    { card: UnitCards.LONGBOWMAN, quantity: 3 },
-    { card: UnitCards.JAVELINEER, quantity: 3 },
-    { card: UnitCards.CAVALRY_ARCHER, quantity: 3 },
-    { card: UnitCards.FALCON_RIDER, quantity: 2 },
-    { card: UnitCards.MERRY_RALLIER, quantity: 4 },
+    { card: UnitCards.ADVENTURER, quantity: 2 },
+    { card: UnitCards.EXCELLENT_EQUESTRIAN, quantity: 2 },
     // Spells
-    { card: SpellCards.FEED_TEAM, quantity: 4 },
-    { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
+    { card: SpellCards.CONCENTRATED_FOCUS, quantity: 3 },
+    { card: SpellCards.FISH_MARKET_VISIT, quantity: 1 },
 ];
 
 // Crystal + Iron - (Genie Deck)
-export const SAMPLE_DECKLIST_6: DeckList = [
+export const GENIES_DECKLIST: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
-    { card: makeResourceCard(Resource.IRON), quantity: 9 },
+    { card: makeResourceCard(Resource.CRYSTAL), quantity: 6 },
+    { card: makeResourceCard(Resource.IRON), quantity: 6 },
     { card: AdvancedResourceCards.SAHARAN_DESERT, quantity: 4 },
-    // Other
+    { card: AdvancedResourceCards.DIVINE_PALACE, quantity: 4 },
+    { card: AdvancedResourceCards.TREACHEROUS_DESERT, quantity: 2 },
+    // Units
+    { card: UnitCards.NOVICE_ASTRONOMER, quantity: 4 },
     { card: UnitCards.FORTUNE_PREDICTOR, quantity: 4 },
-    // Magicians
     { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    // Soldiers
     { card: UnitCards.CAPTAIN_OF_THE_GUARD, quantity: 4 },
-    { card: UnitCards.LANCER, quantity: 3 },
-    { card: UnitCards.KNIGHT_TEMPLAR, quantity: 2 },
+    { card: UnitCards.ENERGY_ENHANCER, quantity: 2 },
+    { card: UnitCards.SPIRIT_TENDER, quantity: 1 },
+    { card: UnitCards.UNHOLY_VETERAN, quantity: 1 },
+    { card: UnitCards.MAGI_RIDER, quantity: 4 },
     // Spells
-    { card: SpellCards.DISTORT_REALITY, quantity: 4 },
-    { card: SpellCards.OPEN_NEBULA, quantity: 2 },
+    { card: SpellCards.DISTORT_REALITY, quantity: 2 },
+    { card: SpellCards.DECAY, quantity: 1 },
+    { card: SpellCards.OPEN_NEBULA, quantity: 1 },
     { card: SpellCards.SPECTRAL_GENESIS, quantity: 4 },
+    { card: SpellCards.ZEN_STANCE, quantity: 4 },
+    { card: SpellCards.SIGNAL_BEACON, quantity: 2 },
 ];
 
 // Crystal + Water + Fire - (Sorceror Deck)
-export const SAMPLE_DECKLIST_7: DeckList = [
+export const SORCERORS_DECKLIST: DeckList = [
     // Resources
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 4 },
-    { card: makeResourceCard(Resource.WATER), quantity: 2 },
-    { card: makeResourceCard(Resource.FIRE), quantity: 4 },
+    { card: makeResourceCard(Resource.CRYSTAL), quantity: 2 },
     { card: AdvancedResourceCards.CLOUD_HAVEN, quantity: 4 },
-    { card: AdvancedResourceCards.SEASIDE_COVE, quantity: 3 },
-    { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 3 },
+    { card: AdvancedResourceCards.SEASIDE_COVE, quantity: 4 },
+    { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 4 },
+    { card: AdvancedResourceCards.LONE_TOWER, quantity: 4 },
+    { card: AdvancedResourceCards.MYSTIFYING_LAKE, quantity: 4 },
+    { card: AdvancedResourceCards.TROUBLED_PARADISE, quantity: 4 },
     // Magicians
-    { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 3 },
-    { card: UnitCards.FIRE_MAGE, quantity: 2 },
+    { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
+    { card: UnitCards.FIRE_MAGE, quantity: 1 },
     { card: UnitCards.WATER_MAGE, quantity: 1 },
-    { card: UnitCards.BRIGHT_SCHOLAR, quantity: 3 },
+    { card: UnitCards.ALADDIN, quantity: 2 },
+    { card: UnitCards.BRIGHT_SCHOLAR, quantity: 2 },
     { card: UnitCards.INFERNO_SORCEROR, quantity: 1 },
-    { card: UnitCards.WIND_MAGE, quantity: 1 },
+    { card: UnitCards.CURIOUS_RESEARCHER, quantity: 2 },
+    { card: UnitCards.WATER_GUARDIAN, quantity: 1 },
     // Spells
-    { card: SpellCards.HOLY_REVIVAL, quantity: 3 },
+    { card: SpellCards.INCREDIBLE_DISCOVERY, quantity: 3 },
+    { card: SpellCards.SCOUR_THE_LIBRARY, quantity: 3 },
+    { card: SpellCards.HOLY_REVIVAL, quantity: 2 },
     { card: SpellCards.CONSTANT_REFILL, quantity: 2 },
     { card: SpellCards.SUMMON_DEMONS, quantity: 1 },
     { card: SpellCards.VOLCANIC_INFERNO, quantity: 3 },
-    { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+    { card: SpellCards.EMBER_SPEAR, quantity: 2 },
     { card: SpellCards.BUBBLE_BLAST, quantity: 2 },
     { card: SpellCards.SPECTRAL_GENESIS, quantity: 2 },
 ];
 
 // Water + Bamboo (Coral)
-export const SAMPLE_DECKLIST_8: DeckList = [
+export const DIVERS_DECKLIST: DeckList = [
     // Resources
     { card: makeResourceCard(Resource.WATER), quantity: 8 },
     { card: makeResourceCard(Resource.BAMBOO), quantity: 8 },
     { card: AdvancedResourceCards.LUSH_REEF, quantity: 4 },
+    { card: AdvancedResourceCards.ROYAL_RESIDENCE, quantity: 4 },
     // Units
     { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
     { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
+    { card: UnitCards.SEASONAL_CROPHAND, quantity: 4 },
     { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
+    { card: UnitCards.PASTURE_EXPLORER, quantity: 3 },
     { card: UnitCards.FALCON_RIDER, quantity: 4 },
     { card: UnitCards.MERRY_RALLIER, quantity: 4 },
     { card: UnitCards.DEEP_SEA_EXPLORER, quantity: 4 },
+    { card: UnitCards.ICTHYOMANCER, quantity: 1 },
 
     // Spells
     { card: SpellCards.BUBBLE_BLAST, quantity: 1 },
@@ -194,11 +231,12 @@ export const SAMPLE_DECKLIST_8: DeckList = [
 ];
 
 // Iron + Fire (Cannoneers)
-export const SAMPLE_DECKLIST_9: DeckList = [
+export const CANNONEERS_DECKLIST: DeckList = [
     // Resources
     { card: makeResourceCard(Resource.IRON), quantity: 8 },
     { card: makeResourceCard(Resource.FIRE), quantity: 8 },
     { card: AdvancedResourceCards.SMELTING_FORGE, quantity: 4 },
+    { card: AdvancedResourceCards.ORNATE_TEMPLE, quantity: 4 },
     // Units
     { card: UnitCards.FIRE_TECHNICIAN, quantity: 3 },
     { card: UnitCards.QUARRY_WORKER, quantity: 4 },
@@ -206,10 +244,35 @@ export const SAMPLE_DECKLIST_9: DeckList = [
     { card: UnitCards.MARTIAL_TRAINER, quantity: 2 },
     { card: UnitCards.FIRE_MAGE, quantity: 4 },
     { card: UnitCards.CANNON, quantity: 4 },
+    { card: UnitCards.ZEALOUS_ACOLYTE, quantity: 1 },
+    { card: UnitCards.BANISHER_OF_MAGIC, quantity: 1 },
 
     // Spells
     { card: SpellCards.EMBER_SPEAR, quantity: 4 },
     { card: SpellCards.IGNITE_SPARKS, quantity: 4 },
+    { card: SpellCards.FESTIVE_BAZAAR, quantity: 4 },
+    { card: SpellCards.FIRE_AWAY, quantity: 1 },
+    { card: SpellCards.BESIEGE_THE_CASTLE, quantity: 1 },
+];
+
+export const PIRATES_DECKLIST: DeckList = [
+    { card: SpellCards.RAISE_THE_MASTS, quantity: 4 },
+    { card: UnitCards.ELDER_PIRATE, quantity: 4 },
+    { card: UnitCards.NOBLE_STEED, quantity: 4 },
+    { card: UnitCards.SCHEMING_EXPLORER, quantity: 4 },
+    { card: UnitCards.DARING_CORSAIR, quantity: 4 },
+    { card: UnitCards.SHIP_COXSWAIN, quantity: 4 },
+    { card: UnitCards.CUTLASS_CRUSADER, quantity: 2 },
+    { card: UnitCards.SPELUNKER, quantity: 4 },
+    { card: UnitCards.IRONSMITH, quantity: 2 },
+    { card: UnitCards.QUESTING_DUO, quantity: 4 },
+    { card: UnitCards.PIKEMAN, quantity: 2 },
+    { card: makeResourceCard(Resource.IRON), quantity: 4 },
+    { card: makeResourceCard(Resource.WATER), quantity: 4 },
+    { card: AdvancedResourceCards.HARBOR_TOWN, quantity: 4 },
+    { card: AdvancedResourceCards.CITY_CANALS, quantity: 4 },
+    { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
+    { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 2 },
 ];
 
 // For debugging / gamebuilding purposes

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -2,7 +2,7 @@ export enum PlayerConstants {
     MAX_DECK_SIZE = 200,
     STARTING_HEALTH = 20,
     STARTING_HAND_SIZE = 7,
-    STARTING_DECK_SIZE = 48,
+    STARTING_DECK_SIZE = 60,
 }
 
 export const AUTO_RESOLVE_LINGER_DURATION = 1000;

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -1,14 +1,15 @@
 import {
-    SAMPLE_DECKLIST_0,
+    MONKS_DECKLIST,
     SAMPLE_DECKLIST_1,
-    SAMPLE_DECKLIST_2,
-    SAMPLE_DECKLIST_3,
-    SAMPLE_DECKLIST_4,
-    SAMPLE_DECKLIST_5,
-    SAMPLE_DECKLIST_6,
-    SAMPLE_DECKLIST_7,
-    SAMPLE_DECKLIST_8,
-    SAMPLE_DECKLIST_9,
+    FIRE_MAGES_DECKLIST,
+    WATER_MAGES_DECKLIST,
+    WIND_MAGES_DECKLIST,
+    FARMERS_DECKLIST,
+    GENIES_DECKLIST,
+    SORCERORS_DECKLIST,
+    DIVERS_DECKLIST,
+    CANNONEERS_DECKLIST,
+    PIRATES_DECKLIST,
 } from '@/constants/deckLists';
 import { DeckList } from '@/types/cards';
 
@@ -23,9 +24,10 @@ export enum DeckListSelections {
     DIVERS = 'Divers 🤿',
     FARMERS = 'Farmers 👩‍🌾',
     GENIES = 'Genies 🧞‍♀️',
-    MAGES_FIRE = 'Mages 🔥',
-    MAGES_WATER = 'Mages 🌊',
-    MAGES_WIND = 'Mages 💨',
+    MAGES_FIRE = 'Fire Mages 🔥',
+    MAGES_WATER = 'Water Mages 🌊',
+    MAGES_WIND = 'Wind Mages 💨',
+    PIRATES = 'Pirates 🏴‍☠️',
     MONKS = 'Monks 🤺',
     RANDOM = 'Random ⁉️',
     SORCERORS = 'Sorcerors 🧙🏾‍♀️',
@@ -34,16 +36,17 @@ export enum DeckListSelections {
 export const PREMADE_DECKLIST_DEFAULT = DeckListSelections.MONKS;
 
 export const deckListMappings: Record<DeckListSelections, DeckList> = {
-    [DeckListSelections.CANNONEER]: SAMPLE_DECKLIST_9,
-    [DeckListSelections.DIVERS]: SAMPLE_DECKLIST_8,
-    [DeckListSelections.GENIES]: SAMPLE_DECKLIST_6,
-    [DeckListSelections.MONKS]: SAMPLE_DECKLIST_0,
-    [DeckListSelections.MAGES_FIRE]: SAMPLE_DECKLIST_2,
-    [DeckListSelections.MAGES_WATER]: SAMPLE_DECKLIST_3,
-    [DeckListSelections.MAGES_WIND]: SAMPLE_DECKLIST_4,
-    [DeckListSelections.FARMERS]: SAMPLE_DECKLIST_5,
+    [DeckListSelections.CANNONEER]: CANNONEERS_DECKLIST,
+    [DeckListSelections.DIVERS]: DIVERS_DECKLIST,
+    [DeckListSelections.GENIES]: GENIES_DECKLIST,
+    [DeckListSelections.MONKS]: MONKS_DECKLIST,
+    [DeckListSelections.MAGES_FIRE]: FIRE_MAGES_DECKLIST,
+    [DeckListSelections.MAGES_WATER]: WATER_MAGES_DECKLIST,
+    [DeckListSelections.MAGES_WIND]: WIND_MAGES_DECKLIST,
+    [DeckListSelections.FARMERS]: FARMERS_DECKLIST,
     [DeckListSelections.RANDOM]: SAMPLE_DECKLIST_1,
-    [DeckListSelections.SORCERORS]: SAMPLE_DECKLIST_7,
+    [DeckListSelections.SORCERORS]: SORCERORS_DECKLIST,
+    [DeckListSelections.PIRATES]: PIRATES_DECKLIST,
 };
 
 export const MAX_PLAYER_NAME_LENGTH = 25;

--- a/src/factories/board/makeNewBoard.spec.ts
+++ b/src/factories/board/makeNewBoard.spec.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_DECKLIST_2 } from '@/constants/deckLists';
+import { FIRE_MAGES_DECKLIST } from '@/constants/deckLists';
 import { PlayerConstants } from '@/constants/gameConstants';
 import { DeckListSelections } from '@/constants/lobbyConstants';
 import { Skeleton } from '@/types/cards';
@@ -28,7 +28,7 @@ describe('Make New Board', () => {
                 .map((card) => card.name)
                 .sort()
         ).toEqual(
-            makeDeck(SAMPLE_DECKLIST_2)
+            makeDeck(FIRE_MAGES_DECKLIST)
                 .map((card) => card.name)
                 .sort()
         );

--- a/src/factories/board/makeNewBoard.ts
+++ b/src/factories/board/makeNewBoard.ts
@@ -1,5 +1,5 @@
 import sampleSize from 'lodash.samplesize';
-import { SAMPLE_DECKLIST_0, SAMPLE_DECKLIST_1 } from '@/constants/deckLists';
+import { MONKS_DECKLIST, SAMPLE_DECKLIST_1 } from '@/constants/deckLists';
 import {
     deckListMappings,
     DeckListSelections,
@@ -35,7 +35,7 @@ export const makeNewBoard = ({
 
         const selection = playerDeckListSelections?.[i];
         let deckList =
-            (selection && deckListMappings[selection]) || SAMPLE_DECKLIST_0;
+            (selection && deckListMappings[selection]) || MONKS_DECKLIST;
         if (selection === DeckListSelections.RANDOM) {
             [deckList] = sampleSize(
                 Object.values(deckListMappings).filter(

--- a/src/transformers/isDeckValidForFomat/isDeckValidForFormat.spec.ts
+++ b/src/transformers/isDeckValidForFomat/isDeckValidForFormat.spec.ts
@@ -1,5 +1,5 @@
 import { SpellCards } from '@/cardDb/spells';
-import { ALL_CARDS, SAMPLE_DECKLIST_7 } from '@/constants/deckLists';
+import { ALL_CARDS, SORCERORS_DECKLIST } from '@/constants/deckLists';
 import { PlayerConstants } from '@/constants/gameConstants';
 import { makeResourceCard } from '@/factories/cards';
 import { Format } from '@/types/games';
@@ -8,7 +8,7 @@ import { isDeckValidForFormat } from './isDeckValidForFormat';
 
 describe('isDeckValidForFormat', () => {
     it('validates for standard', () => {
-        expect(isDeckValidForFormat(SAMPLE_DECKLIST_7)).toEqual({
+        expect(isDeckValidForFormat(SORCERORS_DECKLIST)).toEqual({
             isValid: true,
             reason: undefined,
         });
@@ -16,7 +16,7 @@ describe('isDeckValidForFormat', () => {
 
     it('returns false when there are too many of a single card', () => {
         expect(
-            isDeckValidForFormat(SAMPLE_DECKLIST_7, Format.SINGLETON)
+            isDeckValidForFormat(SORCERORS_DECKLIST, Format.SINGLETON)
         ).toEqual({
             isValid: false,
             reason: 'May have no more than 1 of [Spectral Genesis]',
@@ -31,7 +31,7 @@ describe('isDeckValidForFormat', () => {
             )
         ).toEqual({
             isValid: false,
-            reason: 'Must have at least 48 cards in deck',
+            reason: 'Must have at least 60 cards in deck',
         });
     });
 


### PR DESCRIPTION
Originally, I had wanted the game to feel "unique" from Magic (which has a 60 card deck) and I had landed on a 48-card deck size.

The problem with 48 cards is that it makes decks feel repetitive when you can have 4-of's in a deck.  It also doesn't allow the whole card-pool to shine as much.

- Bumped the deck minimum size to 60
- Made the dual lands that come in untapped deal 2 damage to the user
- Added a "pirates" deck