### PR TITLE
Fix: patch opacity regression for deck builder

### DIFF
--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -132,25 +132,31 @@ const MiniCard: React.FC<MiniCardProps> = ({
         quantityToDisplay = quantity;
     }
 
-    const onAddCard = () => {
+    const hasOnClick = () => {
         if (isDisplayOnly) {
-            return;
+            return false;
         }
         if (
             gameFormat &&
             !isFormatConstructed(gameFormat) &&
             quantityToDisplay <= 0
         ) {
-            return;
+            return false;
         }
-        dispatch(addCard(card));
+        return true;
+    };
+
+    const onAddCard = () => {
+        if (hasOnClick()) {
+            dispatch(addCard(card));
+        }
     };
 
     return (
         <>
             <MiniCardFrame
-                style={{ opacity: quantityToDisplay === 0 ? '.7' : '1' }}
-                hasOnClick={!isDisplayOnly && quantityToDisplay > 0}
+                style={{ opacity: hasOnClick() ? '1' : '.7' }}
+                hasOnClick={hasOnClick()}
                 primaryColor={primaryColor}
                 secondaryColor={secondaryColor}
                 onClick={onAddCard}


### PR DESCRIPTION
On https://github.com/lijim/monks-and-mages/pull/421, we introduced having 0.7 opacity for cards that had no onClick, but our logic was flawed in that it prevented places like the regular deck builder (not draft mode's deck builder) from having proper tinting on the CompactDeckList component:

<img width="456" alt="Screen Shot 2023-03-15 at 4 17 30 AM" src="https://user-images.githubusercontent.com/1839462/225248247-7922ea9d-90c6-4966-b449-08f6e0e4c95a.png">

This patch introduces logic to consolidate where we do an early return in onClick and make that the basis for whether to display cursor: pointer / have higher/lower opacity
<img width="611" alt="Screen Shot 2023-03-15 at 4 18 09 AM" src="https://user-images.githubusercontent.com/1839462/225248462-d794b084-28ee-4ef2-baa2-b71383f224a4.png">

