### PR TITLE
Feat: add pack generation helpers

### DIFF
--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -808,6 +808,7 @@ const TEA = makeCard({
         },
     ],
     rarity: CardRarity.COMMON,
+    isTokenOnly: true,
 });
 
 const POISON_MUSHROOM = makeCard({
@@ -822,6 +823,7 @@ const POISON_MUSHROOM = makeCard({
         },
     ],
     rarity: CardRarity.COMMON,
+    isTokenOnly: true,
 });
 
 const ARCHERY_AT_SUNSET = makeCard({
@@ -1074,6 +1076,7 @@ const SPARK_JOY = makeCard({
         },
     ],
     rarity: CardRarity.COMMON,
+    isTokenOnly: true,
 });
 
 const FESTIVE_BAZAAR = makeCard({
@@ -1446,6 +1449,7 @@ const RICHES = makeCard({
         },
     ],
     rarity: CardRarity.COMMON,
+    isTokenOnly: true,
 });
 
 const LANDMARK = makeCard({
@@ -1460,6 +1464,7 @@ const LANDMARK = makeCard({
         },
     ],
     rarity: CardRarity.COMMON,
+    isTokenOnly: true,
 });
 
 export const SpellCards = {

--- a/src/client/components/Pack/Pack.tsx
+++ b/src/client/components/Pack/Pack.tsx
@@ -1,22 +1,12 @@
-import sampleSize from 'lodash.samplesize';
 import React, { useMemo } from 'react';
 
-import { ALL_CARDS } from '@/constants/deckLists';
 import { CardGridItem } from '../CardGridItem';
-import { Card, CardType } from '@/types/cards';
-import { makeCard } from '@/factories/cards';
-
-const PACK_SIZE = 15;
-
-const CARD_POOL = ALL_CARDS.filter((card) => {
-    if (card.card.cardType === CardType.RESOURCE && !card.card.isAdvanced)
-        return false;
-    return true;
-});
+import { Card } from '@/types/cards';
+import { makePack } from '@/factories';
 
 export const Pack = () => {
     const packContents: Card[] = useMemo(() => {
-        return sampleSize(CARD_POOL, PACK_SIZE).map((c) => makeCard(c.card));
+        return makePack();
     }, []);
 
     return (

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -285,9 +285,11 @@ export const ALL_CARDS: DeckList = [
     ...Object.values(AdvancedResourceCards).map((card) => {
         return { card, quantity: 1 };
     }),
-    ...Object.values(SpellCards).map((card) => {
-        return { card, quantity: 1 };
-    }),
+    ...Object.values(SpellCards)
+        .filter((card) => !card.isTokenOnly)
+        .map((card) => {
+            return { card, quantity: 1 };
+        }),
     ...Object.values(UnitCards).map((card) => {
         return { card, quantity: 1 };
     }),

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,0 +1,7 @@
+export * from './board';
+export * from './cards';
+export * from './chat';
+export * from './deck';
+export * from './games';
+export * from './pack';
+export * from './player';

--- a/src/factories/pack/index.ts
+++ b/src/factories/pack/index.ts
@@ -1,0 +1,1 @@
+export * from './makePack';

--- a/src/factories/pack/makePack.ts
+++ b/src/factories/pack/makePack.ts
@@ -1,0 +1,31 @@
+import sampleSize from 'lodash.samplesize';
+import { AdvancedResourceCards } from '@/cardDb/resources/advancedResources';
+import { SpellCards } from '@/cardDb/spells';
+import { UnitCards } from '@/cardDb/units';
+import { Card, CardRarity } from '@/types/cards';
+import { makeCard } from '../cards';
+
+const CARDPOOL = [
+    ...Object.values(AdvancedResourceCards),
+    ...Object.values(SpellCards),
+    ...Object.values(UnitCards),
+].filter((card) => !card.isTokenOnly);
+
+const MYTHICS = CARDPOOL.filter((card) => card.rarity === CardRarity.MYTHIC);
+const RARES = CARDPOOL.filter((card) => card.rarity === CardRarity.RARE);
+const UNCOMMONS = CARDPOOL.filter(
+    (card) => card.rarity === CardRarity.UNCOMMON
+);
+const COMMONS = CARDPOOL.filter((card) => card.rarity === CardRarity.COMMON);
+
+export const makePack = (): Card[] => {
+    const commons = sampleSize(COMMONS, 9);
+    const uncommons = sampleSize(UNCOMMONS, 4);
+    const raresAndMythics =
+        Math.random() < 0.2
+            ? [...sampleSize(RARES, 1), ...sampleSize(MYTHICS, 1)]
+            : sampleSize(RARES, 2);
+    return [...commons, ...uncommons, ...raresAndMythics].map((card) =>
+        makeCard(card)
+    );
+};

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -20,6 +20,7 @@ type CardBase = {
     artistUrl?: string;
     id?: string;
     imgSrc?: string;
+    isTokenOnly?: boolean; // true if the card should not show up in packs, e.g. 'Tea' / 'Landmark'
     rarity: CardRarity;
 };
 


### PR DESCRIPTION
New factory method In preparation for Draft / limited mode

Built a "makePack" factory that allows us to generate a pack of 15 cards - 9 commons, 4 uncommons, and either 2 rares or 1 rare/mythic.