### PR TITLE
Feat: Future proof game for sideboards

### DIFF
--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -240,12 +240,12 @@ export const CompactDeckList: React.FC<CompactDeckListProps> = ({
 
     if (shouldShowBasicResources) {
         const basicResourceCards = new Map(
-            ALL_BASIC_RESOURCES.map(({ card }) => [
+            ALL_BASIC_RESOURCES.mainBoard.map(({ card }) => [
                 card,
                 Number.MAX_SAFE_INTEGER,
             ])
         );
-        let resources = piles.find((pile) => pile.title === 'Resources');
+        const resources = piles.find((pile) => pile.title === 'Resources');
         if (!resources) {
             piles = [
                 {

--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -251,7 +251,10 @@ describe('DeckBuilder', () => {
         render(<DeckBuilder />, {
             preloadedState: {
                 deckList: {
-                    customDeckList: [{ card: 'Lancer', quantity: 1 }],
+                    customDeckList: {
+                        mainBoard: [{ card: 'Lancer', quantity: 1 }],
+                        sideBoard: [],
+                    },
                     premadeDecklist: null,
                 },
             },

--- a/src/client/components/DeckListSelector/DeckListSelector.spec.tsx
+++ b/src/client/components/DeckListSelector/DeckListSelector.spec.tsx
@@ -56,10 +56,13 @@ describe('DeckListSelector', () => {
             },
             deckList: {
                 premadeDecklist: DeckListSelections.RANDOM,
-                customDeckList: [
-                    { card: 'Lancer', quantity: 4 },
-                    { card: 'Iron', quantity: 44 },
-                ],
+                customDeckList: {
+                    mainBoard: [
+                        { card: 'Lancer', quantity: 4 },
+                        { card: 'Iron', quantity: 44 },
+                    ],
+                    sideBoard: [],
+                },
             },
         };
         render(<DeckListSelector />, { preloadedState });

--- a/src/client/redux/deckBuilder/deckBuilder.ts
+++ b/src/client/redux/deckBuilder/deckBuilder.ts
@@ -16,7 +16,7 @@ type DeckBuilderState = {
 const initialState: DeckBuilderState = {
     currentSavedDeckName: '',
     currentSavedDeckId: '',
-    decklist: [],
+    decklist: { mainBoard: [], sideBoard: [] },
     format: Format.STANDARD,
     isSavedDeckAltered: false,
 };
@@ -69,7 +69,7 @@ export const deckBuilderSlice = createSlice({
             );
             const { decklist } = state;
 
-            const matchingCardSlot = decklist.find(
+            const matchingCardSlot = decklist.mainBoard.find(
                 (cardSlot) => cardSlot.card.name === card.name
             );
             const isConstructed = isFormatConstructed(state.format);
@@ -88,7 +88,7 @@ export const deckBuilderSlice = createSlice({
             if (matchingCardSlot) {
                 matchingCardSlot.quantity += 1;
             } else {
-                decklist.push({ card, quantity: 1 });
+                decklist.mainBoard.push({ card, quantity: 1 });
             }
             state.decklist = decklist;
             if (state.currentSavedDeckName) {
@@ -98,22 +98,24 @@ export const deckBuilderSlice = createSlice({
         removeCard(state, action: PayloadAction<Card>) {
             const card = action.payload;
             const { decklist } = state;
-            const matchingCardSlot = decklist.find(
+            const matchingCardSlot = decklist.mainBoard.find(
                 (cardSlot) => cardSlot.card.name === card.name
             );
 
             if (matchingCardSlot) {
                 matchingCardSlot.quantity -= 1;
             }
-            state.decklist = [
-                ...decklist.filter((cardSlot) => cardSlot.quantity > 0),
+            state.decklist.mainBoard = [
+                ...decklist.mainBoard.filter(
+                    (cardSlot) => cardSlot.quantity > 0
+                ),
             ];
             if (state.currentSavedDeckName) {
                 state.isSavedDeckAltered = true;
             }
         },
         clearDeck(state) {
-            state.decklist = [];
+            state.decklist.mainBoard = [];
             if (state.currentSavedDeckName) {
                 state.isSavedDeckAltered = true;
             }

--- a/src/client/redux/selectors/deckBuilder.ts
+++ b/src/client/redux/selectors/deckBuilder.ts
@@ -31,9 +31,13 @@ export const getNumberLeft =
                 (card) => card.name === cardToFind.name
             ).length || 0;
         const usedSoFar =
-            state.deckBuilder.decklist.find(
+            state.deckBuilder.decklist.mainBoard.find(
+                ({ card }) => card.name === cardToFind.name
+            )?.quantity || 0;
+        const usedSoFarInSideboard =
+            state.deckBuilder.decklist.sideBoard.find(
                 ({ card }) => card.name === cardToFind.name
             )?.quantity || 0;
 
-        return quantityInPool - usedSoFar;
+        return quantityInPool - usedSoFar - usedSoFarInSideboard;
     };

--- a/src/constants/deckLists.ts
+++ b/src/constants/deckLists.ts
@@ -6,319 +6,361 @@ import { makeResourceCard } from '@/factories/cards';
 import { AdvancedResourceCards } from '@/cardDb/resources/advancedResources';
 
 // Bamboo + Iron - revised version (not used in mocks)
-export const MONKS_DECKLIST: DeckList = [
-    // 22 Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 7 },
-    { card: makeResourceCard(Resource.IRON), quantity: 7 },
-    { card: AdvancedResourceCards.TANGLED_RUINS, quantity: 4 },
-    { card: AdvancedResourceCards.PREFECTURE_CAPITAL, quantity: 4 },
-    // 20 Soldiers
-    { card: UnitCards.PIKEMAN, quantity: 4 },
-    { card: UnitCards.LANCER, quantity: 4 },
-    { card: UnitCards.INFANTRY_OFFICER, quantity: 4 },
-    { card: UnitCards.SQUIRE, quantity: 3 },
-    { card: UnitCards.ORCISH_CORPORAL, quantity: 2 },
-    { card: UnitCards.MARTIAL_TRAINER, quantity: 3 },
-    // 6 Assassins
-    { card: UnitCards.ASSASSIN, quantity: 2 },
-    { card: UnitCards.SHADOW_STRIKER, quantity: 2 },
-    { card: UnitCards.BOUNTY_COLLECTOR, quantity: 2 },
-    // 6 Ranged
-    { card: UnitCards.JAVELINEER, quantity: 4 },
-    { card: UnitCards.MERRY_RALLIER, quantity: 2 },
-    // 6 Spells
-    { card: SpellCards.THROW_SHURIKEN, quantity: 2 },
-    { card: SpellCards.RAIN_OF_ARROWS, quantity: 4 },
-];
+export const MONKS_DECKLIST: DeckList = {
+    mainBoard: [
+        // 22 Resources
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 7 },
+        { card: makeResourceCard(Resource.IRON), quantity: 7 },
+        { card: AdvancedResourceCards.TANGLED_RUINS, quantity: 4 },
+        { card: AdvancedResourceCards.PREFECTURE_CAPITAL, quantity: 4 },
+        // 20 Soldiers
+        { card: UnitCards.PIKEMAN, quantity: 4 },
+        { card: UnitCards.LANCER, quantity: 4 },
+        { card: UnitCards.INFANTRY_OFFICER, quantity: 4 },
+        { card: UnitCards.SQUIRE, quantity: 3 },
+        { card: UnitCards.ORCISH_CORPORAL, quantity: 2 },
+        { card: UnitCards.MARTIAL_TRAINER, quantity: 3 },
+        // 6 Assassins
+        { card: UnitCards.ASSASSIN, quantity: 2 },
+        { card: UnitCards.SHADOW_STRIKER, quantity: 2 },
+        { card: UnitCards.BOUNTY_COLLECTOR, quantity: 2 },
+        // 6 Ranged
+        { card: UnitCards.JAVELINEER, quantity: 4 },
+        { card: UnitCards.MERRY_RALLIER, quantity: 2 },
+        // 6 Spells
+        { card: SpellCards.THROW_SHURIKEN, quantity: 2 },
+        { card: SpellCards.RAIN_OF_ARROWS, quantity: 4 },
+    ],
+    sideBoard: [],
+};
 
 // Bamboo + Iron (mock version, for mocks only)
-export const SAMPLE_DECKLIST_1: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 23 },
-    { card: makeResourceCard(Resource.IRON), quantity: 12 },
-    // Soldiers
-    { card: UnitCards.SQUIRE, quantity: 3 },
-    { card: UnitCards.LANCER, quantity: 3 },
-    { card: UnitCards.MARTIAL_TRAINER, quantity: 3 },
-    { card: UnitCards.KNIGHT_TEMPLAR, quantity: 3 },
-    // Assassins
-    { card: UnitCards.ASSASSIN, quantity: 2 },
-    { card: UnitCards.SHADOW_STRIKER, quantity: 2 },
-    { card: UnitCards.BOUNTY_COLLECTOR, quantity: 3 },
-    // Ranged
-    { card: UnitCards.LONGBOWMAN, quantity: 3 },
-    { card: UnitCards.JAVELINEER, quantity: 3 },
-];
+export const SAMPLE_DECKLIST_1: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 23 },
+        { card: makeResourceCard(Resource.IRON), quantity: 12 },
+        // Soldiers
+        { card: UnitCards.SQUIRE, quantity: 3 },
+        { card: UnitCards.LANCER, quantity: 3 },
+        { card: UnitCards.MARTIAL_TRAINER, quantity: 3 },
+        { card: UnitCards.KNIGHT_TEMPLAR, quantity: 3 },
+        // Assassins
+        { card: UnitCards.ASSASSIN, quantity: 2 },
+        { card: UnitCards.SHADOW_STRIKER, quantity: 2 },
+        { card: UnitCards.BOUNTY_COLLECTOR, quantity: 3 },
+        // Ranged
+        { card: UnitCards.LONGBOWMAN, quantity: 3 },
+        { card: UnitCards.JAVELINEER, quantity: 3 },
+    ],
+    sideBoard: [],
+};
 
 // Fire + Crystal (Fire Mage)
-export const FIRE_MAGES_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.FIRE), quantity: 8 },
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 6 },
-    { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 4 },
-    { card: AdvancedResourceCards.LONE_TOWER, quantity: 4 },
-    { card: AdvancedResourceCards.LAVA_RIVER, quantity: 2 },
-    // Units
-    { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    { card: UnitCards.MIDNIGHT_HELLSPAWN, quantity: 2 },
-    { card: UnitCards.INFERNO_SORCEROR, quantity: 4 },
-    // Spells
-    { card: SpellCards.SUPERNOVA, quantity: 4 },
-    { card: SpellCards.BEAM_ME_UP, quantity: 4 },
-    { card: SpellCards.STRIKE_TWICE, quantity: 2 },
-    { card: SpellCards.EMBER_SPEAR, quantity: 4 },
-    { card: SpellCards.SPECTRAL_GENESIS, quantity: 2 },
-    { card: SpellCards.DISTORT_REALITY, quantity: 2 },
-    { card: SpellCards.VOLCANIC_INFERNO, quantity: 4 },
-    { card: SpellCards.CAVE_IMPLOSION, quantity: 4 },
-];
+export const FIRE_MAGES_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.FIRE), quantity: 8 },
+        { card: makeResourceCard(Resource.CRYSTAL), quantity: 6 },
+        { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 4 },
+        { card: AdvancedResourceCards.LONE_TOWER, quantity: 4 },
+        { card: AdvancedResourceCards.LAVA_RIVER, quantity: 2 },
+        // Units
+        { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
+        { card: UnitCards.MIDNIGHT_HELLSPAWN, quantity: 2 },
+        { card: UnitCards.INFERNO_SORCEROR, quantity: 4 },
+        // Spells
+        { card: SpellCards.SUPERNOVA, quantity: 4 },
+        { card: SpellCards.BEAM_ME_UP, quantity: 4 },
+        { card: SpellCards.STRIKE_TWICE, quantity: 2 },
+        { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+        { card: SpellCards.SPECTRAL_GENESIS, quantity: 2 },
+        { card: SpellCards.DISTORT_REALITY, quantity: 2 },
+        { card: SpellCards.VOLCANIC_INFERNO, quantity: 4 },
+        { card: SpellCards.CAVE_IMPLOSION, quantity: 4 },
+    ],
+    sideBoard: [],
+};
 
 // Water + Crystal (Water Mage)
-export const WATER_MAGES_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.WATER), quantity: 14 },
-    { card: AdvancedResourceCards.COASTAL_CASTLE, quantity: 4 },
-    { card: AdvancedResourceCards.CHILLY_BERG, quantity: 4 },
-    // Units
-    { card: UnitCards.FROST_WYRM, quantity: 1 },
-    { card: UnitCards.GIANT_JELLY, quantity: 4 },
-    { card: UnitCards.LAKE_ZOMBIE, quantity: 4 },
-    { card: UnitCards.MEDITATION_EXPERT, quantity: 2 },
-    { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
-    { card: UnitCards.MANTA_RAY_CONJURER, quantity: 2 },
-    { card: UnitCards.RAIN_CHANNELER, quantity: 1 },
-    { card: UnitCards.WAVING_FISHERMAN, quantity: 1 },
-    { card: UnitCards.FROST_WALKER, quantity: 2 },
-    { card: UnitCards.MISBEGOTTEN_MISTWALKER, quantity: 1 },
-    { card: UnitCards.PEACE_BRINGER, quantity: 1 },
-    { card: UnitCards.WATER_MAGE, quantity: 4 },
-    { card: UnitCards.THUNDER_SCHEDULER, quantity: 3 },
-    { card: UnitCards.MAELSTROM_SEEKER, quantity: 1 },
+export const WATER_MAGES_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.WATER), quantity: 14 },
+        { card: AdvancedResourceCards.COASTAL_CASTLE, quantity: 4 },
+        { card: AdvancedResourceCards.CHILLY_BERG, quantity: 4 },
+        // Units
+        { card: UnitCards.FROST_WYRM, quantity: 1 },
+        { card: UnitCards.GIANT_JELLY, quantity: 4 },
+        { card: UnitCards.LAKE_ZOMBIE, quantity: 4 },
+        { card: UnitCards.MEDITATION_EXPERT, quantity: 2 },
+        { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
+        { card: UnitCards.MANTA_RAY_CONJURER, quantity: 2 },
+        { card: UnitCards.RAIN_CHANNELER, quantity: 1 },
+        { card: UnitCards.WAVING_FISHERMAN, quantity: 1 },
+        { card: UnitCards.FROST_WALKER, quantity: 2 },
+        { card: UnitCards.MISBEGOTTEN_MISTWALKER, quantity: 1 },
+        { card: UnitCards.PEACE_BRINGER, quantity: 1 },
+        { card: UnitCards.WATER_MAGE, quantity: 4 },
+        { card: UnitCards.THUNDER_SCHEDULER, quantity: 3 },
+        { card: UnitCards.MAELSTROM_SEEKER, quantity: 1 },
 
-    // Spells
-    { card: SpellCards.COLD_ISOLATION, quantity: 4 },
-    { card: SpellCards.REFLECTION_OPPORTUNITY, quantity: 1 },
-    { card: SpellCards.PIERCE_THE_HEAVENS, quantity: 2 },
-];
+        // Spells
+        { card: SpellCards.COLD_ISOLATION, quantity: 4 },
+        { card: SpellCards.REFLECTION_OPPORTUNITY, quantity: 1 },
+        { card: SpellCards.PIERCE_THE_HEAVENS, quantity: 2 },
+    ],
+    sideBoard: [],
+};
 
 // Water + Fire (aka wind)
-export const WIND_MAGES_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.WATER), quantity: 8 },
-    { card: makeResourceCard(Resource.FIRE), quantity: 8 },
-    { card: AdvancedResourceCards.CLOUD_HAVEN, quantity: 4 },
-    { card: AdvancedResourceCards.TROUBLED_PARADISE, quantity: 4 },
-    { card: AdvancedResourceCards.CHILLY_BERG, quantity: 1 },
-    // Units
-    { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
-    { card: UnitCards.HEAVENLY_FERRIER, quantity: 2 },
-    { card: UnitCards.FLUX_FIGHTER, quantity: 4 },
-    { card: UnitCards.FERRY_OPERATOR, quantity: 4 },
-    { card: UnitCards.WATER_MAGE, quantity: 3 },
-    { card: UnitCards.WIND_MAGE, quantity: 2 },
-    { card: UnitCards.ARCHANGEL, quantity: 3 },
+export const WIND_MAGES_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.WATER), quantity: 8 },
+        { card: makeResourceCard(Resource.FIRE), quantity: 8 },
+        { card: AdvancedResourceCards.CLOUD_HAVEN, quantity: 4 },
+        { card: AdvancedResourceCards.TROUBLED_PARADISE, quantity: 4 },
+        { card: AdvancedResourceCards.CHILLY_BERG, quantity: 1 },
+        // Units
+        { card: UnitCards.FIRE_TECHNICIAN, quantity: 4 },
+        { card: UnitCards.HEAVENLY_FERRIER, quantity: 2 },
+        { card: UnitCards.FLUX_FIGHTER, quantity: 4 },
+        { card: UnitCards.FERRY_OPERATOR, quantity: 4 },
+        { card: UnitCards.WATER_MAGE, quantity: 3 },
+        { card: UnitCards.WIND_MAGE, quantity: 2 },
+        { card: UnitCards.ARCHANGEL, quantity: 3 },
 
-    // Spells
-    { card: SpellCards.EMBER_SPEAR, quantity: 4 },
-    { card: SpellCards.A_GENTLE_GUST, quantity: 2 },
-    { card: SpellCards.SOLFATARA, quantity: 2 },
-    { card: SpellCards.A_THOUSAND_WINDS, quantity: 3 },
-    { card: SpellCards.COLLOSAL_TSUNAMI, quantity: 2 },
-];
+        // Spells
+        { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+        { card: SpellCards.A_GENTLE_GUST, quantity: 2 },
+        { card: SpellCards.SOLFATARA, quantity: 2 },
+        { card: SpellCards.A_THOUSAND_WINDS, quantity: 3 },
+        { card: SpellCards.COLLOSAL_TSUNAMI, quantity: 2 },
+    ],
+    sideBoard: [],
+};
 
 // Bamboo + Iron - Farmer deck
-export const FARMERS_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 7 },
-    { card: makeResourceCard(Resource.IRON), quantity: 3 },
-    { card: AdvancedResourceCards.TANGLED_RUINS, quantity: 4 },
-    { card: AdvancedResourceCards.PREFECTURE_CAPITAL, quantity: 4 },
-    { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
-    // Units
-    { card: UnitCards.ALERT_FELINE, quantity: 4 },
-    { card: UnitCards.ANGRY_HEN, quantity: 4 },
-    { card: UnitCards.STONE_SLINGER, quantity: 4 },
-    { card: UnitCards.SWORDS_MASTER, quantity: 4 },
-    { card: UnitCards.BOUNTY_COLLECTOR, quantity: 4 },
-    { card: UnitCards.CAVALRY_ARCHER, quantity: 4 },
-    { card: UnitCards.CANYON_ELITE, quantity: 2 },
-    { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
-    { card: UnitCards.ADVENTURER, quantity: 2 },
-    { card: UnitCards.EXCELLENT_EQUESTRIAN, quantity: 2 },
-    // Spells
-    { card: SpellCards.CONCENTRATED_FOCUS, quantity: 3 },
-    { card: SpellCards.FISH_MARKET_VISIT, quantity: 1 },
-];
+export const FARMERS_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 7 },
+        { card: makeResourceCard(Resource.IRON), quantity: 3 },
+        { card: AdvancedResourceCards.TANGLED_RUINS, quantity: 4 },
+        { card: AdvancedResourceCards.PREFECTURE_CAPITAL, quantity: 4 },
+        { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
+        // Units
+        { card: UnitCards.ALERT_FELINE, quantity: 4 },
+        { card: UnitCards.ANGRY_HEN, quantity: 4 },
+        { card: UnitCards.STONE_SLINGER, quantity: 4 },
+        { card: UnitCards.SWORDS_MASTER, quantity: 4 },
+        { card: UnitCards.BOUNTY_COLLECTOR, quantity: 4 },
+        { card: UnitCards.CAVALRY_ARCHER, quantity: 4 },
+        { card: UnitCards.CANYON_ELITE, quantity: 2 },
+        { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
+        { card: UnitCards.ADVENTURER, quantity: 2 },
+        { card: UnitCards.EXCELLENT_EQUESTRIAN, quantity: 2 },
+        // Spells
+        { card: SpellCards.CONCENTRATED_FOCUS, quantity: 3 },
+        { card: SpellCards.FISH_MARKET_VISIT, quantity: 1 },
+    ],
+    sideBoard: [],
+};
 
 // Crystal + Iron - (Genie Deck)
-export const GENIES_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 6 },
-    { card: makeResourceCard(Resource.IRON), quantity: 6 },
-    { card: AdvancedResourceCards.SAHARAN_DESERT, quantity: 4 },
-    { card: AdvancedResourceCards.DIVINE_PALACE, quantity: 4 },
-    { card: AdvancedResourceCards.TREACHEROUS_DESERT, quantity: 2 },
-    // Units
-    { card: UnitCards.NOVICE_ASTRONOMER, quantity: 4 },
-    { card: UnitCards.FORTUNE_PREDICTOR, quantity: 4 },
-    { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    { card: UnitCards.CAPTAIN_OF_THE_GUARD, quantity: 4 },
-    { card: UnitCards.ENERGY_ENHANCER, quantity: 2 },
-    { card: UnitCards.SPIRIT_TENDER, quantity: 1 },
-    { card: UnitCards.UNHOLY_VETERAN, quantity: 1 },
-    { card: UnitCards.MAGI_RIDER, quantity: 4 },
-    // Spells
-    { card: SpellCards.DISTORT_REALITY, quantity: 2 },
-    { card: SpellCards.DECAY, quantity: 1 },
-    { card: SpellCards.OPEN_NEBULA, quantity: 1 },
-    { card: SpellCards.SPECTRAL_GENESIS, quantity: 4 },
-    { card: SpellCards.ZEN_STANCE, quantity: 4 },
-    { card: SpellCards.SIGNAL_BEACON, quantity: 2 },
-];
+export const GENIES_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.CRYSTAL), quantity: 6 },
+        { card: makeResourceCard(Resource.IRON), quantity: 6 },
+        { card: AdvancedResourceCards.SAHARAN_DESERT, quantity: 4 },
+        { card: AdvancedResourceCards.DIVINE_PALACE, quantity: 4 },
+        { card: AdvancedResourceCards.TREACHEROUS_DESERT, quantity: 2 },
+        // Units
+        { card: UnitCards.NOVICE_ASTRONOMER, quantity: 4 },
+        { card: UnitCards.FORTUNE_PREDICTOR, quantity: 4 },
+        { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
+        { card: UnitCards.CAPTAIN_OF_THE_GUARD, quantity: 4 },
+        { card: UnitCards.ENERGY_ENHANCER, quantity: 2 },
+        { card: UnitCards.SPIRIT_TENDER, quantity: 1 },
+        { card: UnitCards.UNHOLY_VETERAN, quantity: 1 },
+        { card: UnitCards.MAGI_RIDER, quantity: 4 },
+        // Spells
+        { card: SpellCards.DISTORT_REALITY, quantity: 2 },
+        { card: SpellCards.DECAY, quantity: 1 },
+        { card: SpellCards.OPEN_NEBULA, quantity: 1 },
+        { card: SpellCards.SPECTRAL_GENESIS, quantity: 4 },
+        { card: SpellCards.ZEN_STANCE, quantity: 4 },
+        { card: SpellCards.SIGNAL_BEACON, quantity: 2 },
+    ],
+    sideBoard: [],
+};
 
 // Crystal + Water + Fire - (Sorceror Deck)
-export const SORCERORS_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 2 },
-    { card: AdvancedResourceCards.CLOUD_HAVEN, quantity: 4 },
-    { card: AdvancedResourceCards.SEASIDE_COVE, quantity: 4 },
-    { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 4 },
-    { card: AdvancedResourceCards.LONE_TOWER, quantity: 4 },
-    { card: AdvancedResourceCards.MYSTIFYING_LAKE, quantity: 4 },
-    { card: AdvancedResourceCards.TROUBLED_PARADISE, quantity: 4 },
-    // Magicians
-    { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
-    { card: UnitCards.FIRE_MAGE, quantity: 1 },
-    { card: UnitCards.WATER_MAGE, quantity: 1 },
-    { card: UnitCards.ALADDIN, quantity: 2 },
-    { card: UnitCards.BRIGHT_SCHOLAR, quantity: 2 },
-    { card: UnitCards.INFERNO_SORCEROR, quantity: 1 },
-    { card: UnitCards.CURIOUS_RESEARCHER, quantity: 2 },
-    { card: UnitCards.WATER_GUARDIAN, quantity: 1 },
-    // Spells
-    { card: SpellCards.INCREDIBLE_DISCOVERY, quantity: 3 },
-    { card: SpellCards.SCOUR_THE_LIBRARY, quantity: 3 },
-    { card: SpellCards.HOLY_REVIVAL, quantity: 2 },
-    { card: SpellCards.CONSTANT_REFILL, quantity: 2 },
-    { card: SpellCards.SUMMON_DEMONS, quantity: 1 },
-    { card: SpellCards.VOLCANIC_INFERNO, quantity: 3 },
-    { card: SpellCards.EMBER_SPEAR, quantity: 2 },
-    { card: SpellCards.BUBBLE_BLAST, quantity: 2 },
-    { card: SpellCards.SPECTRAL_GENESIS, quantity: 2 },
-];
+export const SORCERORS_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.CRYSTAL), quantity: 2 },
+        { card: AdvancedResourceCards.CLOUD_HAVEN, quantity: 4 },
+        { card: AdvancedResourceCards.SEASIDE_COVE, quantity: 4 },
+        { card: AdvancedResourceCards.STRATOVOLCANO, quantity: 4 },
+        { card: AdvancedResourceCards.LONE_TOWER, quantity: 4 },
+        { card: AdvancedResourceCards.MYSTIFYING_LAKE, quantity: 4 },
+        { card: AdvancedResourceCards.TROUBLED_PARADISE, quantity: 4 },
+        // Magicians
+        { card: UnitCards.MAGICIANS_APPRENTICE, quantity: 4 },
+        { card: UnitCards.FIRE_MAGE, quantity: 1 },
+        { card: UnitCards.WATER_MAGE, quantity: 1 },
+        { card: UnitCards.ALADDIN, quantity: 2 },
+        { card: UnitCards.BRIGHT_SCHOLAR, quantity: 2 },
+        { card: UnitCards.INFERNO_SORCEROR, quantity: 1 },
+        { card: UnitCards.CURIOUS_RESEARCHER, quantity: 2 },
+        { card: UnitCards.WATER_GUARDIAN, quantity: 1 },
+        // Spells
+        { card: SpellCards.INCREDIBLE_DISCOVERY, quantity: 3 },
+        { card: SpellCards.SCOUR_THE_LIBRARY, quantity: 3 },
+        { card: SpellCards.HOLY_REVIVAL, quantity: 2 },
+        { card: SpellCards.CONSTANT_REFILL, quantity: 2 },
+        { card: SpellCards.SUMMON_DEMONS, quantity: 1 },
+        { card: SpellCards.VOLCANIC_INFERNO, quantity: 3 },
+        { card: SpellCards.EMBER_SPEAR, quantity: 2 },
+        { card: SpellCards.BUBBLE_BLAST, quantity: 2 },
+        { card: SpellCards.SPECTRAL_GENESIS, quantity: 2 },
+    ],
+    sideBoard: [],
+};
 
 // Water + Bamboo (Coral)
-export const DIVERS_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.WATER), quantity: 8 },
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 8 },
-    { card: AdvancedResourceCards.LUSH_REEF, quantity: 4 },
-    { card: AdvancedResourceCards.ROYAL_RESIDENCE, quantity: 4 },
-    // Units
-    { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
-    { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
-    { card: UnitCards.SEASONAL_CROPHAND, quantity: 4 },
-    { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
-    { card: UnitCards.PASTURE_EXPLORER, quantity: 3 },
-    { card: UnitCards.FALCON_RIDER, quantity: 4 },
-    { card: UnitCards.MERRY_RALLIER, quantity: 4 },
-    { card: UnitCards.DEEP_SEA_EXPLORER, quantity: 4 },
-    { card: UnitCards.ICTHYOMANCER, quantity: 1 },
+export const DIVERS_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.WATER), quantity: 8 },
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 8 },
+        { card: AdvancedResourceCards.LUSH_REEF, quantity: 4 },
+        { card: AdvancedResourceCards.ROYAL_RESIDENCE, quantity: 4 },
+        // Units
+        { card: UnitCards.BAMBOO_FARMER, quantity: 4 },
+        { card: UnitCards.RELAXED_ROWBOATER, quantity: 4 },
+        { card: UnitCards.SEASONAL_CROPHAND, quantity: 4 },
+        { card: UnitCards.MANTA_RAY_CONJURER, quantity: 4 },
+        { card: UnitCards.PASTURE_EXPLORER, quantity: 3 },
+        { card: UnitCards.FALCON_RIDER, quantity: 4 },
+        { card: UnitCards.MERRY_RALLIER, quantity: 4 },
+        { card: UnitCards.DEEP_SEA_EXPLORER, quantity: 4 },
+        { card: UnitCards.ICTHYOMANCER, quantity: 1 },
 
-    // Spells
-    { card: SpellCards.BUBBLE_BLAST, quantity: 1 },
-    { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
-];
+        // Spells
+        { card: SpellCards.BUBBLE_BLAST, quantity: 1 },
+        { card: SpellCards.RAIN_OF_ARROWS, quantity: 3 },
+    ],
+    sideBoard: [],
+};
 
 // Iron + Fire (Cannoneers)
-export const CANNONEERS_DECKLIST: DeckList = [
-    // Resources
-    { card: makeResourceCard(Resource.IRON), quantity: 8 },
-    { card: makeResourceCard(Resource.FIRE), quantity: 8 },
-    { card: AdvancedResourceCards.SMELTING_FORGE, quantity: 4 },
-    { card: AdvancedResourceCards.ORNATE_TEMPLE, quantity: 4 },
-    // Units
-    { card: UnitCards.FIRE_TECHNICIAN, quantity: 3 },
-    { card: UnitCards.QUARRY_WORKER, quantity: 4 },
-    { card: UnitCards.SQUIRE, quantity: 3 },
-    { card: UnitCards.MARTIAL_TRAINER, quantity: 2 },
-    { card: UnitCards.FIRE_MAGE, quantity: 4 },
-    { card: UnitCards.CANNON, quantity: 4 },
-    { card: UnitCards.ZEALOUS_ACOLYTE, quantity: 1 },
-    { card: UnitCards.BANISHER_OF_MAGIC, quantity: 1 },
+export const CANNONEERS_DECKLIST: DeckList = {
+    mainBoard: [
+        // Resources
+        { card: makeResourceCard(Resource.IRON), quantity: 8 },
+        { card: makeResourceCard(Resource.FIRE), quantity: 8 },
+        { card: AdvancedResourceCards.SMELTING_FORGE, quantity: 4 },
+        { card: AdvancedResourceCards.ORNATE_TEMPLE, quantity: 4 },
+        // Units
+        { card: UnitCards.FIRE_TECHNICIAN, quantity: 3 },
+        { card: UnitCards.QUARRY_WORKER, quantity: 4 },
+        { card: UnitCards.SQUIRE, quantity: 3 },
+        { card: UnitCards.MARTIAL_TRAINER, quantity: 2 },
+        { card: UnitCards.FIRE_MAGE, quantity: 4 },
+        { card: UnitCards.CANNON, quantity: 4 },
+        { card: UnitCards.ZEALOUS_ACOLYTE, quantity: 1 },
+        { card: UnitCards.BANISHER_OF_MAGIC, quantity: 1 },
 
-    // Spells
-    { card: SpellCards.EMBER_SPEAR, quantity: 4 },
-    { card: SpellCards.IGNITE_SPARKS, quantity: 4 },
-    { card: SpellCards.FESTIVE_BAZAAR, quantity: 4 },
-    { card: SpellCards.FIRE_AWAY, quantity: 1 },
-    { card: SpellCards.BESIEGE_THE_CASTLE, quantity: 1 },
-];
+        // Spells
+        { card: SpellCards.EMBER_SPEAR, quantity: 4 },
+        { card: SpellCards.IGNITE_SPARKS, quantity: 4 },
+        { card: SpellCards.FESTIVE_BAZAAR, quantity: 4 },
+        { card: SpellCards.FIRE_AWAY, quantity: 1 },
+        { card: SpellCards.BESIEGE_THE_CASTLE, quantity: 1 },
+    ],
+    sideBoard: [],
+};
 
-export const PIRATES_DECKLIST: DeckList = [
-    { card: SpellCards.RAISE_THE_MASTS, quantity: 4 },
-    { card: UnitCards.ELDER_PIRATE, quantity: 4 },
-    { card: UnitCards.NOBLE_STEED, quantity: 4 },
-    { card: UnitCards.SCHEMING_EXPLORER, quantity: 4 },
-    { card: UnitCards.DARING_CORSAIR, quantity: 4 },
-    { card: UnitCards.SHIP_COXSWAIN, quantity: 4 },
-    { card: UnitCards.CUTLASS_CRUSADER, quantity: 2 },
-    { card: UnitCards.SPELUNKER, quantity: 4 },
-    { card: UnitCards.IRONSMITH, quantity: 2 },
-    { card: UnitCards.QUESTING_DUO, quantity: 4 },
-    { card: UnitCards.PIKEMAN, quantity: 2 },
-    { card: makeResourceCard(Resource.IRON), quantity: 4 },
-    { card: makeResourceCard(Resource.WATER), quantity: 4 },
-    { card: AdvancedResourceCards.HARBOR_TOWN, quantity: 4 },
-    { card: AdvancedResourceCards.CITY_CANALS, quantity: 4 },
-    { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
-    { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 2 },
-];
+export const PIRATES_DECKLIST: DeckList = {
+    mainBoard: [
+        { card: SpellCards.RAISE_THE_MASTS, quantity: 4 },
+        { card: UnitCards.ELDER_PIRATE, quantity: 4 },
+        { card: UnitCards.NOBLE_STEED, quantity: 4 },
+        { card: UnitCards.SCHEMING_EXPLORER, quantity: 4 },
+        { card: UnitCards.DARING_CORSAIR, quantity: 4 },
+        { card: UnitCards.SHIP_COXSWAIN, quantity: 4 },
+        { card: UnitCards.CUTLASS_CRUSADER, quantity: 2 },
+        { card: UnitCards.SPELUNKER, quantity: 4 },
+        { card: UnitCards.IRONSMITH, quantity: 2 },
+        { card: UnitCards.QUESTING_DUO, quantity: 4 },
+        { card: UnitCards.PIKEMAN, quantity: 2 },
+        { card: makeResourceCard(Resource.IRON), quantity: 4 },
+        { card: makeResourceCard(Resource.WATER), quantity: 4 },
+        { card: AdvancedResourceCards.HARBOR_TOWN, quantity: 4 },
+        { card: AdvancedResourceCards.CITY_CANALS, quantity: 4 },
+        { card: AdvancedResourceCards.SLAG_FIELDS, quantity: 4 },
+        { card: AdvancedResourceCards.OLD_FARMHOUSE, quantity: 2 },
+    ],
+    sideBoard: [],
+};
 
-export const ALL_BASIC_RESOURCES: DeckList = [
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
-    { card: makeResourceCard(Resource.FIRE), quantity: 1 },
-    { card: makeResourceCard(Resource.IRON), quantity: 1 },
-    { card: makeResourceCard(Resource.WATER), quantity: 1 },
-];
+export const ALL_BASIC_RESOURCES: DeckList = {
+    mainBoard: [
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
+        { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
+        { card: makeResourceCard(Resource.FIRE), quantity: 1 },
+        { card: makeResourceCard(Resource.IRON), quantity: 1 },
+        { card: makeResourceCard(Resource.WATER), quantity: 1 },
+    ],
+    sideBoard: [],
+};
 
 // For debugging / gamebuilding purposes
-export const ALL_CARDS: DeckList = [
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
-    { card: makeResourceCard(Resource.FIRE), quantity: 1 },
-    { card: makeResourceCard(Resource.IRON), quantity: 1 },
-    { card: makeResourceCard(Resource.WATER), quantity: 1 },
-    ...Object.values(AdvancedResourceCards).map((card) => {
-        return { card, quantity: 1 };
-    }),
-    ...Object.values(SpellCards)
-        .filter((card) => !card.isTokenOnly)
-        .map((card) => {
+export const ALL_CARDS: DeckList = {
+    mainBoard: [
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
+        { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
+        { card: makeResourceCard(Resource.FIRE), quantity: 1 },
+        { card: makeResourceCard(Resource.IRON), quantity: 1 },
+        { card: makeResourceCard(Resource.WATER), quantity: 1 },
+        ...Object.values(AdvancedResourceCards).map((card) => {
             return { card, quantity: 1 };
         }),
-    ...Object.values(UnitCards).map((card) => {
-        return { card, quantity: 1 };
-    }),
-];
+        ...Object.values(SpellCards)
+            .filter((card) => !card.isTokenOnly)
+            .map((card) => {
+                return { card, quantity: 1 };
+            }),
+        ...Object.values(UnitCards).map((card) => {
+            return { card, quantity: 1 };
+        }),
+    ],
+    sideBoard: [],
+};
 
-export const ALL_CARDS_AND_TOKENS: DeckList = [
-    { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
-    { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
-    { card: makeResourceCard(Resource.FIRE), quantity: 1 },
-    { card: makeResourceCard(Resource.IRON), quantity: 1 },
-    { card: makeResourceCard(Resource.WATER), quantity: 1 },
-    ...Object.values(AdvancedResourceCards).map((card) => {
-        return { card, quantity: 1 };
-    }),
-    ...Object.values(SpellCards).map((card) => {
-        return { card, quantity: 1 };
-    }),
-    ...Object.values(UnitCards).map((card) => {
-        return { card, quantity: 1 };
-    }),
-    ...Object.values(Tokens).map((card) => {
-        return { card, quantity: 1 };
-    }),
-];
+export const ALL_CARDS_AND_TOKENS: DeckList = {
+    mainBoard: [
+        { card: makeResourceCard(Resource.BAMBOO), quantity: 1 },
+        { card: makeResourceCard(Resource.CRYSTAL), quantity: 1 },
+        { card: makeResourceCard(Resource.FIRE), quantity: 1 },
+        { card: makeResourceCard(Resource.IRON), quantity: 1 },
+        { card: makeResourceCard(Resource.WATER), quantity: 1 },
+        ...Object.values(AdvancedResourceCards).map((card) => {
+            return { card, quantity: 1 };
+        }),
+        ...Object.values(SpellCards).map((card) => {
+            return { card, quantity: 1 };
+        }),
+        ...Object.values(UnitCards).map((card) => {
+            return { card, quantity: 1 };
+        }),
+        ...Object.values(Tokens).map((card) => {
+            return { card, quantity: 1 };
+        }),
+    ],
+    sideBoard: [],
+};

--- a/src/factories/board/makeNewBoard.spec.ts
+++ b/src/factories/board/makeNewBoard.spec.ts
@@ -67,9 +67,10 @@ describe('Make New Board', () => {
 
     it('makes a board with custom decklists', () => {
         const nameToCustomDeckSkeleton = new Map<string, Skeleton>();
-        nameToCustomDeckSkeleton.set('Hal', [
-            { card: 'Assassin', quantity: 4 },
-        ]);
+        nameToCustomDeckSkeleton.set('Hal', {
+            mainBoard: [{ card: 'Assassin', quantity: 4 }],
+            sideBoard: [],
+        });
         const board = makeNewBoard({
             playerNames: ['Hal', 'Orin', 'Samus'],
             nameToCustomDeckSkeleton,

--- a/src/factories/deck/makeDeck.spec.ts
+++ b/src/factories/deck/makeDeck.spec.ts
@@ -6,16 +6,19 @@ import { makeDeck } from './makeDeck';
 
 describe('Make Deck', () => {
     it('takes a decklist and makes a deck', () => {
-        const deckList: DeckList = [
-            {
-                card: makeResourceCard(Resource.BAMBOO),
-                quantity: 20,
-            },
-            {
-                card: makeCard(UnitCards.LONGBOWMAN),
-                quantity: 4,
-            },
-        ];
+        const deckList: DeckList = {
+            mainBoard: [
+                {
+                    card: makeResourceCard(Resource.BAMBOO),
+                    quantity: 20,
+                },
+                {
+                    card: makeCard(UnitCards.LONGBOWMAN),
+                    quantity: 4,
+                },
+            ],
+            sideBoard: [],
+        };
 
         const deck = makeDeck(deckList);
         expect(

--- a/src/factories/deck/makeDeck.ts
+++ b/src/factories/deck/makeDeck.ts
@@ -9,7 +9,7 @@ import { SAMPLE_DECKLIST_1 } from '@/constants/deckLists';
  */
 export const makeDeck = (deckList: DeckList): Card[] => {
     const cards: Card[] = [];
-    deckList.forEach(({ card, quantity }) => {
+    deckList.mainBoard.forEach(({ card, quantity }) => {
         [...new Array(quantity)].forEach(() => {
             if (card.cardType !== CardType.RESOURCE) {
                 cards.push(makeCard(card));

--- a/src/factories/player/makeNewPlayer.spec.ts
+++ b/src/factories/player/makeNewPlayer.spec.ts
@@ -1,12 +1,16 @@
 import { Resource } from '@/types/resources';
 import { makeResourceCard } from '../cards';
 import { makeNewPlayer } from './makeNewPlayer';
+import { DeckList } from '@/types/cards';
 
 describe('Make New Player', () => {
     it('generates distinct decks for players', () => {
-        const decklist = [
-            { card: makeResourceCard(Resource.BAMBOO), quantity: 9 },
-        ];
+        const decklist: DeckList = {
+            mainBoard: [
+                { card: makeResourceCard(Resource.BAMBOO), quantity: 9 },
+            ],
+            sideBoard: [],
+        };
         const player1 = makeNewPlayer({ name: 'Minnie Mouse', decklist });
         const player2 = makeNewPlayer({ name: 'Donald Duck', decklist });
         expect(player1.name).toBe('Minnie Mouse');

--- a/src/mocks/savedDecks.ts
+++ b/src/mocks/savedDecks.ts
@@ -5,7 +5,10 @@ export const mockSavedDeck: SavedDeck = {
     createdAt: 12345,
     id: uuidv4(),
     name: 'my first deck',
-    skeleton: [{ card: 'Smelting Forge', quantity: 4 }],
+    skeleton: {
+        mainBoard: [{ card: 'Smelting Forge', quantity: 4 }],
+        sideBoard: [],
+    },
     updateAt: 12345,
     userUid: 'auth0Id|a01fde2',
 };

--- a/src/transformers/getDeckListFromSkeleton/getDeckListFromSkeleton.spec.ts
+++ b/src/transformers/getDeckListFromSkeleton/getDeckListFromSkeleton.spec.ts
@@ -3,39 +3,45 @@ import { getDeckListFromSkeleton } from './getDeckListFromSkeleton';
 
 describe('get decklist from skeleton', () => {
     it('extracts cards by name', () => {
-        const { decklist, errors } = getDeckListFromSkeleton([
-            {
-                card: 'Lancer',
-                quantity: 4,
-            },
-            {
-                card: 'Iron',
-                quantity: 4,
-            },
-        ]);
-        expect(decklist[0].card.name).toBe('Lancer');
-        expect(decklist[0].quantity).toBe(4);
-        expect(decklist[1].card.name).toBe('Iron');
-        expect(decklist[1].card.cardType).toBe(CardType.RESOURCE);
-        expect(decklist[1].quantity).toBe(4);
+        const { decklist, errors } = getDeckListFromSkeleton({
+            mainBoard: [
+                {
+                    card: 'Lancer',
+                    quantity: 4,
+                },
+                {
+                    card: 'Iron',
+                    quantity: 4,
+                },
+            ],
+            sideBoard: [],
+        });
+        expect(decklist.mainBoard[0].card.name).toBe('Lancer');
+        expect(decklist.mainBoard[0].quantity).toBe(4);
+        expect(decklist.mainBoard[1].card.name).toBe('Iron');
+        expect(decklist.mainBoard[1].card.cardType).toBe(CardType.RESOURCE);
+        expect(decklist.mainBoard[1].quantity).toBe(4);
         expect(errors).toEqual([]);
     });
 
     it('skips over typos and bad inputs', () => {
-        const { decklist, errors } = getDeckListFromSkeleton([
-            {
-                card: 'LancerZ',
-                quantity: 4,
-            },
-            {
-                card: 'Iron',
-                quantity: 4,
-            },
-        ]);
-        expect(decklist[0].card.name).toBe('Iron');
-        expect(decklist[0].card.cardType).toBe(CardType.RESOURCE);
-        expect(decklist[0].quantity).toBe(4);
-        expect(decklist).toHaveLength(1);
+        const { decklist, errors } = getDeckListFromSkeleton({
+            mainBoard: [
+                {
+                    card: 'LancerZ',
+                    quantity: 4,
+                },
+                {
+                    card: 'Iron',
+                    quantity: 4,
+                },
+            ],
+            sideBoard: [],
+        });
+        expect(decklist.mainBoard[0].card.name).toBe('Iron');
+        expect(decklist.mainBoard[0].card.cardType).toBe(CardType.RESOURCE);
+        expect(decklist.mainBoard[0].quantity).toBe(4);
+        expect(decklist.mainBoard).toHaveLength(1);
         expect(errors).toEqual(['Could not read "LancerZ"']);
     });
 });

--- a/src/transformers/getDeckListFromSkeleton/getDeckListFromSkeleton.ts
+++ b/src/transformers/getDeckListFromSkeleton/getDeckListFromSkeleton.ts
@@ -9,12 +9,27 @@ type GetDeckListFromSkeltonReturn = {
 export const getDeckListFromSkeleton = (
     skeleton: Skeleton
 ): GetDeckListFromSkeltonReturn => {
-    const decklist: DeckList = [];
+    const decklist: DeckList = { mainBoard: [], sideBoard: [] };
     const errors: string[] = [];
-    skeleton.forEach(({ card, quantity }) => {
-        const matchingEntry = ALL_CARDS.find((c) => c.card.name === card);
+    skeleton.mainBoard.forEach(({ card, quantity }) => {
+        const matchingEntry = ALL_CARDS.mainBoard.find(
+            (c) => c.card.name === card
+        );
         if (matchingEntry) {
-            decklist.push({
+            decklist.mainBoard.push({
+                card: matchingEntry.card,
+                quantity,
+            });
+        } else {
+            errors.push(`Could not read "${card}"`);
+        }
+    });
+    skeleton.sideBoard.forEach(({ card, quantity }) => {
+        const matchingEntry = ALL_CARDS.mainBoard.find(
+            (c) => c.card.name === card
+        );
+        if (matchingEntry) {
+            decklist.sideBoard.push({
                 card: matchingEntry.card,
                 quantity,
             });

--- a/src/transformers/getSkeletonFromDeckList/getSkeletonFromDeckList.spec.ts
+++ b/src/transformers/getSkeletonFromDeckList/getSkeletonFromDeckList.spec.ts
@@ -7,30 +7,48 @@ import { getSkeletonFromDeckList } from './getSkeletonFromDeckList';
 
 describe('get skeleton from decklist', () => {
     it('transforms a deck list into a skeleton object', () => {
-        const decklist: DeckList = [
-            {
-                card: makeAdvancedResourceCard(
-                    AdvancedResourceCards.CLOUD_HAVEN
-                ),
-                quantity: 4,
-            },
-            {
-                card: makeAdvancedResourceCard(
-                    AdvancedResourceCards.SEASIDE_COVE
-                ),
-                quantity: 4,
-            },
-        ];
+        const decklist: DeckList = {
+            mainBoard: [
+                {
+                    card: makeAdvancedResourceCard(
+                        AdvancedResourceCards.CLOUD_HAVEN
+                    ),
+                    quantity: 4,
+                },
+                {
+                    card: makeAdvancedResourceCard(
+                        AdvancedResourceCards.SEASIDE_COVE
+                    ),
+                    quantity: 2,
+                },
+            ],
+            sideBoard: [
+                {
+                    card: makeAdvancedResourceCard(
+                        AdvancedResourceCards.SEASIDE_COVE
+                    ),
+                    quantity: 2,
+                },
+            ],
+        };
 
-        expect(getSkeletonFromDeckList(decklist)).toEqual([
-            {
-                card: 'Cloud Haven',
-                quantity: 4,
-            },
-            {
-                card: 'Seaside Cove',
-                quantity: 4,
-            },
-        ]);
+        expect(getSkeletonFromDeckList(decklist)).toEqual({
+            mainBoard: [
+                {
+                    card: 'Cloud Haven',
+                    quantity: 4,
+                },
+                {
+                    card: 'Seaside Cove',
+                    quantity: 2,
+                },
+            ],
+            sideBoard: [
+                {
+                    card: 'Seaside Cove',
+                    quantity: 2,
+                },
+            ],
+        });
     });
 });

--- a/src/transformers/getSkeletonFromDeckList/getSkeletonFromDeckList.ts
+++ b/src/transformers/getSkeletonFromDeckList/getSkeletonFromDeckList.ts
@@ -1,8 +1,14 @@
 import { DeckList, Skeleton } from '@/types/cards';
 
 export const getSkeletonFromDeckList = (decklist: DeckList): Skeleton => {
-    return decklist.map(({ card, quantity }) => ({
-        card: card.name,
-        quantity,
-    }));
+    return {
+        mainBoard: decklist.mainBoard.map(({ card, quantity }) => ({
+            card: card.name,
+            quantity,
+        })),
+        sideBoard: decklist.sideBoard.map(({ card, quantity }) => ({
+            card: card.name,
+            quantity,
+        })),
+    };
 };

--- a/src/transformers/isDeckValidForFomat/isDeckValidForFormat.spec.ts
+++ b/src/transformers/isDeckValidForFomat/isDeckValidForFormat.spec.ts
@@ -26,7 +26,10 @@ describe('isDeckValidForFormat', () => {
     it('returns false when there are not enough cards', () => {
         expect(
             isDeckValidForFormat(
-                [{ card: SpellCards.HOLY_REVIVAL, quantity: 1 }],
+                {
+                    mainBoard: [{ card: SpellCards.HOLY_REVIVAL, quantity: 1 }],
+                    sideBoard: [],
+                },
                 Format.SINGLETON
             )
         ).toEqual({
@@ -38,7 +41,15 @@ describe('isDeckValidForFormat', () => {
     it('returns false when there are too many cards', () => {
         expect(
             isDeckValidForFormat(
-                [{ card: makeResourceCard(Resource.BAMBOO), quantity: 400 }],
+                {
+                    mainBoard: [
+                        {
+                            card: makeResourceCard(Resource.BAMBOO),
+                            quantity: 400,
+                        },
+                    ],
+                    sideBoard: [],
+                },
                 Format.SINGLETON
             )
         ).toEqual({
@@ -49,9 +60,13 @@ describe('isDeckValidForFormat', () => {
 
     it('validates for singleton', () => {
         expect(
-            isDeckValidForFormat(
-                ALL_CARDS.slice(0, PlayerConstants.MAX_DECK_SIZE)
-            )
+            isDeckValidForFormat({
+                mainBoard: ALL_CARDS.mainBoard.slice(
+                    0,
+                    PlayerConstants.MAX_DECK_SIZE
+                ),
+                sideBoard: [],
+            })
         ).toEqual({
             isValid: true,
             reason: undefined,

--- a/src/transformers/isDeckValidForFomat/isDeckValidForFormat.ts
+++ b/src/transformers/isDeckValidForFomat/isDeckValidForFormat.ts
@@ -26,7 +26,7 @@ export const isDeckValidForFormat = (
         : PlayerConstants.STARTING_DECK_SIZE_LIMITED;
     const maxDeckSize = PlayerConstants.MAX_DECK_SIZE;
     let reason: string;
-    deck.forEach(({ card, quantity }) => {
+    deck.mainBoard.forEach(({ card, quantity }) => {
         numCards += quantity;
         if (card.cardType === CardType.RESOURCE && !card.isAdvanced) {
             return;

--- a/src/transformers/splitDeckListToPiles/splitDeckListToPiles.spec.ts
+++ b/src/transformers/splitDeckListToPiles/splitDeckListToPiles.spec.ts
@@ -15,11 +15,14 @@ describe('Split deck list to piles', () => {
 
     it('splits apart advanced and basic resources', () => {
         const piles = splitDeckListToPiles(
-            makeDeck([
-                { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
-                { card: makeResourceCard(Resource.IRON), quantity: 9 },
-                { card: AdvancedResourceCards.SAHARAN_DESERT, quantity: 4 },
-            ])
+            makeDeck({
+                mainBoard: [
+                    { card: makeResourceCard(Resource.CRYSTAL), quantity: 8 },
+                    { card: makeResourceCard(Resource.IRON), quantity: 9 },
+                    { card: AdvancedResourceCards.SAHARAN_DESERT, quantity: 4 },
+                ],
+                sideBoard: [],
+            })
         );
         expect(piles[0].title).toEqual('Resources');
         expect(piles[0].cards.size).toEqual(3);

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -110,7 +110,10 @@ export interface SpellCard extends SpellBase {
 
 export type Card = ResourceCard | UnitCard | SpellCard;
 
-export type DeckList = { card: Card; quantity: number }[];
+export type DeckList = {
+    mainBoard: { card: Card; quantity: number }[];
+    sideBoard: { card: Card; quantity: number }[];
+};
 
 /**
  * Used to store decklists as 'skeleton states' for imports + downloads.
@@ -119,7 +122,10 @@ export type DeckList = { card: Card; quantity: number }[];
  * Can be easily stringified b/c this construct is so minimalistic:
  * just a card string and a number
  */
-export type Skeleton = { card: string; quantity: number }[];
+export type Skeleton = {
+    mainBoard: { card: string; quantity: number }[];
+    sideBoard: { card: string; quantity: number }[];
+};
 
 export type PileOfCards = {
     cards: Map<Card, number>;


### PR DESCRIPTION
As I started working on draft mode, I thought it would be nice to support sideboards in the future in case players wanted to play best of 3 or even best of 5.

This update doesn't add sideboards in per se, but it does allow for the possibility of it in the future.

With Typescript, it was very easy to change the structure of `DeckList` and `Skeleton` to take a new structure.

The rest was paint-by-the-numbers using jest:watch to fix all the places where everything needed updating.

Before - decklist was an array:
<img width="500" alt="Screen Shot 2023-03-15 at 4 01 22 AM" src="https://user-images.githubusercontent.com/1839462/225244730-f7a1d6ff-2dd1-4966-bc12-6e3498790b09.png">


Now - decklist is an Object with a main board + sideboard array:
<img width="500" alt="Screen Shot 2023-03-15 at 4 00 49 AM" src="https://user-images.githubusercontent.com/1839462/225244588-4ff7dee4-4cc2-4cc4-8d55-13988bbbfc17.png">
