### PR TITLE
Fix: Display proper numbers when drafting after playing limited

### DIFF
--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -118,6 +118,7 @@ const MiniCard: React.FC<MiniCardProps> = ({
     });
 
     const gameFormat = useSelector(getGameFormat);
+    const gameState = useSelector(getGameState);
     const numberLeft = useSelector(getNumberLeft(card));
 
     const associatedCards = getAssociatedCards(card);
@@ -126,7 +127,10 @@ const MiniCard: React.FC<MiniCardProps> = ({
     let quantityToDisplay = 0;
     if (isFormatConstructed(gameFormat)) {
         quantityToDisplay = quantity;
-    } else if (quantity !== Number.MAX_SAFE_INTEGER) {
+    } else if (
+        quantity !== Number.MAX_SAFE_INTEGER &&
+        gameState === GameState.DECKBUILDING
+    ) {
         quantityToDisplay = numberLeft;
     } else {
         quantityToDisplay = quantity;

--- a/src/client/components/CompactDeckList/CompactDeckList.tsx
+++ b/src/client/components/CompactDeckList/CompactDeckList.tsx
@@ -159,7 +159,12 @@ const MiniCard: React.FC<MiniCardProps> = ({
     return (
         <>
             <MiniCardFrame
-                style={{ opacity: hasOnClick() ? '1' : '.7' }}
+                style={{
+                    opacity:
+                        hasOnClick() || gameState === GameState.DRAFTING
+                            ? '1'
+                            : '.7',
+                }}
                 hasOnClick={hasOnClick()}
                 primaryColor={primaryColor}
                 secondaryColor={secondaryColor}


### PR DESCRIPTION
It was possible to get into this state if playing a round of draft right after playing sealed.

Now we'll check to make sure that the game state is in deckbuilding before using subtraction logic to determine card quantities

<img width="1055" alt="Screen Shot 2023-03-15 at 7 37 31 AM" src="https://user-images.githubusercontent.com/1839462/225298178-cb741f4f-977b-41cd-9c63-f389f6b5e589.png">
