### PR TITLE
Fix: Don't crash on initial load for /me page

### DIFF
--- a/src/client/components/SelfProfilePage/SelfProfilePage.spec.tsx
+++ b/src/client/components/SelfProfilePage/SelfProfilePage.spec.tsx
@@ -1,0 +1,80 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import { SelfProfilePage } from './SelfProfilePage';
+
+jest.mock('@auth0/auth0-react', () => ({
+    __esModule: true,
+    useAuth0: () => ({
+        user: 'auth0|1234',
+    }),
+}));
+
+const server = setupServer(
+    rest.get('/api/levels', (_, res, ctx) => {
+        return res(
+            ctx.json([
+                {
+                    name: 'Angry Hen',
+                    level: 1,
+                    xpRequired: 0,
+                    image: 'https://monksandmages.com/images/units/angry-hen.webp',
+                },
+                {
+                    name: 'Manta Ray',
+                    level: 2,
+                    xpRequired: 15,
+                    image: 'https://monksandmages.com/images/units/manta-ray.webp',
+                },
+                {
+                    name: 'Bamboo Farmer',
+                    level: 3,
+                    xpRequired: 30,
+                    image: 'https://monksandmages.com/images/units/bamboo-farmer.webp',
+                },
+                {
+                    name: 'Gargoyle',
+                    level: 4,
+                    xpRequired: 50,
+                    image: 'https://monksandmages.com/images/units/gargoyle.webp',
+                },
+            ])
+        );
+    }),
+
+    rest.get('/api/users/self', (_, res, ctx) => {
+        return res(
+            ctx.json({
+                uid: 'auth0|1234',
+                username: 'groucho',
+                createdAt: '2023-02-25T08:41:41.258Z',
+                numberOfGamesWon: 0,
+                exp: 20,
+                avatarUrl: '',
+            })
+        );
+    }),
+
+    rest.get('/socket.io/', (_, res, ctx) => {
+        return res(ctx.json({}));
+    })
+);
+
+beforeAll(() => {
+    server.listen();
+});
+afterAll(() => {
+    server.close();
+});
+
+describe('Self Profile Page', () => {
+    it('displays available avatars', async () => {
+        render(<SelfProfilePage />);
+        expect(
+            await screen.findByTestId(
+                'Avatar-https://monksandmages.com/images/units/manta-ray.webp'
+            )
+        ).toBeInTheDocument();
+    });
+});

--- a/src/client/components/SelfProfilePage/SelfProfilePage.tsx
+++ b/src/client/components/SelfProfilePage/SelfProfilePage.tsx
@@ -43,13 +43,7 @@ const StackedProfileStat = styled.div`
 `;
 
 export const SelfProfilePage = (): JSX.Element => {
-    const {
-        currentLevel,
-        nextLevel,
-        data: selfData,
-        availableAvatars,
-        mutate,
-    } = useLoggedInPlayerInfo();
+    const loggedInPlayerInfo = useLoggedInPlayerInfo();
 
     const { trigger } = useSWRMutation<
         unknown,
@@ -62,23 +56,33 @@ export const SelfProfilePage = (): JSX.Element => {
         await trigger({
             avatarUrl: avatar,
         });
-        mutate();
+        loggedInPlayerInfo?.mutate();
     };
+
+    if (!loggedInPlayerInfo) {
+        return null;
+    }
+    const {
+        data: selfData,
+        currentLevel,
+        nextLevel,
+        availableAvatars,
+    } = loggedInPlayerInfo;
 
     const currentAvatar = selfData?.avatarUrl || DEFAULT_AVATAR;
 
     return (
         <CenterColumn>
-            <h1>{selfData.username}</h1>
+            <h1>{selfData?.username}</h1>
             <ProfileStats>
                 <StackedProfileStat>
                     <span>
-                        {new Date(selfData.createdAt).toLocaleDateString()}
+                        {new Date(selfData?.createdAt).toLocaleDateString()}
                     </span>
                     <h3 style={{ margin: 0 }}>Joined</h3>
                 </StackedProfileStat>
                 <StackedProfileStat>
-                    <span>{selfData.numberOfGamesWon}</span>
+                    <span>{selfData?.numberOfGamesWon}</span>
                     <h3 style={{ margin: 0 }}>Games won</h3>
                 </StackedProfileStat>
                 <StackedProfileStat>
@@ -87,7 +91,7 @@ export const SelfProfilePage = (): JSX.Element => {
                 </StackedProfileStat>
                 <StackedProfileStat>
                     <span>
-                        {selfData.exp}{' '}
+                        {selfData?.exp}{' '}
                         {nextLevel ? <>/ {nextLevel.xpRequired}</> : null}
                     </span>
                     <h3 style={{ margin: 0 }}>XP</h3>
@@ -109,6 +113,7 @@ export const SelfProfilePage = (): JSX.Element => {
                             }`,
                             cursor: 'pointer',
                         }}
+                        data-testid={`Avatar-${avatar}`}
                         onClick={onClickAvatar(avatar)}
                     >
                         <CardImage src={avatar} />


### PR DESCRIPTION
The Profile Page was crashing b/c the first load of the `useLoggedInPlayerInfo` hook was returning null.  Added some defensive programming checks to bail out early in the component if the returned value was null

Also: added a test for this to fix it fully:
<img width="600" alt="Screen Shot 2023-02-27 at 6 58 34 AM" src="https://user-images.githubusercontent.com/1839462/221558083-7bac4b9b-bab3-4c0d-8bcc-e719146b63f8.png">
