### PR TITLE
Feat: allow users to update existing decks

### DIFF
--- a/src/client/components/SavedDeckManager/SavedDeckManager.tsx
+++ b/src/client/components/SavedDeckManager/SavedDeckManager.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import useSWR, { useSWRConfig } from 'swr';
 
@@ -13,6 +13,7 @@ import { fetcher } from '@/apiHelpers';
 import { SavedDeckSquare } from '@/client/components/SavedDeckSquare';
 import { DeckList } from '@/types/cards';
 import { PrimaryColorButton } from '../Button';
+import { saveNewDeck } from '@/client/redux/deckBuilder';
 
 const Backdrop = styled.div`
     background: rgba(255, 255, 255, 0.8);
@@ -38,6 +39,7 @@ export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
     decklist,
 }) => {
     const { mutate } = useSWRConfig();
+    const dispatch = useDispatch();
 
     const [deckName, setDeckName] = useState('');
     const username = useSelector<RootState, string | undefined>(getCleanName);
@@ -48,7 +50,7 @@ export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
 
     const createDeck = async () => {
         try {
-            await axios.post(
+            const savedDeck = await axios.post<SavedDeck>(
                 '/api/saved_decks',
                 {
                     username,
@@ -61,6 +63,7 @@ export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
                     },
                 }
             );
+            dispatch(saveNewDeck(savedDeck.data));
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error);

--- a/src/client/redux/deckBuilder/deckBuilder.ts
+++ b/src/client/redux/deckBuilder/deckBuilder.ts
@@ -9,6 +9,7 @@ type DeckBuilderState = {
     currentSavedDeckName: string;
     decklist: DeckList;
     format: Format;
+    isSavedDeckAltered: boolean;
 };
 
 const initialState: DeckBuilderState = {
@@ -16,6 +17,7 @@ const initialState: DeckBuilderState = {
     currentSavedDeckId: '',
     decklist: [],
     format: Format.STANDARD,
+    isSavedDeckAltered: false,
 };
 
 export const deckBuilderSlice = createSlice({
@@ -32,6 +34,7 @@ export const deckBuilderSlice = createSlice({
             if (decklist) {
                 state.decklist = decklist;
             }
+            state.isSavedDeckAltered = false;
         },
         loadDeck(state, action: PayloadAction<Skeleton>) {
             const { decklist } = getDeckListFromSkeleton(action.payload);
@@ -39,6 +42,21 @@ export const deckBuilderSlice = createSlice({
             if (decklist) {
                 state.decklist = decklist;
             }
+            state.currentSavedDeckName = '';
+            state.currentSavedDeckId = '';
+            state.isSavedDeckAltered = false;
+        },
+        saveNewDeck(state, action: PayloadAction<SavedDeck>) {
+            const { name, id } = action.payload;
+            state.currentSavedDeckName = name;
+            state.currentSavedDeckId = id;
+            state.isSavedDeckAltered = false;
+        },
+        saveOldDeck(state, action: PayloadAction<SavedDeck>) {
+            const { name, id } = action.payload;
+            state.currentSavedDeckName = name;
+            state.currentSavedDeckId = id;
+            state.isSavedDeckAltered = false;
         },
         addCard(state, action: PayloadAction<Card>) {
             const card = action.payload;
@@ -68,6 +86,9 @@ export const deckBuilderSlice = createSlice({
                 decklist.push({ card, quantity: 1 });
             }
             state.decklist = decklist;
+            if (state.currentSavedDeckName) {
+                state.isSavedDeckAltered = true;
+            }
         },
         removeCard(state, action: PayloadAction<Card>) {
             const card = action.payload;
@@ -82,9 +103,15 @@ export const deckBuilderSlice = createSlice({
             state.decklist = [
                 ...decklist.filter((cardSlot) => cardSlot.quantity > 0),
             ];
+            if (state.currentSavedDeckName) {
+                state.isSavedDeckAltered = true;
+            }
         },
         clearDeck(state) {
             state.decklist = [];
+            if (state.currentSavedDeckName) {
+                state.isSavedDeckAltered = true;
+            }
         },
     },
 });
@@ -92,5 +119,12 @@ export const deckBuilderSlice = createSlice({
 export const deckBuilderReducer: Reducer<DeckBuilderState> =
     deckBuilderSlice.reducer;
 
-export const { chooseSavedDeck, loadDeck, addCard, removeCard, clearDeck } =
-    deckBuilderSlice.actions;
+export const {
+    chooseSavedDeck,
+    loadDeck,
+    addCard,
+    removeCard,
+    clearDeck,
+    saveNewDeck,
+    saveOldDeck,
+} = deckBuilderSlice.actions;

--- a/src/client/redux/selectors/deckBuilder.ts
+++ b/src/client/redux/selectors/deckBuilder.ts
@@ -1,5 +1,6 @@
-import { DeckList } from '@/types/cards';
+import { DeckList, Skeleton } from '@/types/cards';
 import { RootState } from '../store';
+import { getSkeletonFromDeckList } from '@/transformers/getSkeletonFromDeckList';
 
 export const getCurrentSavedDeckName = (state: Partial<RootState>): string =>
     state.deckBuilder.currentSavedDeckName;
@@ -9,3 +10,9 @@ export const getCurrentSavedDeckId = (state: Partial<RootState>): string =>
 
 export const getDeckList = (state: Partial<RootState>): DeckList =>
     state.deckBuilder.decklist;
+
+export const getSkeleton = (state: Partial<RootState>): Skeleton =>
+    getSkeletonFromDeckList(state.deckBuilder.decklist);
+
+export const getIsSavedDeckAltered = (state: Partial<RootState>): boolean =>
+    state.deckBuilder.isSavedDeckAltered;

--- a/src/types/api/api.ts
+++ b/src/types/api/api.ts
@@ -1,0 +1,3 @@
+export type ErrorMessage = {
+    message: string;
+};

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,2 +1,3 @@
+export * from './api';
 export * from './gameResults';
 export * from './users';


### PR DESCRIPTION
Closes: #389 

<img width="800" alt="Screen Shot 2023-02-28 at 8 12 49 AM" src="https://user-images.githubusercontent.com/1839462/221864400-0f8c3423-746c-48bf-a1fa-6fe46baaf91a.png">

Lets users save existing decks alongside the API updates here: https://github.com/lijim/monks-and-mages-db-service/pull/28