### PR TITLE
Fix: Gracefully handle abandons in multiplayer / improve "win state" logic

### DIFF
--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -640,6 +640,60 @@ describe('resolve effect', () => {
     });
 
     describe('Deal Damage', () => {
+        it('passes the turn to the next player if dealing lethal to self', () => {
+            const boardWith4Players = makeNewBoard({
+                playerNames: ['Timmy', 'Tommy', 'Tom', 'Monty'],
+                startingPlayerIndex: 0,
+            });
+            const [timmy, tommy] = boardWith4Players.players;
+            // tommy has no more cards left, so after timmy loses, tom should be alive
+            tommy.deck = [];
+            tommy.numCardsInDeck = 0;
+            timmy.resourcePool = { [Resource.FIRE]: 2 };
+
+            const newBoard = resolveEffect(
+                boardWith4Players,
+                {
+                    effect: {
+                        type: EffectType.DEAL_DAMAGE,
+                        strength: 20,
+                    },
+                    playerNames: ['Timmy'],
+                },
+                'Timmy'
+            );
+            expect(newBoard.gameState).toEqual(GameState.PLAYING);
+            expect(newBoard.players[0].isActivePlayer).toBe(false);
+            expect(newBoard.players[0].resourcePool).toEqual({});
+            expect(newBoard.players[1].isAlive).toBe(false);
+            expect(newBoard.players[2].isActivePlayer).toBe(true);
+        });
+
+        it('ends the game if dealing lethal to multiple players', () => {
+            const boardWith4Players = makeNewBoard({
+                playerNames: ['Timmy', 'Tommy', 'Tom', 'Monty'],
+                startingPlayerIndex: 0,
+            });
+            const [timmy, tommy] = boardWith4Players.players;
+            // tommy has no more cards left, so after timmy loses, tom should be alive
+            tommy.deck = [];
+            tommy.numCardsInDeck = 0;
+            timmy.resourcePool = { [Resource.FIRE]: 2 };
+
+            const newBoard = resolveEffect(
+                boardWith4Players,
+                {
+                    effect: {
+                        type: EffectType.DEAL_DAMAGE,
+                        strength: 20,
+                    },
+                    playerNames: ['Timmy', 'Tom', 'Monty'],
+                },
+                'Timmy'
+            );
+            expect(newBoard.gameState).toEqual(GameState.WIN);
+        });
+
         it('deals damage to a unit', () => {
             const squire = makeCard(UnitCards.SQUIRE);
             board.players[0].units = [squire];

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -558,6 +558,8 @@ describe('resolve effect', () => {
                 makeCard(UnitCards.SHADOW_STRIKER),
                 makeCard(UnitCards.LONGBOWMAN),
             ];
+            // test: the other player can have an empty deck too
+            board.players[1].deck = [];
 
             const newBoard = resolveEffect(
                 board,

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -260,7 +260,9 @@ export const resolveEffect = (
 
             playerTargets.forEach((player) => {
                 player.health -= effectStrength;
-                if (player.health <= 0) player.isAlive = false;
+                if (player.health <= 0) {
+                    player.isAlive = false;
+                }
             });
             applyWinState(clonedBoard);
             return clonedBoard;

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -18,7 +18,7 @@ import {
     ResolveEffectParams,
     ServerToClientEvents,
 } from '@/types';
-import { applyGameAction, applyWinState } from '../gameEngine';
+import { applyGameAction, applyWinState, passTurn } from '../gameEngine';
 import { resolveEffect } from '../resolveEffect';
 import { makePlayerChatMessage, makeSystemChatMessage } from '@/factories/chat';
 import { GameResult } from '@/types/games';
@@ -269,6 +269,11 @@ export const configureIo = (server: HttpServer) => {
                 );
                 player.health = 0;
                 player.isAlive = false;
+                player.effectQueue = [];
+            }
+
+            if (player.isActivePlayer) {
+                passTurn(board);
             }
 
             const playerLeft = board.players.find((p) => p.isAlive);

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -272,7 +272,7 @@ export const configureIo = (server: HttpServer) => {
                 player.effectQueue = [];
             }
 
-            if (player.isActivePlayer) {
+            if (player?.isActivePlayer) {
                 passTurn(board);
             }
 


### PR DESCRIPTION
Our logic for detecting whether players won was previously very 2-player centric, which caused a number of bugs related to players leaving or losing the game in multiplayer.

# Abandons

If a player abandoned a 3 player game, but was the active player, it would cause a state where neither of the remaining players could do anything (like mulligan, play the game, etc.) - see the state below:

https://user-images.githubusercontent.com/1839462/222680275-6a97c948-a012-4078-bd17-3556f5cddf4c.mov

We've fixed it so that now, if a player abandons the game, the game continues playing on until there is a winner:

https://user-images.githubusercontent.com/1839462/222678250-61529f68-df73-4516-b456-6937c048bd87.mov

Closes: #256 

# Self Damage / effect resolution

Any effect that causes the game to check a win state (e.g. drawing the last card in a deck, dealing damage to a player via a spell)

We've also added code that makes it so that if both players have no cards in the deck left, the last remaining player should win (as everyone else would draw out) on the `passTurn` function.  This is covered under tests in resolveEffect.

Closes: #213