### PR TITLE
Feat: Helpers for creating a "drafting" / "sealed" experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ Linting on this project is done via a combination of typescript, [prettier](http
 
 Unit testing is covered via [Jest](https://jestjs.io/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
 
-# Game rules
+# Gameplay
 
--   Players come with a deck of at least 50 cards
+## Game rules
+
+-   Players come with a deck of at least 60 cards
 -   2-4 players can play against each other
 -   7 cards to start, 1 card drawn per turn (unless starting player)
--   Players start with 15 life
+-   Players start with 20 life
 -   Players lose when they either reach 0 or less life or attempt to draw from an empty deck
 -   Cards come in 3 flavors: _Resources_, _Units_, and _Spells_
     -   **Resources** are the basis for paying for the other two types of cards. When a player deploys a resource card (one per turn can be deployed), they add that resource to their casting pool. This casting pool refills every turn.
@@ -83,7 +85,7 @@ Unit testing is covered via [Jest](https://jestjs.io/) and [React Testing Librar
         -   Ember Spear (🔥) deal 3 damage to any target
         -   A gentle gust (🔥)(🌊) buffs the team's stats by 1
 
-# Game philosophy
+## Game philosophy
 
 -   the game has 5 resources with separate identities:
 

--- a/src/client/redux/board/board.ts
+++ b/src/client/redux/board/board.ts
@@ -19,6 +19,8 @@ export const boardSlice = createSlice({
         updateBoardState(state, action: PayloadAction<Board>) {
             state.gameState = action.payload.gameState;
             state.players = action.payload.players;
+            state.draftPiles = action.payload.draftPiles;
+            state.draftPoolSize = action.payload.draftPoolSize;
         },
     },
 });

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -6,3 +6,14 @@ export enum PlayerConstants {
 }
 
 export const AUTO_RESOLVE_LINGER_DURATION = 1000;
+
+export const DRAFT_PACKS_BY_PLAYER_COUNT: Record<number, number> = {
+    2: 6,
+    3: 10,
+    4: 15,
+};
+
+export const DRAFT_PILE_QUANTITY = 4;
+export const DRAFT_PILE_STARTING_SIZE = 3;
+
+export const SEALED_PACK_QUANTITY = 6;

--- a/src/factories/board/makeNewBoard.spec.ts
+++ b/src/factories/board/makeNewBoard.spec.ts
@@ -1,9 +1,15 @@
 import { FIRE_MAGES_DECKLIST } from '@/constants/deckLists';
-import { PlayerConstants } from '@/constants/gameConstants';
+import {
+    DRAFT_PACKS_BY_PLAYER_COUNT,
+    DRAFT_PILE_QUANTITY,
+    DRAFT_PILE_STARTING_SIZE,
+    PlayerConstants,
+} from '@/constants/gameConstants';
 import { DeckListSelections } from '@/constants/lobbyConstants';
 import { Skeleton } from '@/types/cards';
 import { makeDeck } from '../deck';
 import { makeNewBoard } from './makeNewBoard';
+import { Format } from '@/types/games';
 
 describe('Make New Board', () => {
     it('makes a new board with players', () => {
@@ -71,5 +77,24 @@ describe('Make New Board', () => {
         expect(board.players[0].hand[0].name).toEqual('Assassin');
     });
 
-    it.todo('caps at 4 players and makes everyone else a spectator');
+    it('makes a draft game', () => {
+        const board = makeNewBoard({
+            playerNames: ['Hal', 'Orin', 'Samus'],
+            format: Format.DRAFT,
+        });
+        expect(board.draftPoolSize).toEqual(
+            DRAFT_PACKS_BY_PLAYER_COUNT[3] * 15 -
+                DRAFT_PILE_QUANTITY * DRAFT_PILE_STARTING_SIZE
+        );
+        expect(board.draftPiles).toHaveLength(DRAFT_PILE_QUANTITY);
+        expect(board.draftPiles[0]).toHaveLength(DRAFT_PILE_STARTING_SIZE);
+    });
+
+    it('makes a sealed game', () => {
+        const board = makeNewBoard({
+            playerNames: ['Hal', 'Orin', 'Samus'],
+            format: Format.SEALED,
+        });
+        expect(board.players[0].deckBuildingPool).toHaveLength(6 * 15);
+    });
 });

--- a/src/factories/player/makeNewPlayer.ts
+++ b/src/factories/player/makeNewPlayer.ts
@@ -25,6 +25,7 @@ export const makeNewPlayer = ({
         avatar: avatarUrl,
         cemetery: [],
         deck: activeDeck,
+        deckBuildingPool: [],
         effectQueue: [],
         hand,
         health: STARTING_HEALTH,

--- a/src/server/obscureBoardInfo/obscureBoardInfo.ts
+++ b/src/server/obscureBoardInfo/obscureBoardInfo.ts
@@ -11,6 +11,8 @@ export const obscureBoardInfo = (
     forPlayerName?: string
 ): Board => {
     const obscuredBoard = cloneDeep(board);
+    // hide drafting pools
+    obscuredBoard.draftPool = [];
 
     obscuredBoard.players.forEach((player) => {
         player.numCardsInHand = player.hand.length;

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -8,6 +8,7 @@ export type Player = {
     avatar?: string;
     cemetery: Card[];
     deck: Card[];
+    deckBuildingPool: Card[];
     effectQueue: Effect[];
     hand: Card[]; // defaults to 1 every turn
     health: number;
@@ -27,11 +28,15 @@ export type Player = {
 export enum GameState {
     // players decide whether to keep their opening cards 1 at a time, with the active player
     // making a choice and passing
+    DRAFTING = 'DRAFTING',
+    DECKBUILDING = 'DECKBUILDING',
     MULLIGANING = 'MULLIGANING',
     PLAYING = 'PLAYING',
     TIE = 'TIE',
     WIN = 'WIN',
 }
+
+export type DraftPile = Card[];
 
 // Board as it's experienced by server / client
 export type Board = {
@@ -40,6 +45,9 @@ export type Board = {
     gameState: GameState;
     players: Player[];
     startingPlayerIndex: number;
+    draftPool: Card[];
+    draftPoolSize: number;
+    draftPiles: DraftPile[];
 };
 
 /**


### PR DESCRIPTION
In this game, everything in the game that is displayed derives from the state of the Board object, as passed from the server, calling the obscureBoardInfo helper to obscure critical pieces of information (e.g. opponent's hand, etc.).

Game actions from the client are sent as actions to the server, which calculate a potential new game board state to display/

When approaching the challenge of building "draft" mode, a logical place to start is to modify and expand the concept of the "Board" objects to encapsulate everything to do with drafting - draft pool, draft piles, etc.

Players also get an update in that they have a `deckBuildingPool` property as well, which starts as a blank array (or an array of 6 packs for sealed mode).

This PR upgraded the makeNewBoard / makeNewPlayer to account for sealed and draft mode games.

No visual components made yet for the draft mode experience (I want them to live in GameDisplay, but under a separate component called DraftDisplay.  In GameDisplay, we'll check if the board's current format is draft / sealed and render a draft UI / deck-building UI respectively)

<img width="700" alt="Screen Shot 2023-03-12 at 7 20 00 PM" src="https://user-images.githubusercontent.com/1839462/224580143-399e930f-7f6d-4677-ae9a-88fd766dccd3.png">
