### PR TITLE
Feat: Nerf / buff cards

### DIFF
--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -1053,7 +1053,7 @@ const RAIN_OF_ARROWS = makeCard({
 const TEAM_GATHERING = makeCard({
     name: 'Team Gathering',
     imgSrc: 'https://images.pexels.com/photos/2152958/pexels-photo-2152958.jpeg',
-    cost: { [Resource.BAMBOO]: 2, [Resource.GENERIC]: 3 },
+    cost: { [Resource.BAMBOO]: 2, [Resource.GENERIC]: 2 },
     effects: [
         {
             type: EffectType.DRAW_PER_UNIT,

--- a/src/cardDb/units/mages/fire.ts
+++ b/src/cardDb/units/mages/fire.ts
@@ -350,7 +350,7 @@ const LU_ZISHEN_FLOWERY_MONK: UnitCard = makeCard({
         },
     ],
     totalHp: 3,
-    attack: 3,
+    attack: 2,
     numAttacks: 2,
     isRanged: true,
     isMagical: true,

--- a/src/cardDb/units/mages/water.ts
+++ b/src/cardDb/units/mages/water.ts
@@ -520,7 +520,12 @@ const PENELOPE_THE_TORTOISE: UnitCard = makeCard({
     enterEffects: [
         {
             type: EffectType.DRAW,
-            strength: 3,
+            strength: 2,
+        },
+        {
+            type: EffectType.HEAL,
+            target: TargetTypes.SELF_PLAYER,
+            strength: 4,
         },
         {
             type: EffectType.EXTRACT_CARD,

--- a/src/cardDb/units/ranged.ts
+++ b/src/cardDb/units/ranged.ts
@@ -270,7 +270,7 @@ const MERRY_RALLIER: UnitCard = makeCard({
     imgSrc: 'https://images.pexels.com/photos/9935713/pexels-photo-9935713.jpeg',
     cost: {
         [Resource.BAMBOO]: 2,
-        [Resource.GENERIC]: 4,
+        [Resource.GENERIC]: 3,
     },
     description: '',
     enterEffects: [

--- a/src/cardDb/units/tribes/sorcerors.ts
+++ b/src/cardDb/units/tribes/sorcerors.ts
@@ -34,7 +34,7 @@ const CURIOUS_RESEARCHER: UnitCard = makeCard({
     name: 'Curious Researcher',
     imgSrc: 'https://images.pexels.com/photos/4256852/pexels-photo-4256852.jpeg',
     cost: {
-        [Resource.GENERIC]: 2,
+        [Resource.GENERIC]: 3,
         [Resource.FIRE]: 1,
     },
     description: '',


### PR DESCRIPTION
After playtesting - a few cards need nerfing.

Curious researcher feels like a better version of a 2/2 draw a card for 3.  It has too much upside for no downside, so nerfing it to 4 mana.

Lu Zishen is too strong as a 3/3 - since it hits twice, it can deal a whopping 6 damage when ahead, while also taking out 4 damage worth of opposing units

Penelope the Tortoise receives a buff - healing for 4, drawing one less card (3 -> 2)

The 'draw per unit' cards, Merry Rallier and Team Gathering, have been made to cost 1 less.  These cards are difficult currently to get to in terms of mana cost compared to their upside, and need to be slightly more accessible