### PR TITLE
Feat: downshift cards in rarity

### DIFF
--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -995,7 +995,7 @@ const SUMMON_THE_CROWS = makeCard({
             summonType: Tokens.FALCON,
         },
     ],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.COMMON,
 });
 
 // Monks (bamboo + iron)

--- a/src/cardDb/units/mages/crystal.ts
+++ b/src/cardDb/units/mages/crystal.ts
@@ -238,7 +238,7 @@ const CYRUS_PURPLE_DRAGON: UnitCard = makeCard({
     isMagical: true,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.MYTHIC,
+    rarity: CardRarity.RARE,
 });
 
 export const CRYSTAL_MAGES = {

--- a/src/cardDb/units/mages/water.ts
+++ b/src/cardDb/units/mages/water.ts
@@ -143,7 +143,7 @@ const RAIN_CHANNELER: UnitCard = makeCard({
     isMagical: true,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.COMMON,
 });
 
 const WAVING_FISHERMAN: UnitCard = makeCard({
@@ -170,7 +170,7 @@ const WAVING_FISHERMAN: UnitCard = makeCard({
     isMagical: true,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.UNCOMMON,
 });
 
 const MISBEGOTTEN_MISTWALKER = makeCard({
@@ -201,7 +201,7 @@ const MISBEGOTTEN_MISTWALKER = makeCard({
     isMagical: true,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.UNCOMMON,
 });
 
 const WATER_MAGE: UnitCard = makeCard({
@@ -358,7 +358,7 @@ const THUNDER_SCHEDULER: UnitCard = makeCard({
     isMagical: true,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.UNCOMMON,
 });
 
 const MAELSTROM_SEEKER: UnitCard = makeCard({

--- a/src/cardDb/units/misc.ts
+++ b/src/cardDb/units/misc.ts
@@ -180,7 +180,7 @@ const PASTURE_EXPLORER: UnitCard = makeCard({
     isMagical: false,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.COMMON,
 });
 
 const RELAXED_ROWBOATER: UnitCard = makeCard({

--- a/src/cardDb/units/ranged.ts
+++ b/src/cardDb/units/ranged.ts
@@ -243,7 +243,7 @@ const FALCON_RIDER: UnitCard = makeCard({
     isMagical: false,
     isSoldier: false,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.UNCOMMON,
 });
 
 const EXCELLENT_EQUESTRIAN: UnitCard = makeCard({

--- a/src/cardDb/units/soldiers.ts
+++ b/src/cardDb/units/soldiers.ts
@@ -346,7 +346,7 @@ const FROST_WALKER: UnitCard = makeCard({
     isMagical: false,
     isSoldier: true,
     passiveEffects: [],
-    rarity: CardRarity.RARE,
+    rarity: CardRarity.UNCOMMON,
 });
 
 const DRAGON_MIST_WARRIOR: UnitCard = makeCard({


### PR DESCRIPTION
Attempting to balance each mono-color card identity to have:

- 16 commons
- 9 uncommons
- 6 rares
- 1 mythic

We had a few outliers (e.g. Green having 9 rares / 8 uncommons) where I've deemed it necessary to shift some of the cards to other rarities to balance the game out