### PR TITLE
Fix issue where effects would linger without a valid target

### DIFF
--- a/src/client/components/GameManager/GameManager.spec.tsx
+++ b/src/client/components/GameManager/GameManager.spec.tsx
@@ -42,7 +42,6 @@ describe('Game Manager', () => {
         });
         const effect = {
             type: EffectType.BOUNCE,
-            target: TargetTypes.OWN_UNIT,
         };
         board.players[0].effectQueue = [effect];
 

--- a/src/client/redux/selectors/selectors.ts
+++ b/src/client/redux/selectors/selectors.ts
@@ -1,6 +1,6 @@
 import { GameState, Player } from '@/types/board';
 import { Effect } from '@/types/cards';
-import { TargetTypes } from '@/types/effects';
+import { TargetTypes, getDefaultTargetForEffect } from '@/types/effects';
 import { RootState } from '../store';
 
 export const isUserInitialized = (state: Partial<RootState>): boolean =>
@@ -74,7 +74,7 @@ export const shouldLastEffectFizzle = (state: Partial<RootState>): boolean => {
     const selfPlayer = getSelfPlayer(state);
     const players = [...otherPlayers, selfPlayer];
 
-    switch (lastEffect.target) {
+    switch (lastEffect.target || getDefaultTargetForEffect(lastEffect.type)) {
         case TargetTypes.OPPOSING_UNIT: {
             return otherPlayers.every((player) => player.units.length === 0);
         }

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -272,7 +272,7 @@ export const PIRATES_DECKLIST: DeckList = [
     { card: AdvancedResourceCards.HARBOR_TOWN, quantity: 4 },
     { card: AdvancedResourceCards.CITY_CANALS, quantity: 4 },
     { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
-    { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 20 },
+    { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 2 },
 ];
 
 // For debugging / gamebuilding purposes

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -272,7 +272,7 @@ export const PIRATES_DECKLIST: DeckList = [
     { card: AdvancedResourceCards.HARBOR_TOWN, quantity: 4 },
     { card: AdvancedResourceCards.CITY_CANALS, quantity: 4 },
     { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
-    { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 2 },
+    { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 20 },
 ];
 
 // For debugging / gamebuilding purposes

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -27,8 +27,8 @@ export enum DeckListSelections {
     MAGES_FIRE = 'Fire Mages 🔥',
     MAGES_WATER = 'Water Mages 🌊',
     MAGES_WIND = 'Wind Mages 💨',
-    PIRATES = 'Pirates 🏴‍☠️',
     MONKS = 'Monks 🤺',
+    PIRATES = 'Pirates 🏴‍☠️',
     RANDOM = 'Random ⁉️',
     SORCERORS = 'Sorcerors 🧙🏾‍♀️',
 }


### PR DESCRIPTION
Found this while play-testing.

Closes: #360

We had an issue where effects (like Old Farmhouse's "buff attack" effect) would linger on the game client if they didn't have a target type specified (we use `getDefaultTargetForEffect` for these types of effects).

Fixed this by adding the logic in for grabbing the default targets in the useEffect that handles fizzling the effects that don't have valid targets.

What the "linger" state looks like - game is unable to proceed:
<img width="1724" alt="Screen Shot 2023-02-21 at 8 12 15 AM" src="https://user-images.githubusercontent.com/1839462/220356072-6954277b-e26a-4129-9a98-755e443f6647.png">
