### PR TITLE
Feat: add helper text on cards

### DIFF
--- a/src/client/components/CardGridItem/CardGridItem.spec.tsx
+++ b/src/client/components/CardGridItem/CardGridItem.spec.tsx
@@ -6,7 +6,7 @@ import { makeCard, makeResourceCard } from '@/factories/cards';
 import { ResourceCard } from '@/types/cards';
 import { Resource } from '@/types/resources';
 
-import { CardGridItem } from './CardGridItem';
+import { CardGridItem, HelperText } from './CardGridItem';
 import { UnitCards } from '@/cardDb/units';
 import { SpellCards } from '@/cardDb/spells';
 import { AdvancedResourceCards } from '@/cardDb/resources/advancedResources';
@@ -33,6 +33,16 @@ describe('Card (Grid Item)', () => {
         expect(screen.getByText('Temple Guardian')).toBeInTheDocument();
         expect(screen.getByText('6 ⚔️')).toBeInTheDocument(); // attack
         expect(screen.getByText('7 💙')).toBeInTheDocument(); // health
+    });
+
+    it('renders help text', () => {
+        // difficult to mock hover action on card, so testing the component directly
+        render(<HelperText card={makeCard(UnitCards.TEMPLE_GUARDIAN)} />);
+        expect(
+            screen.getByText(
+                'Soldiers must be attacked by non-magical units first'
+            )
+        ).toBeInTheDocument();
     });
 
     it('renders a spell card', () => {

--- a/src/client/components/CardGridItem/CardGridItem.tsx
+++ b/src/client/components/CardGridItem/CardGridItem.tsx
@@ -79,6 +79,44 @@ export const CardGridSingleItem: React.FC<CardGridItemProps> = ({
     return undefined;
 };
 
+interface HelperTextProps {
+    card: Card;
+}
+
+export const HelperText = ({ card }: HelperTextProps): JSX.Element => {
+    if (card.cardType === CardType.UNIT) {
+        if (card.isSoldier) {
+            return (
+                <div style={{ width: 185, fontSize: 12, textAlign: 'center' }}>
+                    Soldiers must be attacked by non-magical units first
+                </div>
+            );
+        }
+
+        if (card.isMagical) {
+            return (
+                <div style={{ width: 185, fontSize: 12, textAlign: 'center' }}>
+                    Magical units act like ranged units (not taking damage on
+                    your turn from attacking non-ranged units).
+                    <br />
+                    <br />
+                    They are also not forced to attack soldiers first
+                </div>
+            );
+        }
+
+        if (card.isRanged) {
+            return (
+                <div style={{ width: 185, fontSize: 12, textAlign: 'center' }}>
+                    Ranged units do not take damage from attacking units on your
+                    turn (except other ranged + magical units)
+                </div>
+            );
+        }
+    }
+    return null;
+};
+
 export const CardGridItem: React.FC<CardGridItemProps> = ({
     card,
     hasTooltip,
@@ -129,6 +167,7 @@ export const CardGridItem: React.FC<CardGridItemProps> = ({
                         isOnBoard={isOnBoard}
                         card={cardModifiedForTooltip}
                     />
+                    {isOnBoard && <HelperText card={card} />}
                     <div
                         {...getArrowProps({
                             className: 'tooltip-arrow',

--- a/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
+++ b/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
@@ -4,12 +4,12 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useSWRConfig } from 'swr';
 
+import cookie from 'cookiejs';
 import { SavedDeck } from '@/types/deckBuilder';
 import { Colors } from '@/constants/colors';
 import { Skeleton } from '@/types/cards';
 import { getCleanName } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
-import cookie from 'cookiejs';
 
 type SavedDeckSquareProps = {
     savedDeck: SavedDeck;


### PR DESCRIPTION
Soldier, ranged, and magical are a little confusing to new players.  We added some help text to units on board to assist with displaying them
<img width="800" alt="Screen Shot 2023-02-24 at 6 11 52 AM" src="https://user-images.githubusercontent.com/1839462/221165186-05b6d66d-ca44-4167-a808-2905da364b68.png">
