### PR TITLE
Feat: Highlight the selected deck

### DIFF
--- a/src/client/components/CenterPromptBox/CenterPromptBox.spec.tsx
+++ b/src/client/components/CenterPromptBox/CenterPromptBox.spec.tsx
@@ -145,6 +145,7 @@ describe('Center Prompt Box', () => {
 
             const { dispatch, webSocket } = render(<CenterPromptBox />, {
                 preloadedState,
+                useRealDispatch: false,
             });
             fireEvent.click(screen.getByText('Return to Lobby'));
             expect(dispatch).toHaveBeenCalledWith(push('/'));

--- a/src/client/components/CompactDeckList/CompactDeckList.spec.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import { CompactDeckList } from './CompactDeckList';
 import { makeSampleDeck1 } from '@/factories/deck';
+import { render } from '@/test-utils';
 
 describe('DeckList', () => {
     it('renders a deck', () => {

--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import styled from 'styled-components';
 
+import { useDispatch } from 'react-redux';
 import { Card, CardType } from '@/types/cards';
 import { splitDeckListToPiles } from '@/transformers/splitDeckListToPiles';
 import { QuantitySelector } from '../QuantitySelector';
@@ -14,6 +15,7 @@ import {
 import { RESOURCE_GLOSSARY } from '@/types/resources';
 import { CardGridSingleItem } from '../CardGridItem';
 import { Colors } from '@/constants/colors';
+import { addCard } from '@/client/redux/deckBuilder';
 
 interface CompactDeckListProps {
     deck: Card[];
@@ -79,17 +81,16 @@ const CostCell = styled.div`
 
 type MiniCardProps = {
     card: Card;
-    onClickCard: (card: Card) => void;
     quantity: number;
     shouldShowQuantity: boolean;
 };
 
 const MiniCard: React.FC<MiniCardProps> = ({
     card,
-    onClickCard,
     quantity,
     shouldShowQuantity,
 }) => {
+    const dispatch = useDispatch();
     const {
         getArrowProps,
         getTooltipProps,
@@ -105,16 +106,17 @@ const MiniCard: React.FC<MiniCardProps> = ({
         card.cardType === CardType.RESOURCE ? { ...card, isUsed: false } : card;
 
     const { primaryColor, secondaryColor } = getColorsForCard(card);
+    const onAddCard = () => {
+        dispatch(addCard(card));
+    };
 
     return (
         <>
             <MiniCardFrame
-                hasOnClick={!!onClickCard}
+                hasOnClick={true}
                 primaryColor={primaryColor}
                 secondaryColor={secondaryColor}
-                onClick={() => {
-                    onClickCard(card);
-                }}
+                onClick={onAddCard}
                 tabIndex={0}
                 ref={setTriggerRef}
             >
@@ -169,7 +171,6 @@ const MiniCard: React.FC<MiniCardProps> = ({
 
 export const CompactDeckList: React.FC<CompactDeckListProps> = ({
     deck,
-    onClickCard,
     shouldShowQuantity = true,
 }) => {
     const piles = splitDeckListToPiles(deck);
@@ -183,7 +184,6 @@ export const CompactDeckList: React.FC<CompactDeckListProps> = ({
                             card={card}
                             quantity={quantity}
                             shouldShowQuantity={shouldShowQuantity}
-                            onClickCard={onClickCard}
                             key={card.name}
                         />
                     ))}

--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -35,11 +35,13 @@ describe('DeckBuilder', () => {
     beforeAll(() => {
         HTMLAnchorElement.prototype.click = jest.fn();
     });
-    it('adds cards from the entire card pool (constructed mode)', () => {
+    it.only('adds cards from the entire card pool (constructed mode)', async () => {
         render(<DeckBuilder />);
         fireEvent.click(screen.getByText('Lancer'));
         expect(
-            within(screen.getByTestId('CurrentDeck')).getByText('Lancer')
+            await within(await screen.findByTestId('CurrentDeck')).findByText(
+                'Lancer'
+            )
         ).toBeInTheDocument();
     });
     // it.todo('adds cards from a filtered card pool');
@@ -261,7 +263,7 @@ describe('DeckBuilder', () => {
 
     describe('Search filters', () => {
         it('searches by free text on card titles', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
             const searchBar = screen.getByTestId('Filters-FreeText');
             fireEvent.change(searchBar, { target: { value: 'star' } });
             expect(screen.queryByText(UnitCards.LANCER.name)).toBeNull();
@@ -271,7 +273,7 @@ describe('DeckBuilder', () => {
         });
 
         it('searches by rules text', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
             const searchBar = screen.getByTestId('Filters-FreeText');
             fireEvent.change(searchBar, { target: { value: 'Poison' } });
             expect(
@@ -283,7 +285,7 @@ describe('DeckBuilder', () => {
         });
 
         it('searches by resource cost', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
 
             fireEvent.click(screen.getByTestId('Filters-ResourceCost-2'));
 
@@ -294,7 +296,7 @@ describe('DeckBuilder', () => {
         });
 
         it('clears the free text search field', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
             const cardPool = screen.getByTestId('CardPool');
             const searchBar = screen.getByTestId('Filters-FreeText');
             fireEvent.change(searchBar, { target: { value: 'star' } });
@@ -308,7 +310,7 @@ describe('DeckBuilder', () => {
         });
 
         it('searches by colors (exactly)', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
 
             fireEvent.change(
                 screen.getByTestId('Filters-ResourcesMatchStrategy'),
@@ -333,7 +335,7 @@ describe('DeckBuilder', () => {
         });
 
         it('searches by colors (strictly)', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
 
             fireEvent.change(
                 screen.getByTestId('Filters-ResourcesMatchStrategy'),
@@ -358,7 +360,7 @@ describe('DeckBuilder', () => {
         });
 
         it('searches by colors (loosely)', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
 
             fireEvent.change(
                 screen.getByTestId('Filters-ResourcesMatchStrategy'),
@@ -383,7 +385,7 @@ describe('DeckBuilder', () => {
         });
 
         it('filters by unit type', () => {
-            render(<DeckBuilder />, { useRealDispatch: true });
+            render(<DeckBuilder />);
 
             fireEvent.click(screen.getByText('⚔️'));
             fireEvent.click(screen.getByText('🪄'));

--- a/src/client/components/DeckBuilder/DeckBuilder.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'redux-first-history';
@@ -9,15 +9,9 @@ import { TopNavBar } from '../TopNavBar';
 import { makeDeck } from '@/factories/deck';
 import { ALL_CARDS } from '@/constants/deckLists';
 import { CompactDeckList } from '../CompactDeckList';
-import {
-    Card,
-    CardType,
-    DeckList as DeckListType,
-    Skeleton,
-} from '@/types/cards';
+import { Card, DeckList as DeckListType, Skeleton } from '@/types/cards';
 import { SecondaryColorButton } from '../Button';
 import { getSkeletonFromDeckList } from '@/transformers/getSkeletonFromDeckList';
-import { getDeckListFromSkeleton } from '@/transformers/getDeckListFromSkeleton';
 import { WebSocketContext } from '../WebSockets';
 import { RootState } from '@/client/redux/store';
 import { isDeckValidForFormat } from '@/transformers/isDeckValidForFomat';
@@ -26,7 +20,8 @@ import { DeckBuilderFilters } from '../DeckBuilderFilters';
 import { filterCards } from '@/transformers/filterCards';
 import { Filters } from '@/types/deckBuilder';
 import { SavedDeckManager } from '../SavedDeckManager';
-import { getAuth0Id } from '@/client/redux/selectors';
+import { getAuth0Id, getDeckList } from '@/client/redux/selectors';
+import { clearDeck, loadDeck } from '@/client/redux/deckBuilder';
 
 const DeckListContainers = styled.div`
     display: grid;
@@ -55,18 +50,16 @@ const ValidationMsg = styled.div`
 
 type DeckBuilderProps = {
     cardPool?: Card[];
-    isConstructed?: boolean;
 };
 
 export const DeckBuilder: React.FC<DeckBuilderProps> = ({
     cardPool = makeDeck(ALL_CARDS),
-    isConstructed = true,
 }) => {
-    const [currentDeck, setCurrentDeck] = useState<DeckListType>([]);
     const webSocket = useContext(WebSocketContext);
     const skeleton = useSelector<RootState, Skeleton>(
         (state) => state.deckList.customDeckList
     );
+    const currentDeck = useSelector<RootState, DeckListType>(getDeckList);
     const dispatch = useDispatch();
     const fileInputEl = useRef<HTMLInputElement>(null);
     const filters = useSelector<RootState, Filters>(
@@ -76,51 +69,9 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
 
     useEffect(() => {
         if (skeleton) {
-            setCurrentDeck(getDeckListFromSkeleton(skeleton).decklist);
+            dispatch(loadDeck(skeleton));
         }
     }, []);
-
-    const setSkeleton = (newSkeleton: Skeleton) => {
-        setCurrentDeck(getDeckListFromSkeleton(newSkeleton).decklist);
-    };
-
-    const addCard = (card: Card) => {
-        const isCardNotBasicResource = !(
-            card.cardType === CardType.RESOURCE && !card.isAdvanced
-        );
-
-        const matchingCardSlot = currentDeck.find(
-            (cardSlot) => cardSlot.card.name === card.name
-        );
-
-        // on constructed mode, everything except basic resourcs is capped at 4
-        if (
-            isConstructed &&
-            isCardNotBasicResource &&
-            matchingCardSlot &&
-            matchingCardSlot.quantity >= 4
-        )
-            return;
-
-        if (matchingCardSlot) {
-            matchingCardSlot.quantity += 1;
-        } else {
-            currentDeck.push({ card, quantity: 1 });
-        }
-        setCurrentDeck([...currentDeck]);
-    };
-    const removeCard = (card: Card) => {
-        const matchingCardSlot = currentDeck.find(
-            (cardSlot) => cardSlot.card.name === card.name
-        );
-
-        if (matchingCardSlot) {
-            matchingCardSlot.quantity -= 1;
-        }
-        setCurrentDeck([
-            ...currentDeck.filter((cardSlot) => cardSlot.quantity > 0),
-        ]);
-    };
 
     const copyToClipboard = () => {
         navigator.clipboard.writeText(
@@ -143,15 +94,7 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
 
     const importDeckList = (txtBlob: string) => {
         try {
-            const { decklist, errors } = getDeckListFromSkeleton(
-                JSON.parse(txtBlob)
-            );
-            if (!errors?.length) {
-                setCurrentDeck(decklist);
-            } else {
-                // eslint-disable-next-line no-alert
-                window.alert(`Error found in decklist: ${errors[0]}`);
-            }
+            dispatch(loadDeck(JSON.parse(txtBlob)));
         } catch (error) {
             if (error.name === 'SyntaxError') {
                 // eslint-disable-next-line no-alert
@@ -192,8 +135,8 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
         dispatch(push('/'));
     };
 
-    const clearDeck = () => {
-        setCurrentDeck([]);
+    const onClickClearDeck = () => {
+        dispatch(clearDeck);
     };
 
     const { isValid: isCurrentDeckValid, reason: reasonForDeckInvalid } =
@@ -209,11 +152,7 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
                 <DeckListBackDrop data-testid="CardPool">
                     <DeckBuilderFilters />
                     {deck.length}
-                    <CompactDeckList
-                        deck={deck}
-                        shouldShowQuantity={false}
-                        onClickCard={addCard}
-                    />
+                    <CompactDeckList deck={deck} shouldShowQuantity={false} />
                 </DeckListBackDrop>
                 <DeckListBackDrop data-testid="CurrentDeck">
                     <SecondaryColorButton onClick={copyToClipboard} zoom={0.8}>
@@ -242,7 +181,7 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
                         Import File
                     </SecondaryColorButton>{' '}
                     &nbsp;&nbsp;
-                    <SecondaryColorButton onClick={clearDeck} zoom={0.8}>
+                    <SecondaryColorButton onClick={onClickClearDeck} zoom={0.8}>
                         Clear
                     </SecondaryColorButton>{' '}
                     &nbsp;&nbsp;
@@ -256,18 +195,9 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
                     <br />
                     <ValidationMsg>{reasonForDeckInvalid}</ValidationMsg>
                     <br />
-                    <DeckList
-                        deck={makeDeck(currentDeck)}
-                        addCard={addCard}
-                        removeCard={removeCard}
-                    />
+                    <DeckList deck={makeDeck(currentDeck)} />
                 </DeckListBackDrop>
-                {auth0Id && (
-                    <SavedDeckManager
-                        decklist={currentDeck}
-                        setSkeleton={setSkeleton}
-                    />
-                )}
+                {auth0Id && <SavedDeckManager decklist={currentDeck} />}
             </DeckListContainers>
         </>
     );

--- a/src/client/components/DeckList/DeckList.tsx
+++ b/src/client/components/DeckList/DeckList.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { useDispatch } from 'react-redux';
 import { Card, PileOfCards } from '@/types/cards';
 import { splitDeckListToPiles } from '@/transformers/splitDeckListToPiles';
 import { CardGridItem } from '../CardGridItem';
 import { QuantitySelector } from '../QuantitySelector';
+import { removeCard } from '@/client/redux/deckBuilder';
 
 interface DeckListProps {
-    addCard?: (card: Card) => void;
     deck: Card[];
-    removeCard?: (card: Card) => void;
     shouldShowQuantity?: boolean;
     shouldShowSummary?: boolean;
 }
@@ -59,10 +59,14 @@ const getTotalCardsInPile = (pile: PileOfCards): number => {
 
 export const DeckList: React.FC<DeckListProps> = ({
     deck,
-    removeCard,
     shouldShowQuantity = true,
     shouldShowSummary = true,
 }) => {
+    const dispatch = useDispatch();
+    const onRemoveCard = (card: Card) => {
+        dispatch(removeCard(card));
+    };
+
     if (deck.length === 0) {
         return <Centering />;
     }
@@ -102,7 +106,7 @@ export const DeckList: React.FC<DeckListProps> = ({
                                     <CardGridItem
                                         card={card}
                                         onClick={() => {
-                                            removeCard?.(card);
+                                            onRemoveCard(card);
                                         }}
                                     />
                                 </DeckListCardSlot>

--- a/src/client/components/SavedDeckManager/SavedDeckManager.tsx
+++ b/src/client/components/SavedDeckManager/SavedDeckManager.tsx
@@ -11,7 +11,7 @@ import { SavedDeck } from '@/types/deckBuilder';
 import { getSkeletonFromDeckList } from '@/transformers/getSkeletonFromDeckList';
 import { fetcher } from '@/apiHelpers';
 import { SavedDeckSquare } from '@/client/components/SavedDeckSquare';
-import { DeckList, Skeleton } from '@/types/cards';
+import { DeckList } from '@/types/cards';
 import { PrimaryColorButton } from '../Button';
 
 const Backdrop = styled.div`
@@ -32,12 +32,10 @@ const DeckListGrid = styled.div`
 
 type SavedDeckManagerProps = {
     decklist: DeckList;
-    setSkeleton: (decklist: Skeleton) => void;
 };
 
 export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
     decklist,
-    setSkeleton,
 }) => {
     const { mutate } = useSWRConfig();
 
@@ -98,7 +96,6 @@ export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
                         <SavedDeckSquare
                             key={savedDeck.id}
                             savedDeck={savedDeck}
-                            setSkeleton={setSkeleton}
                         />
                     ))}
             </DeckListGrid>

--- a/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
+++ b/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
@@ -25,7 +25,7 @@ type OutlineProps = {
 };
 
 const SavedDeckOutline = styled.div<OutlineProps>`
-    border: 1px solid
+    border: ${({ isHighlighted }) => (isHighlighted ? 3 : 1)}px solid
         ${({ isHighlighted }) =>
             isHighlighted ? Colors.FOCUS_BLUE : Colors.LIGHT_GREY};
     :not(:last-child) {

--- a/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
+++ b/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useSWRConfig } from 'swr';
 
@@ -8,16 +8,26 @@ import cookie from 'cookiejs';
 import { SavedDeck } from '@/types/deckBuilder';
 import { Colors } from '@/constants/colors';
 import { Skeleton } from '@/types/cards';
-import { getCleanName } from '@/client/redux/selectors';
+import {
+    getCleanName,
+    getCurrentSavedDeckName,
+} from '@/client/redux/selectors';
 import { RootState } from '@/client/redux/store';
+import { chooseSavedDeck } from '@/client/redux/deckBuilder';
 
 type SavedDeckSquareProps = {
     savedDeck: SavedDeck;
     setSkeleton: (decklist: Skeleton) => void;
 };
 
-const SavedDeckOutline = styled.div`
-    border: 1px solid ${Colors.LIGHT_GREY};
+type OutlineProps = {
+    isHighlighted: boolean;
+};
+
+const SavedDeckOutline = styled.div<OutlineProps>`
+    border: 1px solid
+        ${({ isHighlighted }) =>
+            isHighlighted ? Colors.FOCUS_BLUE : Colors.LIGHT_GREY};
     :not(:last-child) {
         border-right: none;
     }
@@ -39,11 +49,15 @@ const deleteDeckFn = async (username: string, deckId: string) =>
     });
 
 export const SavedDeckSquare: React.FC<SavedDeckSquareProps> = ({
-    savedDeck: { name, skeleton, id },
+    savedDeck,
     setSkeleton,
 }) => {
+    const { name, skeleton, id } = savedDeck;
     const username = useSelector<RootState, string | undefined>(getCleanName);
-
+    const dispatch = useDispatch();
+    const currentSavedDeckName = useSelector<RootState, string>(
+        getCurrentSavedDeckName
+    );
     const { mutate } = useSWRConfig();
 
     const deleteDeck = async () => {
@@ -63,11 +77,17 @@ export const SavedDeckSquare: React.FC<SavedDeckSquareProps> = ({
                 tabIndex={0}
                 onClick={() => {
                     setSkeleton(skeleton);
+                    dispatch(chooseSavedDeck(savedDeck));
                 }}
+                isHighlighted={currentSavedDeckName === name}
             >
                 <b>{name}</b>
             </SavedDeckOutline>
-            <SavedDeckOutline tabIndex={0} onClick={deleteDeck}>
+            <SavedDeckOutline
+                tabIndex={0}
+                onClick={deleteDeck}
+                isHighlighted={currentSavedDeckName === name}
+            >
                 🗑
             </SavedDeckOutline>
         </HStack>

--- a/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
+++ b/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
@@ -7,7 +7,6 @@ import { useSWRConfig } from 'swr';
 import cookie from 'cookiejs';
 import { SavedDeck } from '@/types/deckBuilder';
 import { Colors } from '@/constants/colors';
-import { Skeleton } from '@/types/cards';
 import {
     getCleanName,
     getCurrentSavedDeckName,
@@ -17,7 +16,6 @@ import { chooseSavedDeck } from '@/client/redux/deckBuilder';
 
 type SavedDeckSquareProps = {
     savedDeck: SavedDeck;
-    setSkeleton: (decklist: Skeleton) => void;
 };
 
 type OutlineProps = {
@@ -50,9 +48,8 @@ const deleteDeckFn = async (username: string, deckId: string) =>
 
 export const SavedDeckSquare: React.FC<SavedDeckSquareProps> = ({
     savedDeck,
-    setSkeleton,
 }) => {
-    const { name, skeleton, id } = savedDeck;
+    const { name, id } = savedDeck;
     const username = useSelector<RootState, string | undefined>(getCleanName);
     const dispatch = useDispatch();
     const currentSavedDeckName = useSelector<RootState, string>(
@@ -76,7 +73,6 @@ export const SavedDeckSquare: React.FC<SavedDeckSquareProps> = ({
             <SavedDeckOutline
                 tabIndex={0}
                 onClick={() => {
-                    setSkeleton(skeleton);
                     dispatch(chooseSavedDeck(savedDeck));
                 }}
                 isHighlighted={currentSavedDeckName === name}

--- a/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
+++ b/src/client/components/SelfPlayerInfo/SelfPlayerInfo.spec.tsx
@@ -59,27 +59,7 @@ describe('Self Player Board', () => {
         };
         const { dispatch, webSocket } = render(<SelfPlayerInfo />, {
             preloadedState,
-        });
-        fireEvent.click(screen.getByText('Pass Turn'));
-        expect(dispatch).toHaveBeenCalledWith(passTurn());
-        expect(dispatch).toHaveBeenCalledWith(passTurn());
-        expect(webSocket.takeGameAction).toHaveBeenCalledWith({
-            type: GameActionTypes.PASS_TURN,
-        });
-    });
-
-    it("passes the turn if you're the active player", () => {
-        const preloadedState: Partial<RootState> = {
-            user: {
-                name: 'Melvin',
-            },
-            board: makeNewBoard({
-                playerNames: ['Melvin', 'Melissa'],
-                startingPlayerIndex: 0,
-            }),
-        };
-        const { dispatch, webSocket } = render(<SelfPlayerInfo />, {
-            preloadedState,
+            useRealDispatch: false,
         });
         fireEvent.click(screen.getByText('Pass Turn'));
         expect(dispatch).toHaveBeenCalledWith(passTurn());

--- a/src/client/components/SelfProfilePage/SelfProfilePage.spec.tsx
+++ b/src/client/components/SelfProfilePage/SelfProfilePage.spec.tsx
@@ -72,9 +72,7 @@ describe('Self Profile Page', () => {
     it('displays available avatars', async () => {
         render(<SelfProfilePage />);
         expect(
-            await screen.findByTestId(
-                'Avatar-https://monksandmages.com/images/units/manta-ray.webp'
-            )
+            await screen.findByText('Level 2 - Manta Ray')
         ).toBeInTheDocument();
     });
 });

--- a/src/client/components/SelfProfilePage/SelfProfilePage.tsx
+++ b/src/client/components/SelfProfilePage/SelfProfilePage.tsx
@@ -101,9 +101,8 @@ export const SelfProfilePage = (): JSX.Element => {
             <h3>Avatars Unlocked</h3>
             <Avatars>
                 {availableAvatars.map(({ avatar, name }) => (
-                    <div style={{ textAlign: 'center' }}>
+                    <div style={{ textAlign: 'center' }} key={name}>
                         <div
-                            key={avatar}
                             style={{
                                 width: 260,
                                 height: 220,

--- a/src/client/redux/deckBuilder/deckBuilder.ts
+++ b/src/client/redux/deckBuilder/deckBuilder.ts
@@ -1,14 +1,21 @@
 import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
-import { DeckListSelections } from '@/constants/lobbyConstants';
-import { Skeleton } from '@/types/cards';
 import { SavedDeck } from '@/types/deckBuilder';
+import { Card, CardType, DeckList, Skeleton } from '@/types/cards';
+import { getDeckListFromSkeleton } from '@/transformers/getDeckListFromSkeleton';
+import { Format, isFormatConstructed } from '@/types/games';
 
 type DeckBuilderState = {
+    currentSavedDeckId: string;
     currentSavedDeckName: string;
+    decklist: DeckList;
+    format: Format;
 };
 
 const initialState: DeckBuilderState = {
     currentSavedDeckName: '',
+    currentSavedDeckId: '',
+    decklist: [],
+    format: Format.STANDARD,
 };
 
 export const deckBuilderSlice = createSlice({
@@ -16,7 +23,68 @@ export const deckBuilderSlice = createSlice({
     initialState,
     reducers: {
         chooseSavedDeck(state, action: PayloadAction<SavedDeck>) {
-            state.currentSavedDeckName = action.payload.name;
+            const { skeleton, name, id } = action.payload;
+            state.currentSavedDeckName = name;
+            state.currentSavedDeckId = id;
+
+            const { decklist } = getDeckListFromSkeleton(skeleton);
+            // if a valid decklist returned - sometimes it will be corrupted
+            if (decklist) {
+                state.decklist = decklist;
+            }
+        },
+        loadDeck(state, action: PayloadAction<Skeleton>) {
+            const { decklist } = getDeckListFromSkeleton(action.payload);
+
+            if (decklist) {
+                state.decklist = decklist;
+            }
+        },
+        addCard(state, action: PayloadAction<Card>) {
+            const card = action.payload;
+            const isCardNotBasicResource = !(
+                card.cardType === CardType.RESOURCE && !card.isAdvanced
+            );
+            const { decklist } = state;
+
+            const matchingCardSlot = decklist.find(
+                (cardSlot) => cardSlot.card.name === card.name
+            );
+            const isConstructed = isFormatConstructed(state.format);
+
+            // on constructed mode, everything except basic resourcs is capped at 4
+            if (
+                isConstructed &&
+                isCardNotBasicResource &&
+                matchingCardSlot &&
+                matchingCardSlot.quantity >= 4
+            ) {
+                return;
+            }
+
+            if (matchingCardSlot) {
+                matchingCardSlot.quantity += 1;
+            } else {
+                decklist.push({ card, quantity: 1 });
+            }
+            state.decklist = decklist;
+        },
+        removeCard(state, action: PayloadAction<Card>) {
+            const card = action.payload;
+            const { decklist } = state;
+            const matchingCardSlot = decklist.find(
+                (cardSlot) => cardSlot.card.name === card.name
+            );
+
+            if (matchingCardSlot) {
+                matchingCardSlot.quantity -= 1;
+            }
+            state.decklist = [
+                ...decklist.filter((cardSlot) => cardSlot.quantity > 0),
+            ];
+        },
+        clearDeck(state) {
+            state.decklist = [];
         },
     },
 });
@@ -24,4 +92,5 @@ export const deckBuilderSlice = createSlice({
 export const deckBuilderReducer: Reducer<DeckBuilderState> =
     deckBuilderSlice.reducer;
 
-export const { chooseSavedDeck } = deckBuilderSlice.actions;
+export const { chooseSavedDeck, loadDeck, addCard, removeCard, clearDeck } =
+    deckBuilderSlice.actions;

--- a/src/client/redux/deckBuilder/deckBuilder.ts
+++ b/src/client/redux/deckBuilder/deckBuilder.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
+import { DeckListSelections } from '@/constants/lobbyConstants';
+import { Skeleton } from '@/types/cards';
+import { SavedDeck } from '@/types/deckBuilder';
+
+type DeckBuilderState = {
+    currentSavedDeckName: string;
+};
+
+const initialState: DeckBuilderState = {
+    currentSavedDeckName: '',
+};
+
+export const deckBuilderSlice = createSlice({
+    name: 'deckList',
+    initialState,
+    reducers: {
+        chooseSavedDeck(state, action: PayloadAction<SavedDeck>) {
+            state.currentSavedDeckName = action.payload.name;
+        },
+    },
+});
+
+export const deckBuilderReducer: Reducer<DeckBuilderState> =
+    deckBuilderSlice.reducer;
+
+export const { chooseSavedDeck } = deckBuilderSlice.actions;

--- a/src/client/redux/deckBuilder/index.ts
+++ b/src/client/redux/deckBuilder/index.ts
@@ -1,0 +1,1 @@
+export * from './deckBuilder';

--- a/src/client/redux/selectors/deckBuilder.ts
+++ b/src/client/redux/selectors/deckBuilder.ts
@@ -1,0 +1,11 @@
+import { DeckList } from '@/types/cards';
+import { RootState } from '../store';
+
+export const getCurrentSavedDeckName = (state: Partial<RootState>): string =>
+    state.deckBuilder.currentSavedDeckName;
+
+export const getCurrentSavedDeckId = (state: Partial<RootState>): string =>
+    state.deckBuilder.currentSavedDeckId;
+
+export const getDeckList = (state: Partial<RootState>): DeckList =>
+    state.deckBuilder.decklist;

--- a/src/client/redux/selectors/deckList.ts
+++ b/src/client/redux/selectors/deckList.ts
@@ -1,4 +1,0 @@
-import { RootState } from '../store';
-
-export const getCurrentSavedDeckName = (state: Partial<RootState>): string =>
-    state.deckBuilder.currentSavedDeckName;

--- a/src/client/redux/selectors/deckList.ts
+++ b/src/client/redux/selectors/deckList.ts
@@ -1,0 +1,4 @@
+import { RootState } from '../store';
+
+export const getCurrentSavedDeckName = (state: Partial<RootState>): string =>
+    state.deckBuilder.currentSavedDeckName;

--- a/src/client/redux/selectors/index.ts
+++ b/src/client/redux/selectors/index.ts
@@ -1,1 +1,2 @@
 export * from './selectors';
+export * from './deckList';

--- a/src/client/redux/selectors/index.ts
+++ b/src/client/redux/selectors/index.ts
@@ -1,2 +1,2 @@
 export * from './selectors';
-export * from './deckList';
+export * from './deckBuilder';

--- a/src/client/redux/store.ts
+++ b/src/client/redux/store.ts
@@ -9,6 +9,7 @@ import { userReducer, userSlice } from './user';
 import { clientSideGameExtrasReducer } from './clientSideGameExtras';
 import { deckListReducer, deckListSlice } from './deckList';
 import { deckBuilderFiltersReducer } from './deckBuilderFilters';
+import { deckBuilderReducer, deckBuilderSlice } from './deckBuilder';
 
 const { createReduxHistory, routerMiddleware, routerReducer } =
     createReduxHistoryContext({
@@ -20,6 +21,7 @@ export const createRootReducer = () =>
         board: boardReducer,
         clientSideGameExtras: clientSideGameExtrasReducer,
         deckBuilderFilters: deckBuilderFiltersReducer,
+        deckBuilder: deckBuilderReducer,
         deckList: deckListReducer,
         router: routerReducer,
         lobby: lobbyReducer,
@@ -29,6 +31,7 @@ export const createRootReducer = () =>
 const preloadedState = {
     user: userSlice.getInitialState(),
     deckList: deckListSlice.getInitialState(),
+    deckBuilder: deckBuilderSlice.getInitialState(),
 };
 
 // Used for production

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -65,7 +65,7 @@ export function render(
     ui: ReactElement,
     {
         preloadedState = {},
-        useRealDispatch = false,
+        useRealDispatch = true,
         ...renderOptions
     }: ReduxRenderOptions = {}
 ): RenderValue {

--- a/src/types/games.ts
+++ b/src/types/games.ts
@@ -9,3 +9,6 @@ export enum Format {
     SINGLETON = 'SINGLETON',
     STANDARD = 'STANDARD',
 }
+
+export const isFormatConstructed = (format: Format) =>
+    [Format.SINGLETON, Format.STANDARD].includes(format);


### PR DESCRIPTION
Made a big refactor to use redux everywhere for the deck builder in order to add highlighted state to the Saved Deck component.

This was done in preparation for #389, as in order to let users edit a deck, we need to have a concept of which deck it is that they're editing

It makes the most sense to do this all inside of Redux because:
1.) It's easy to visually inspect and debug
2.) We were doing a bunch of prop pass-downs inside of the DeckBuilder's component tree.  This allows us to lift state up into redux and not do those pass-downs (e.g. addCard, removeCard, setSkeleton, etc.)

https://user-images.githubusercontent.com/1839462/221841354-2d39917f-5ce3-48f5-af72-bed6c24f68df.mov

