### PR TITLE
Feat: Deckbuilder UI for Draft / Sealed mode

### DIFF
--- a/src/client/components/CompactDeckList/CompactDeckList.spec.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.spec.tsx
@@ -4,10 +4,20 @@ import { screen } from '@testing-library/react';
 import { CompactDeckList } from './CompactDeckList';
 import { makeSampleDeck1 } from '@/factories/deck';
 import { render } from '@/test-utils';
+import { makeNewBoard } from '@/factories';
 
 describe('DeckList', () => {
     it('renders a deck', () => {
-        render(<CompactDeckList deck={makeSampleDeck1()} />);
+        render(<CompactDeckList deck={makeSampleDeck1()} />, {
+            preloadedState: {
+                board: makeNewBoard({
+                    playerNames: ['Timmy', 'Tommy'],
+                }),
+                user: {
+                    name: 'Timmy',
+                },
+            },
+        });
         expect(screen.queryAllByText('Knight Templar')).toHaveLength(1);
         expect(screen.queryAllByText('Bamboo')).toHaveLength(1);
         expect(screen.queryAllByText('3')).toHaveLength(7);

--- a/src/client/components/DeckBuilder/DeckBuilder.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.tsx
@@ -22,7 +22,7 @@ import { Filters } from '@/types/deckBuilder';
 import { SavedDeckManager } from '../SavedDeckManager';
 import { getAuth0Id, getDeckList } from '@/client/redux/selectors';
 import { chooseFormat, clearDeck, loadDeck } from '@/client/redux/deckBuilder';
-import { Format } from '@/types/games';
+import { Format, isFormatConstructed } from '@/types/games';
 
 const DeckListContainers = styled.div`
     display: grid;
@@ -154,42 +154,58 @@ export const DeckBuilder: React.FC<DeckBuilderProps> = ({
     const deck = filterCards(cardPool, filters);
     return (
         <>
-            <TopNavBar>
-                <b>Customize Your {format} Deck</b> {} <Link to="/">Back</Link>
-            </TopNavBar>
+            {isFormatConstructed(format) && (
+                <TopNavBar>
+                    <b>Customize Your {format} Deck</b> {}{' '}
+                    <Link to="/">Back</Link>
+                </TopNavBar>
+            )}
             <DeckListContainers>
                 <DeckListBackDrop data-testid="CardPool">
                     <DeckBuilderFilters />
                     {deck.length}
-                    <CompactDeckList deck={deck} shouldShowQuantity={false} />
+                    <CompactDeckList
+                        deck={deck}
+                        shouldShowQuantity={!isFormatConstructed(format)}
+                    />
                 </DeckListBackDrop>
                 <DeckListBackDrop data-testid="CurrentDeck">
-                    <SecondaryColorButton onClick={copyToClipboard} zoom={0.8}>
-                        Copy to Clipboard
-                    </SecondaryColorButton>
-                    &nbsp;&nbsp;
-                    <SecondaryColorButton
-                        onClick={importFromClipboard}
-                        zoom={0.8}
-                    >
-                        Import from Clipboard
-                    </SecondaryColorButton>
-                    &nbsp;&nbsp;
-                    <SecondaryColorButton onClick={download} zoom={0.8}>
-                        Download as File
-                    </SecondaryColorButton>
-                    &nbsp;&nbsp;
-                    <input
-                        type="file"
-                        onChange={upload}
-                        accept="text/plain"
-                        style={{ display: 'none' }}
-                        ref={fileInputEl}
-                    />
-                    <SecondaryColorButton onClick={importFile} zoom={0.8}>
-                        Import File
-                    </SecondaryColorButton>{' '}
-                    &nbsp;&nbsp;
+                    {isFormatConstructed(format) && (
+                        <>
+                            <SecondaryColorButton
+                                onClick={copyToClipboard}
+                                zoom={0.8}
+                            >
+                                Copy to Clipboard
+                            </SecondaryColorButton>
+                            &nbsp;&nbsp;
+                            <SecondaryColorButton
+                                onClick={importFromClipboard}
+                                zoom={0.8}
+                            >
+                                Import from Clipboard
+                            </SecondaryColorButton>
+                            &nbsp;&nbsp;
+                            <SecondaryColorButton onClick={download} zoom={0.8}>
+                                Download as File
+                            </SecondaryColorButton>
+                            &nbsp;&nbsp;
+                            <input
+                                type="file"
+                                onChange={upload}
+                                accept="text/plain"
+                                style={{ display: 'none' }}
+                                ref={fileInputEl}
+                            />
+                            <SecondaryColorButton
+                                onClick={importFile}
+                                zoom={0.8}
+                            >
+                                Import File
+                            </SecondaryColorButton>{' '}
+                            &nbsp;&nbsp;
+                        </>
+                    )}
                     <SecondaryColorButton onClick={onClickClearDeck} zoom={0.8}>
                         Clear
                     </SecondaryColorButton>{' '}

--- a/src/client/components/DraftingTable/DraftingTable.tsx
+++ b/src/client/components/DraftingTable/DraftingTable.tsx
@@ -168,7 +168,10 @@ export const DraftingTable = () => {
                                 gridTemplateRows: 'auto auto 1fr',
                             }}
                         >
-                            <CompactDeckList deck={deckbuildingPool} />
+                            <CompactDeckList
+                                deck={deckbuildingPool}
+                                isDisplayOnly
+                            />
                         </div>
                     </div>
                 </div>

--- a/src/client/components/GameDisplay/GameDisplay.spec.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.spec.tsx
@@ -13,20 +13,42 @@ import { Format } from '@/types/games';
 import { GameState } from '@/types/board';
 
 describe('GameDisplay', () => {
-    it('renders a drafting screen', () => {
-        const board = makeNewBoard({
-            playerNames: ['Tommy', 'Timmy'],
-            format: Format.DRAFT,
+    describe('Limited modes', () => {
+        it('renders a drafting screen', () => {
+            const board = makeNewBoard({
+                playerNames: ['Tommy', 'Timmy'],
+                format: Format.DRAFT,
+            });
+            board.gameState = GameState.DRAFTING;
+            const preloadedState: Partial<RootState> = {
+                user: {
+                    name: 'Tommy',
+                },
+                board,
+            };
+            render(<GameDisplay />, { preloadedState });
+            expect(screen.queryByText('Pile 4')).toBeInTheDocument();
         });
-        board.gameState = GameState.DRAFTING;
-        const preloadedState: Partial<RootState> = {
-            user: {
-                name: 'Tommy',
-            },
-            board,
-        };
-        render(<GameDisplay />, { preloadedState });
-        expect(screen.queryByText('Pile 4')).toBeInTheDocument();
+
+        it('renders deckbuilding view', () => {
+            const board = makeNewBoard({
+                playerNames: ['Tommy', 'Timmy'],
+                format: Format.SEALED,
+            });
+            board.gameState = GameState.DECKBUILDING;
+            const preloadedState: Partial<RootState> = {
+                user: {
+                    name: 'Tommy',
+                },
+                board,
+            };
+            render(<GameDisplay />, { preloadedState });
+            expect(
+                screen.queryByText('Must have at least 40 cards in deck')
+            ).toBeInTheDocument();
+            expect(screen.queryAllByText('∞')[0]).toBeInTheDocument();
+            expect(screen.queryAllByText('Fire')[0]).toBeInTheDocument();
+        });
     });
 
     it('renders player names', () => {

--- a/src/client/components/GameDisplay/GameDisplay.tsx
+++ b/src/client/components/GameDisplay/GameDisplay.tsx
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import {
+    getDeckbuildingPoolForPlayer,
+    getGameFormat,
     getGameState,
     getLastEffectForActivePlayer,
     getOtherPlayers,
@@ -14,12 +16,14 @@ import { SelfPlayerInfo } from '../SelfPlayerInfo';
 import { OtherPlayerInfo } from '../OtherPlayerInfo';
 import { HandOfCards } from '../HandOfCards';
 import { PlayerBoardSection } from '../PlayerBoardSection';
-import { Effect } from '@/types/cards';
+import { Card, Effect } from '@/types/cards';
 import { transformEffectToRulesText } from '@/transformers/transformEffectsToRulesText';
 import { CenterPromptBox } from '../CenterPromptBox';
 import { GameChatMessages } from '../GameChatMessages';
 import { LastPlayedCard } from '../LastPlayedCard';
 import { DraftingTable } from '../DraftingTable';
+import { DeckBuilder } from '../DeckBuilder';
+import { Format } from '@/types/games';
 
 const GameGrid = styled.div`
     width: 100%;
@@ -301,15 +305,27 @@ const GameBoard: React.FC<GameBoardProps> = ({ otherPlayers, selfPlayer }) => {
  */
 export const GameDisplay: React.FC = () => {
     const gameState = useSelector<RootState, GameState>(getGameState);
+    const gameFormat = useSelector<RootState, Format>(getGameFormat);
     const selfPlayer = useSelector<RootState, Player>(getSelfPlayer);
     const otherPlayers = useSelector<RootState, Player[]>(getOtherPlayers);
     const lastEffect = useSelector<RootState, Effect>(
         getLastEffectForActivePlayer
     );
+    const deckbuildingPool = useSelector<RootState, Card[]>(
+        getDeckbuildingPoolForPlayer(selfPlayer?.name)
+    );
 
     return (
         <GameGrid>
             {gameState === GameState.DRAFTING && <DraftingTable />}
+            {gameState === GameState.DECKBUILDING && (
+                <div>
+                    <DeckBuilder
+                        cardPool={deckbuildingPool}
+                        format={gameFormat}
+                    />
+                </div>
+            )}
             {[
                 GameState.MULLIGANING,
                 GameState.PLAYING,

--- a/src/client/components/QuantitySelector/QuantitySelector.tsx
+++ b/src/client/components/QuantitySelector/QuantitySelector.tsx
@@ -39,16 +39,18 @@ export const QuantitySelector: React.FC<QuantitySelectorProps> = ({
     hasNoBorder = false,
     quantity,
 }) => {
+    const quantityToDisplay =
+        quantity === Number.MAX_SAFE_INTEGER ? '∞' : quantity;
     if (!isEditable)
         return (
             <span>
-                <Square hasNoBorder={hasNoBorder}>{quantity}</Square>
+                <Square hasNoBorder={hasNoBorder}>{quantityToDisplay}</Square>
             </span>
         );
     return (
         <Grid>
             <Square hasNoBorder={hasNoBorder}>-</Square>
-            <Square hasNoBorder={hasNoBorder}>{quantity}</Square>
+            <Square hasNoBorder={hasNoBorder}>{quantityToDisplay}</Square>
             <Square hasNoBorder={hasNoBorder}>+</Square>
         </Grid>
     );

--- a/src/client/redux/board/board.ts
+++ b/src/client/redux/board/board.ts
@@ -21,6 +21,7 @@ export const boardSlice = createSlice({
             state.players = action.payload.players;
             state.draftPiles = action.payload.draftPiles;
             state.draftPoolSize = action.payload.draftPoolSize;
+            state.format = action.payload.format;
         },
     },
 });

--- a/src/client/redux/selectors/deckBuilder.ts
+++ b/src/client/redux/selectors/deckBuilder.ts
@@ -1,6 +1,7 @@
-import { DeckList, Skeleton } from '@/types/cards';
+import { Card, DeckList, Skeleton } from '@/types/cards';
 import { RootState } from '../store';
 import { getSkeletonFromDeckList } from '@/transformers/getSkeletonFromDeckList';
+import { getSelfPlayer } from './selectors';
 
 export const getCurrentSavedDeckName = (state: Partial<RootState>): string =>
     state.deckBuilder.currentSavedDeckName;
@@ -16,3 +17,23 @@ export const getSkeleton = (state: Partial<RootState>): Skeleton =>
 
 export const getIsSavedDeckAltered = (state: Partial<RootState>): boolean =>
     state.deckBuilder.isSavedDeckAltered;
+
+export const getNumberLeft =
+    (cardToFind: Card) =>
+    (state: Partial<RootState>): number => {
+        const self = getSelfPlayer(state);
+        if (!self?.deckBuildingPool) {
+            return 0;
+        }
+
+        const quantityInPool =
+            self.deckBuildingPool.filter(
+                (card) => card.name === cardToFind.name
+            ).length || 0;
+        const usedSoFar =
+            state.deckBuilder.decklist.find(
+                ({ card }) => card.name === cardToFind.name
+            )?.quantity || 0;
+
+        return quantityInPool - usedSoFar;
+    };

--- a/src/client/redux/selectors/selectors.ts
+++ b/src/client/redux/selectors/selectors.ts
@@ -2,6 +2,7 @@ import { DraftPile, GameState, Player } from '@/types/board';
 import { Card, Effect } from '@/types/cards';
 import { TargetTypes, getDefaultTargetForEffect } from '@/types/effects';
 import { RootState } from '../store';
+import { Format } from '@/types/games';
 
 export const isUserInitialized = (state: Partial<RootState>): boolean =>
     !!state.user.name;
@@ -20,6 +21,8 @@ export const getSelfPlayer = (state: Partial<RootState>): Player | null => {
 
 export const getGameState = (state: RootState): GameState =>
     state.board.gameState;
+
+export const getGameFormat = (state: RootState): Format => state.board?.format;
 
 export const getDraftPiles = (state: RootState): DraftPile[] =>
     state.board.draftPiles;

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -275,6 +275,14 @@ export const PIRATES_DECKLIST: DeckList = [
     { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 2 },
 ];
 
+export const ALL_BASIC_RESOURCES: DeckList = [
+    { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
+    { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
+    { card: makeResourceCard(Resource.FIRE), quantity: 1 },
+    { card: makeResourceCard(Resource.IRON), quantity: 1 },
+    { card: makeResourceCard(Resource.WATER), quantity: 1 },
+];
+
 // For debugging / gamebuilding purposes
 export const ALL_CARDS: DeckList = [
     { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -3,6 +3,7 @@ export enum PlayerConstants {
     STARTING_HEALTH = 20,
     STARTING_HAND_SIZE = 7,
     STARTING_DECK_SIZE = 60,
+    STARTING_DECK_SIZE_LIMITED = 40,
 }
 
 export const AUTO_RESOLVE_LINGER_DURATION = 1000;

--- a/src/transformers/isDeckValidForFomat/isDeckValidForFormat.ts
+++ b/src/transformers/isDeckValidForFomat/isDeckValidForFormat.ts
@@ -1,6 +1,6 @@
 import { PlayerConstants } from '@/constants/gameConstants';
 import { CardType, DeckList } from '@/types/cards';
-import { Format } from '@/types/games';
+import { Format, isFormatConstructed } from '@/types/games';
 
 export const MAX_DUPLICATES_FOR_FORMATS = {
     [Format.SINGLETON]: 1,
@@ -21,7 +21,9 @@ export const isDeckValidForFormat = (
     let numCards = 0;
     let isValid = true;
     const max = MAX_DUPLICATES_FOR_FORMATS[format];
-    const minDeckSize = PlayerConstants.STARTING_DECK_SIZE;
+    const minDeckSize = isFormatConstructed(format)
+        ? PlayerConstants.STARTING_DECK_SIZE
+        : PlayerConstants.STARTING_DECK_SIZE_LIMITED;
     const maxDeckSize = PlayerConstants.MAX_DECK_SIZE;
     let reason: string;
     deck.forEach(({ card, quantity }) => {


### PR DESCRIPTION
<img width="1728" alt="Screen Shot 2023-03-14 at 9 58 02 AM" src="https://user-images.githubusercontent.com/1839462/225024359-6aca8be2-27ac-4c89-a334-e2f0470b4c8e.png">

- Extended `DeckBuilder` and `CompactDeckList` to allow users to construct decks for Draft and Sealed mode.
- Rendered them when the game's state is "deckbuilding"

Next up:
- Add a game action for completing deckbuilding ("submit deck") and wire it up to the submit button
- Add a game action for finishing up draft ("finish draft") and add UI for it
