### PR TITLE
Fix: mitigate stale connections issue

### DIFF
--- a/src/apiHelpers/apiHelpers.ts
+++ b/src/apiHelpers/apiHelpers.ts
@@ -5,42 +5,48 @@ export const apiClient = axios.create({
     baseURL: process.env.API_DOMAIN,
 });
 
-const accessHeaders = {
+const accessHeaders = () => ({
     Authorization: `Bearer ${cookie.get('accessToken')}`,
-};
+});
 
-export const fetcher = (url: string) => {
+// needs to be a function b/c cookie can change and we need to dynamically access it
+// rather than having it be stale
+export const fetcher = () => (url: string) => {
     return axios
         .get(url, {
-            headers: accessHeaders,
+            headers: accessHeaders(),
         })
         .then((res) => res.data);
 };
 
-export const swrPut = async <Data, Response>(
-    key: string,
-    { arg }: { arg: Data }
-): Promise<Response> => {
-    try {
-        const response = await apiClient.put(key, arg, {
-            headers: accessHeaders,
-        });
-        return response.data;
-    } catch (err) {
-        throw err.message;
-    }
-};
+export const swrPut =
+    () =>
+    async <Data, Response>(
+        key: string,
+        { arg }: { arg: Data }
+    ): Promise<Response> => {
+        try {
+            const response = await apiClient.put(key, arg, {
+                headers: accessHeaders(),
+            });
+            return response.data;
+        } catch (err) {
+            throw err.message;
+        }
+    };
 
-export const swrPatch = async <Data, Response>(
-    key: string,
-    { arg }: { arg: Data }
-): Promise<Response> => {
-    try {
-        const response = await apiClient.patch(key, arg, {
-            headers: accessHeaders,
-        });
-        return response.data;
-    } catch (err) {
-        throw err.message;
-    }
-};
+export const swrPatch =
+    () =>
+    async <Data, Response>(
+        key: string,
+        { arg }: { arg: Data }
+    ): Promise<Response> => {
+        try {
+            const response = await apiClient.patch(key, arg, {
+                headers: accessHeaders(),
+            });
+            return response.data;
+        } catch (err) {
+            throw err.message;
+        }
+    };

--- a/src/client/components/SavedDeckManager/SavedDeckManager.tsx
+++ b/src/client/components/SavedDeckManager/SavedDeckManager.tsx
@@ -45,7 +45,7 @@ export const SavedDeckManager: React.FC<SavedDeckManagerProps> = ({
     const username = useSelector<RootState, string | undefined>(getCleanName);
     const { data: savedDecks } = useSWR<SavedDeck[]>(
         `/api/saved_decks/${username}`,
-        fetcher
+        fetcher()
     );
 
     const createDeck = async () => {

--- a/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
+++ b/src/client/components/SavedDeckSquare/SavedDeckSquare.tsx
@@ -81,7 +81,7 @@ export const SavedDeckSquare: React.FC<SavedDeckSquareProps> = ({
         unknown,
         unknown,
         { deckId: string; skeleton: Skeleton }
-    >(`/saved_decks`, swrPatch);
+    >(`/saved_decks`, swrPatch());
 
     const isHighlighted = currentSavedDeckName === name;
 

--- a/src/client/components/SelfProfilePage/SelfProfilePage.tsx
+++ b/src/client/components/SelfProfilePage/SelfProfilePage.tsx
@@ -53,7 +53,7 @@ export const SelfProfilePage = (): JSX.Element => {
         unknown,
         unknown,
         ChooseAvatarParams
-    >(`/users/self/choose_avatar`, swrPatch);
+    >(`/users/self/choose_avatar`, swrPatch());
 
     const onClickAvatar = (avatar: string) => async () => {
         await trigger({

--- a/src/client/components/TopNavBar/TopNavBar.tsx
+++ b/src/client/components/TopNavBar/TopNavBar.tsx
@@ -6,12 +6,13 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { Link } from 'react-router-dom';
 import cookie from 'cookiejs';
 import { RootState } from '@/client/redux/store';
-import { SecondaryColorButton } from '../Button';
+import { PrimaryColorButton, SecondaryColorButton } from '../Button';
 import { LogoutButton } from '../LogoutButton';
 import { getCleanName } from '@/client/redux/selectors';
 import { useLoggedInPlayerInfo } from '@/client/hooks';
 import { CardImage } from '../CardFrame';
 import { Colors } from '@/constants/colors';
+import { GUEST_NAME_PREFIX } from '@/constants/lobbyConstants';
 
 // TODO: rename IntroScreen to LoginBar: https://github.com/lijim/monks-and-mages/issues/28
 
@@ -38,7 +39,7 @@ interface Props {
  */
 export const TopNavBar = ({ children }: Props) => {
     const guestName = useSelector<RootState, string>(getCleanName);
-    const { user } = useAuth0();
+    const { user, loginWithRedirect } = useAuth0();
     const loggedInPlayerInfo = useLoggedInPlayerInfo();
 
     useEffect(() => {
@@ -148,6 +149,11 @@ export const TopNavBar = ({ children }: Props) => {
                 }}
             >
                 👤 <b>{guestName}</b>{' '}
+                {guestName && !guestName.startsWith(GUEST_NAME_PREFIX) && (
+                    <PrimaryColorButton onClick={() => loginWithRedirect()}>
+                        Log In
+                    </PrimaryColorButton>
+                )}
             </div>
             <div className="topNavBar-center">{children}</div>
             <div style={{ display: 'flex', justifyContent: 'end', gap: '4px' }}>

--- a/src/client/components/WebSockets/WebSockets.tsx
+++ b/src/client/components/WebSockets/WebSockets.tsx
@@ -80,27 +80,30 @@ export const WebSocketProvider = ({ children }: Props) => {
     useEffect(() => {
         const authToken = async () => {
             if (!user) return;
+            let accessToken = '';
             if (process.env.ENVIRONMENT !== 'production') {
-                const accessToken = await getAccessTokenWithPopup({
+                accessToken = await getAccessTokenWithPopup({
                     audience: `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
                     scope: 'read:users_app_metadata',
                 });
-                cookie.set('accessToken', accessToken);
-                socket.auth = { ...socket.auth, username: user.name };
-                socket.connect();
-                socket.emit('login', `Bearer ${accessToken}`);
-                setSocket(socket);
             } else {
-                const accessToken = await getAccessTokenSilently({
+                accessToken = await getAccessTokenSilently({
                     audience: `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
                     scope: 'read:users_app_metadata',
                 });
-                cookie.set('accessToken', accessToken);
-                socket.auth = { ...socket.auth, username: user.name };
-                socket.connect();
-                socket.emit('login', `Bearer ${accessToken}`);
-                setSocket(socket);
             }
+
+            socket.on('session', ({ sessionID, userID, username }) => {
+                dispatch(chooseNameReducer({ name: username }));
+                socket.auth = { ...socket.auth, sessionID };
+                localStorage.setItem('sessionID', sessionID);
+                socket.userID = userID;
+            });
+            cookie.set('accessToken', accessToken);
+            socket.auth = { ...socket.auth, username: user.name };
+            socket.connect();
+            socket.emit('login', `Bearer ${accessToken}`);
+            setSocket(socket);
         };
         authToken();
     }, [user]);
@@ -116,13 +119,6 @@ export const WebSocketProvider = ({ children }: Props) => {
             newSocket.auth = { sessionID: sessionIDFromCache };
             newSocket.connect();
         }
-
-        newSocket.on('session', ({ sessionID, userID, username }) => {
-            dispatch(chooseNameReducer({ name: username }));
-            newSocket.auth = { ...newSocket.auth, sessionID };
-            localStorage.setItem('sessionID', sessionID);
-            newSocket.userID = userID;
-        });
 
         // Server-to-client events
         newSocket.on('confirmCustomDeck', (skeleton: Skeleton) => {

--- a/src/client/hooks/useLoggedInPlayerInfo.ts
+++ b/src/client/hooks/useLoggedInPlayerInfo.ts
@@ -29,11 +29,11 @@ export const useLoggedInPlayerInfo = () => {
 
     const { data: levelsData } = useSWR<Level[]>(
         user ? '/api/levels' : null,
-        fetcher
+        fetcher()
     );
     const { data, mutate } = useSWR<UserPlayer>(
         user ? '/api/users/self' : null,
-        fetcher
+        fetcher()
     );
 
     if (!data || !levelsData) {


### PR DESCRIPTION
**Problem**
Normally, a connected user looks like this:
<img width="548" alt="Screen Shot 2023-03-29 at 10 31 59 PM" src="https://user-images.githubusercontent.com/1839462/228713028-6dce7071-ffd0-4cb1-a642-2c4a42b6fdb3.png">

But sometimes, a user can get in a state where they have a sessionID still remembered in local storage, without proper auth0 cookies and we wind up in this state:

<img width="789" alt="Screen Shot 2023-03-29 at 10 31 52 PM" src="https://user-images.githubusercontent.com/1839462/228713006-5a6cba89-36c8-44b1-954d-9c0954a5ad2b.png">

This is annoying to deal with as we debug because it's hard to tell if the user is logged in at a first glance (they're half-logged in in the sense that the game server remembers their sessionID, but they lack auth0 authentication, so they'll lack avatar setting / saved deck selections, etc.)

**Solution**
1.) Although it's not efficient, I made all the SWR fetcher's function factories that generate each time the components re-renders.  This mitigates an issue where sometimes the components render and don't have access to the cookie yet, necessitating a refresh.  The idea here is that the cookie will be retrieved
2.) Added a login button for users partially logged in:
<img width="334" alt="Screen Shot 2023-03-29 at 10 36 23 PM" src="https://user-images.githubusercontent.com/1839462/228713640-d8b12924-7bdf-4201-8790-194ef7b0e11a.png">
