### PR TITLE
Fix: Restore chat message functionality

### DIFF
--- a/src/client/components/RoomSquare/RoomSquare.tsx
+++ b/src/client/components/RoomSquare/RoomSquare.tsx
@@ -5,6 +5,7 @@ import { DetailedRoom } from '@/types';
 import { SecondaryColorButton } from '../Button';
 import { Format } from '@/types/games';
 import { WebSocketContext } from '../WebSockets';
+import { PLAYER_ROOM_PREFIX } from '@/constants/lobbyConstants';
 
 type RoomSquareProps = {
     detailedRoom: DetailedRoom;
@@ -34,7 +35,7 @@ export const RoomSquare: React.FC<RoomSquareProps> = ({
     spectateRoom,
 }) => {
     const webSocket = useContext(WebSocketContext);
-    const normalizedRoomName = roomName.replace('public-', '');
+    const normalizedRoomName = roomName.replace(PLAYER_ROOM_PREFIX, '');
     const shouldShowSpectate = !hasStartedGame && !isSpectacting;
     const shouldShowJoin = !hasJoined && !hasStartedGame && players.length < 4;
     return (

--- a/src/client/components/Rooms/Rooms.tsx
+++ b/src/client/components/Rooms/Rooms.tsx
@@ -9,7 +9,10 @@ import { RootState } from '@/client/redux/store';
 import { WebSocketContext } from '../WebSockets';
 import { DetailedRoom } from '@/types';
 import { PrimaryColorButton } from '../Button';
-import { MAX_ROOM_NAME_LENGTH } from '@/constants/lobbyConstants';
+import {
+    MAX_ROOM_NAME_LENGTH,
+    PLAYER_ROOM_PREFIX,
+} from '@/constants/lobbyConstants';
 import { Colors } from '@/constants/colors';
 import { DeckListSelector } from '../DeckListSelector';
 import { LatestWinners } from '../LatestWinners';
@@ -80,7 +83,8 @@ const RoomsTab = styled.h1`
 `;
 
 const normalizeRoomName = (roomName: string): string => {
-    if (roomName.startsWith('public-')) return roomName.slice('public-'.length);
+    if (roomName.startsWith(PLAYER_ROOM_PREFIX))
+        return roomName.slice(PLAYER_ROOM_PREFIX.length);
     return roomName;
 };
 

--- a/src/constants/lobbyConstants.ts
+++ b/src/constants/lobbyConstants.ts
@@ -19,6 +19,10 @@ export const DEFAULT_ROOM_NAMES = [
     'Cobra Castle 🐍',
 ];
 
+export const PLAYER_ROOM_PREFIX = 'public-';
+
+export const SPECTATOR_ROOM_PREFIX = 'publicSpectate-';
+
 export enum DeckListSelections {
     CANNONEER = 'Cannoneers 🧨',
     DIVERS = 'Divers 🤿',


### PR DESCRIPTION
Problem:
- The major refactor in #428 caused an unintended side-effect in that players weren't able to see game messages.

Fix:
- This fix moves `public-` and `publicSpectate-` away from their "magic-constant" style implementation into exported variables
- Using this, we fixed some logic so that the correct rooms in socket.io are targeted when broadcasting messages to players and spectators