### PR TITLE
Feat: Display avatar names on profile page

### DIFF
--- a/src/client/components/SelfProfilePage/SelfProfilePage.tsx
+++ b/src/client/components/SelfProfilePage/SelfProfilePage.tsx
@@ -100,23 +100,26 @@ export const SelfProfilePage = (): JSX.Element => {
 
             <h3>Avatars Unlocked</h3>
             <Avatars>
-                {availableAvatars.map((avatar) => (
-                    <div
-                        key={avatar}
-                        style={{
-                            width: 260,
-                            height: 220,
-                            border: `5px solid ${
-                                avatar === currentAvatar
-                                    ? Colors.FIRE_ORANGE_EMPHASIZED
-                                    : Colors.LIGHT_GREY
-                            }`,
-                            cursor: 'pointer',
-                        }}
-                        data-testid={`Avatar-${avatar}`}
-                        onClick={onClickAvatar(avatar)}
-                    >
-                        <CardImage src={avatar} />
+                {availableAvatars.map(({ avatar, name }) => (
+                    <div style={{ textAlign: 'center' }}>
+                        <div
+                            key={avatar}
+                            style={{
+                                width: 260,
+                                height: 220,
+                                border: `5px solid ${
+                                    avatar === currentAvatar
+                                        ? Colors.FIRE_ORANGE_EMPHASIZED
+                                        : Colors.LIGHT_GREY
+                                }`,
+                                cursor: 'pointer',
+                            }}
+                            data-testid={`Avatar-${avatar}`}
+                            onClick={onClickAvatar(avatar)}
+                        >
+                            <CardImage src={avatar} />
+                        </div>
+                        <span>{name}</span>
                     </div>
                 ))}
             </Avatars>

--- a/src/client/hooks/useLoggedInPlayerInfo.ts
+++ b/src/client/hooks/useLoggedInPlayerInfo.ts
@@ -1,7 +1,12 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import useSWR from 'swr';
 import { fetcher } from '@/apiHelpers';
-import { DEFAULT_AVATAR, Level, UserPlayer } from '@/types/players';
+import {
+    DEFAULT_AVATAR,
+    DEFAULT_AVATAR_NAME,
+    Level,
+    UserPlayer,
+} from '@/types/players';
 
 const getLevels = (player: UserPlayer | null, levels: Level[] | null) => {
     if (!player || !levels) return null;
@@ -40,8 +45,14 @@ export const useLoggedInPlayerInfo = () => {
         levelsData
     );
     const availableAvatars = [
-        DEFAULT_AVATAR,
-        ...levelsAttained.map((level) => level.image),
+        {
+            name: DEFAULT_AVATAR_NAME,
+            avatar: DEFAULT_AVATAR,
+        },
+        ...levelsAttained.map((level) => ({
+            name: `Level ${level.level} - ${level.name}`,
+            avatar: level.image,
+        })),
     ];
     return {
         currentLevel,

--- a/src/types/players.ts
+++ b/src/types/players.ts
@@ -21,3 +21,5 @@ export type UserPlayer = {
 
 export const DEFAULT_AVATAR =
     'https://monksandmages.com/images/units/alert-feline.webp';
+
+export const DEFAULT_AVATAR_NAME = 'Alert Feline';


### PR DESCRIPTION
<img width="700" alt="Screen Shot 2023-02-28 at 4 28 40 AM" src="https://user-images.githubusercontent.com/1839462/221810697-716251eb-b195-44a7-9564-cee90580d7f8.png">

New: adding the bottom text to the avatars in the profile page (displaying the names of the avatars / associated levels)