### PR TITLE
Feat: Add game recording

### DIFF
--- a/src/types/api/gameResults.ts
+++ b/src/types/api/gameResults.ts
@@ -1,0 +1,6 @@
+export type CreateGameResultsBody = {
+    guests: string[];
+    usernames: string[];
+    winningUsers: string[];
+    winningGuests: string[];
+};

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,0 +1,1 @@
+export * from './gameResults';


### PR DESCRIPTION
This adds an POST call to the DB server whenever a game is decided by a game action (either resolving effect or taking a game action, like attacking)

It does not* call the game recording if the game is decided by a disconnect (to prevent XP farming)