### PR TITLE
Chore: switch away from socket.id as source of truth

### DIFF
--- a/src/client/components/DeckList/DeckList.tsx
+++ b/src/client/components/DeckList/DeckList.tsx
@@ -11,9 +11,9 @@ import { removeCard } from '@/client/redux/deckBuilder';
 
 interface DeckListProps {
     deck: Card[];
+    isDisplayOnly: boolean;
     shouldShowQuantity?: boolean;
     shouldShowSummary?: boolean;
-    isDisplayOnly: boolean;
 }
 
 interface DeckListCardSlotProps {

--- a/src/client/components/LogoutButton/LogoutButton.tsx
+++ b/src/client/components/LogoutButton/LogoutButton.tsx
@@ -13,6 +13,7 @@ export const LogoutButton = () => {
     return (
         <SecondaryColorButton
             onClick={() => {
+                webSocket.logout();
                 webSocket.chooseName('');
                 dispatch(push('/'));
                 logout({ returnTo: window.location.origin });

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -45,8 +45,8 @@ export interface CustomSocket
 }
 
 export interface WebSocketValue extends Partial<ClientToServerEvents> {
-    socket: CustomSocket;
     logout: () => void;
+    socket: CustomSocket;
 }
 
 interface Props {
@@ -102,7 +102,7 @@ export const WebSocketProvider = ({ children }: Props) => {
         const newSocket: CustomSocket = io() as CustomSocket;
 
         newSocket.on('session', ({ sessionID, userID }) => {
-            newSocket.auth = { sessionID };
+            newSocket.auth = { ...newSocket.auth, sessionID };
             localStorage.setItem('sessionID', sessionID);
             newSocket.userID = userID;
         });
@@ -196,7 +196,7 @@ export const WebSocketProvider = ({ children }: Props) => {
         };
 
         const chooseName = (name: string) => {
-            newSocket.auth = { username: name };
+            newSocket.auth = { ...newSocket.auth, username: name };
             newSocket.connect();
             newSocket.emit('chooseName', name);
         };

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -82,14 +82,20 @@ export const WebSocketProvider = ({ children }: Props) => {
                     scope: 'read:users_app_metadata',
                 });
                 cookie.set('accessToken', accessToken);
+                socket.auth = { ...socket.auth, username: user.name };
+                socket.connect();
                 socket.emit('login', `Bearer ${accessToken}`);
+                setSocket(socket);
             } else {
                 const accessToken = await getAccessTokenSilently({
                     audience: `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
                     scope: 'read:users_app_metadata',
                 });
                 cookie.set('accessToken', accessToken);
+                socket.auth = { ...socket.auth, username: user.name };
+                socket.connect();
                 socket.emit('login', `Bearer ${accessToken}`);
+                setSocket(socket);
             }
         };
         authToken();

--- a/src/server/sockets/sessionStore.ts
+++ b/src/server/sockets/sessionStore.ts
@@ -1,0 +1,23 @@
+type Session = {
+    connected: boolean;
+    userID: string;
+    username: string;
+};
+
+export const createMemorySessionStore = () => {
+    const sessions = new Map<string, Session>();
+
+    const findSession = (id: string) => {
+        return sessions.get(id);
+    };
+
+    const saveSession = (id: string, session: Session) => {
+        sessions.set(id, session);
+    };
+
+    const findAllSessions = () => {
+        return Array.from(sessions.values());
+    };
+
+    return { findSession, saveSession, findAllSessions };
+};

--- a/src/server/sockets/socket.spec.ts
+++ b/src/server/sockets/socket.spec.ts
@@ -73,7 +73,7 @@ describe('sockets', () => {
             });
         });
 
-        it('chooses an avatar and joins a room', (done) => {
+        it('chooses an avatar and joins a room', async () => {
             clientSocket.emit(
                 'chooseAvatar',
                 'https://monksandmages.com/images/units/manta-ray.webp'
@@ -109,7 +109,6 @@ describe('sockets', () => {
                     },
                     ...defaultRooms,
                 ]);
-                done();
             });
         });
     });

--- a/src/server/sockets/socket.spec.ts
+++ b/src/server/sockets/socket.spec.ts
@@ -46,6 +46,7 @@ describe('sockets', () => {
             clientSocket = clientIo(`http://localhost:${port}`, {
                 multiplex: false,
                 reconnection: false,
+                auth: { username: 'Dora Wini', sessionID: 'a' },
             });
             clientSocket.on('connect', done);
         });
@@ -72,7 +73,7 @@ describe('sockets', () => {
             });
         });
 
-        it('chooses and avatar and joins a room', (done) => {
+        it('chooses an avatar and joins a room', (done) => {
             clientSocket.emit(
                 'chooseAvatar',
                 'https://monksandmages.com/images/units/manta-ray.webp'

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -19,6 +19,7 @@ import {
     RootState,
 } from '@/client/redux/store';
 import {
+    CustomSocket,
     WebSocketContext,
     WebSocketValue,
 } from '@/client/components/WebSockets';
@@ -95,7 +96,7 @@ export function render(
     if (!useRealDispatch) {
         store.dispatch = jest.fn();
     }
-    const newSocket: Socket<ServerToClientEvents, ClientToServerEvents> = io();
+    const newSocket = io() as CustomSocket;
 
     const mockWebSocket = {
         socket: newSocket,
@@ -104,6 +105,7 @@ export function render(
         chooseName: jest.fn(),
         joinRoom: jest.fn(),
         leaveRoom: jest.fn(),
+        logout: jest.fn(),
         sendChatMessage: jest.fn(),
         spectateRoom: jest.fn(),
         resolveEffect: jest.fn(),
@@ -112,6 +114,7 @@ export function render(
     };
 
     mockWebSocket.socket.emit = jest.fn();
+    mockWebSocket.socket.userID = '';
 
     function Wrapper({ children }: { children?: ReactNode }): ReactElement {
         useEffect(() => {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+// @ts-ignore - TypeScript is merging this with the 'socket.io' interfaces to extend the Socket interface
+import { Socket } from 'socket.io';
+
+declare module 'socket.io' {
+    interface Socket {
+        sessionID: string;
+        userID: string;
+        username: string;
+    }
+}

--- a/src/types/sockets.ts
+++ b/src/types/sockets.ts
@@ -14,6 +14,7 @@ export interface ServerToClientEvents {
     gameChatMessage: (message: ChatMessage) => void;
     listLatestGameResults: (gameResults: GameResult[]) => void;
     listRooms: (rooms: DetailedRoom[]) => void;
+    session: (session: { sessionID: string; userID: string }) => void;
     startGame: () => void;
     updateBoard: (board: Board) => void;
 }


### PR DESCRIPTION
Problem:
- Draft mode is a longer game, and it's exposed some problems with disconnects as we've playtested it
- We need a way for players to rejoin games they've dropped from

Solution:
The socket.io documentation recommends not using socket.id as the source of truth, as it is ephemeral.  They recommend an approach with using socket.auth, as well as some middleware to handle persistent sessions. https://socket.io/get-started/private-messaging-part-2/

The work here is simply to switch the whole app away from socket.id-based helpers - no work yet to make sessions persistent, but this just lays the groundwork for that