### PR TITLE
Add clear deck functionality to deck builder

### DIFF
--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -80,6 +80,19 @@ describe('DeckBuilder', () => {
 
         expect(within(myDeck).getByText('4')).toBeInTheDocument();
     });
+
+    it('clears the whole deck', () => {
+        render(<DeckBuilder />);
+        const cardPool = screen.getByTestId('CardPool');
+        const myDeck = screen.getByTestId('CurrentDeck');
+
+        for (let i = 0; i < 5; i += 1) {
+            fireEvent.click(within(cardPool).getByText('Crystal'));
+        }
+        fireEvent.click(within(myDeck).getByText('Clear'));
+
+        expect(within(myDeck).queryAllByText('Crystal')).toHaveLength(0);
+    });
     it.todo('removes cards via a quantity selector');
 
     it('exports the decklist', () => {
@@ -282,9 +295,10 @@ describe('DeckBuilder', () => {
 
         it('clears the free text search field', () => {
             render(<DeckBuilder />, { useRealDispatch: true });
+            const cardPool = screen.getByTestId('CardPool');
             const searchBar = screen.getByTestId('Filters-FreeText');
             fireEvent.change(searchBar, { target: { value: 'star' } });
-            fireEvent.click(screen.getByText('Clear'));
+            fireEvent.click(within(cardPool).getByText('Clear'));
             expect(
                 screen.queryByText(UnitCards.LANCER.name)
             ).toBeInTheDocument();

--- a/src/client/components/DeckBuilder/DeckBuilder.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.tsx
@@ -192,6 +192,10 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
         dispatch(push('/'));
     };
 
+    const clearDeck = () => {
+        setCurrentDeck([]);
+    };
+
     const { isValid: isCurrentDeckValid, reason: reasonForDeckInvalid } =
         isDeckValidForFormat(currentDeck);
 
@@ -236,6 +240,10 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
                     />
                     <SecondaryColorButton onClick={importFile} zoom={0.8}>
                         Import File
+                    </SecondaryColorButton>{' '}
+                    &nbsp;&nbsp;
+                    <SecondaryColorButton onClick={clearDeck} zoom={0.8}>
+                        Clear
                     </SecondaryColorButton>{' '}
                     &nbsp;&nbsp;
                     <SecondaryColorButton

--- a/src/client/components/SavedDeckManager/SavedDeckManager.tsx
+++ b/src/client/components/SavedDeckManager/SavedDeckManager.tsx
@@ -88,7 +88,7 @@ export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
             </PrimaryColorButton>
             <hr />
             <DeckListGrid>
-                {savedDecks
+                {(savedDecks || ([] as SavedDeck[]))
                     ?.sort((deckA, deckB) =>
                         deckA.name
                             .toLowerCase()

--- a/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
+++ b/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
@@ -4,12 +4,12 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useSWRConfig } from 'swr';
 
+import cookie from 'cookiejs';
 import { SavedDeck } from '@/types/deckBuilder';
 import { Colors } from '@/constants/colors';
 import { Skeleton } from '@/types/cards';
 import { getCleanName } from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
-import cookie from 'cookiejs';
 
 type SavedDeckSquareProps = {
     savedDeck: SavedDeck;


### PR DESCRIPTION
this adds a 'clear' button to the deck builder, which was missing before.

Previously players had to exit the deck builder to clear their deck, which was a very time consuming process

https://user-images.githubusercontent.com/1839462/221165927-2110006e-2ade-410a-908b-9659c09de7b7.mov

