### PR TITLE
Fix: use SVG over transform to prevent z-Index issues

### DIFF
--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -134,18 +134,14 @@ export const TypesAndRarityLine = ({
         >
             <span>{children}</span>
             <span style={{ display: 'flex', gap: '2px', alignItems: 'center' }}>
-                <span
-                    style={{
-                        borderColor: Colors.VANTA_BLACK,
-                        background: COLORS_FOR_RARITY[rarity],
-                        borderStyle: 'solid',
-                        borderWidth: '2px',
-                        display: 'inline-block',
-                        width: '14px',
-                        height: '14px',
-                        transform: 'rotate(45deg)',
-                    }}
-                />
+                <svg width="14" height="14">
+                    <polygon
+                        points="7,1 13,7 7,13 1,7"
+                        fill={COLORS_FOR_RARITY[rarity]}
+                        stroke="white"
+                        stroke-width="1"
+                    />
+                </svg>
                 {rarity}
             </span>
         </div>

--- a/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
+++ b/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/types/resources';
 import { CastingCostFrame } from '../CastingCost';
 import { CardRarity, UnitType } from '@/types/cards';
-import { COLORS_FOR_RARITY, Colors } from '@/constants/colors';
+import { COLORS_FOR_RARITY } from '@/constants/colors';
 
 const FreeTextFilters: React.FC = () => {
     const dispatch = useDispatch<AppDispatch>();

--- a/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
+++ b/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
@@ -199,18 +199,14 @@ const RaritiesFilter: React.FC = () => {
                         data-testid={`Filters-UnitType-${rarity}`}
                         tabIndex={0}
                     >
-                        <span
-                            style={{
-                                borderColor: Colors.VANTA_BLACK,
-                                background: COLORS_FOR_RARITY[rarity],
-                                borderStyle: 'solid',
-                                borderWidth: '2px',
-                                display: 'inline-block',
-                                width: '10px',
-                                height: '10px',
-                                transform: 'rotate(45deg)',
-                            }}
-                        />
+                        <svg width="14" height="14">
+                            <polygon
+                                points="7,1 13,7 7,13 1,7"
+                                fill={COLORS_FOR_RARITY[rarity]}
+                                stroke="white"
+                                stroke-width="1"
+                            />
+                        </svg>
                     </CastingCostFrame>
                 ))}
             </span>

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -3,8 +3,8 @@ import { CardRarity } from '@/types/cards';
 export enum Colors {
     BAMBOO_GREEN = '#136313',
     BUFF_BLUE = '#0096FF',
-    CRYSTAL_PURPLE = '#684B77',
     COMMON_GREY = '#bdc3c7',
+    CRYSTAL_PURPLE = '#684B77',
     DARK_BROWN = '#4a2e15',
     DEBUFF_RED = '#c70039',
     FELT_GREEN = '#247345',


### PR DESCRIPTION
Having an element with `transform: rotate(45deg)` for the tilted squares representing rarity in the last PR (#415) introduced a visual bug on the deck builder / viewer:

<img width="970" alt="Screen Shot 2023-03-10 at 3 02 29 AM" src="https://user-images.githubusercontent.com/1839462/224258053-e84cfd17-d3ae-4be7-bbf4-449b93f7a148.png">

This is because we rely on successive zIndex's to stack the cards on top of each other, but transform creates a new stacking context for zIndex.

We switched to using an SVG based diamond instead to solve this:
<img width="755" alt="Screen Shot 2023-03-10 at 3 05 24 AM" src="https://user-images.githubusercontent.com/1839462/224258637-9c03d3a2-6638-4d41-820e-fcbb9bb6f53c.png">
