### PR TITLE
Feat: add additional cards for players not going first (balance)

### DIFF
--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -450,7 +450,10 @@ describe('Game Action', () => {
                 playerName: 'Timmy',
             });
             expect(newBoardState.players[0].effectQueue).toEqual(
-                unitCard.enterEffects.reverse()
+                unitCard.enterEffects.reverse().map((effect) => ({
+                    ...effect,
+                    sourceId: unitCard.id,
+                }))
             );
         });
 
@@ -869,7 +872,7 @@ describe('Game Action', () => {
             expect(newBoardState.players[0].units[0].numAttacksLeft).toEqual(0);
         });
 
-        it('attacks the opposing player', () => {
+        it('causes an on damage effect on attacking opposing player', () => {
             const attacker = makeCard(UnitCards.WATER_GUARDIAN);
             attacker.damagePlayerEffects = [
                 { type: EffectType.BLOOM, resourceType: Resource.WATER },
@@ -885,9 +888,10 @@ describe('Game Action', () => {
                 },
                 playerName: 'Timmy',
             });
-            expect(newBoardState.players[0].effectQueue).toEqual([
-                { type: EffectType.BLOOM, resourceType: Resource.WATER },
-            ]);
+            expect(newBoardState.players[0].effectQueue[0]).toMatchObject({
+                type: EffectType.BLOOM,
+                resourceType: Resource.WATER,
+            });
         });
 
         it('deals zero damage if buffed below 0 attack', () => {

--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -106,6 +106,11 @@ describe('Game Action', () => {
             });
             newBoardState = applyGameAction({
                 board: newBoardState,
+                gameAction: { type: GameActionTypes.REJECT_MULLIGAN },
+                playerName: 'Tommy',
+            });
+            newBoardState = applyGameAction({
+                board: newBoardState,
                 gameAction: { type: GameActionTypes.ACCEPT_MULLIGAN },
                 playerName: 'Tommy',
             });
@@ -114,7 +119,7 @@ describe('Game Action', () => {
                 newBoardState.players.filter((player) => player.readyToStart)
             ).toHaveLength(3);
             expect(newBoardState.players[1].hand).toHaveLength(
-                PlayerConstants.STARTING_HAND_SIZE - 1 // Tommy mulligans 2 away, but draws 1
+                PlayerConstants.STARTING_HAND_SIZE - 1 // Tommy mulligans 3 away, but draws 1 + has a landmark in his hand
             );
             expect(newBoardState.gameState).toEqual(GameState.PLAYING);
         });

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -338,7 +338,12 @@ export const applyGameAction = ({
             resources.push(resourceCard);
             if (resourceCard.enterEffects) {
                 activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                    cloneDeep(resourceCard.enterEffects).reverse()
+                    cloneDeep(resourceCard.enterEffects)
+                        .reverse()
+                        .map((effect) => ({
+                            ...effect,
+                            sourceId: resourceCard.id,
+                        }))
                 );
             }
             if (resourceCard.comesInTapped) resourceCard.isUsed = true;
@@ -401,7 +406,12 @@ export const applyGameAction = ({
                 }
                 activePlayer.units.push(matchingCard);
                 activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                    cloneDeep(matchingCard.enterEffects).reverse()
+                    cloneDeep(matchingCard.enterEffects)
+                        .reverse()
+                        .map((effect) => ({
+                            ...effect,
+                            sourceId: cardId,
+                        }))
                 );
                 activePlayer.hand.splice(matchingCardIndex, 1);
             }
@@ -506,7 +516,12 @@ export const applyGameAction = ({
                 defendingPlayer.health -= attackTotal;
                 if (attackTotal && attacker.damagePlayerEffects?.length > 0) {
                     activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                        cloneDeep(attacker.damagePlayerEffects).reverse()
+                        cloneDeep(attacker.damagePlayerEffects)
+                            .reverse()
+                            .map((effect) => ({
+                                ...effect,
+                                sourceId: cardId,
+                            }))
                     );
                 }
                 if (defendingPlayer.health <= 0) {

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -9,7 +9,8 @@ import { payForCard } from '@/transformers/payForCard';
 import { PassiveEffect } from '@/types/effects';
 import { PlayerConstants } from '@/constants/gameConstants';
 import { getDeckListFromSkeleton } from '@/transformers';
-import { makeNewPlayer } from '@/factories';
+import { makeCard, makeNewPlayer } from '@/factories';
+import { SpellCards } from '@/cardDb/spells';
 
 const getPlayers = (board: Board) => {
     const { players } = board;
@@ -263,8 +264,28 @@ export const applyGameAction = ({
                 // everyone has readied up, start the game
                 clonedBoard.gameState = GameState.PLAYING;
                 clonedBoard.players.forEach((player, index) => {
+                    // TODO: account for when players drop off mid-mulligan
                     player.isActivePlayer =
                         index === clonedBoard.startingPlayerIndex;
+                    if (!player.isActivePlayer) {
+                        const positionAfterStartingPlayer =
+                            (index - clonedBoard.startingPlayerIndex) %
+                            clonedBoard.players.length;
+                        if (
+                            clonedBoard.players.length === 2 ||
+                            positionAfterStartingPlayer > 1
+                        ) {
+                            player.hand.push(makeCard(SpellCards.RICHES));
+                            addSystemChat(
+                                `${player.name} get a [[Riches]] for not going first`
+                            );
+                        } else if (positionAfterStartingPlayer === 1) {
+                            player.hand.push(makeCard(SpellCards.LANDMARK));
+                            addSystemChat(
+                                `${player.name} get a [[Landmark]] for not going first`
+                            );
+                        }
+                    }
                 });
             } else {
                 activePlayer.isActivePlayer = false;

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -954,7 +954,7 @@ describe('resolve effect', () => {
                 },
                 'Timmy'
             );
-            expect(newBoard.players[0].effectQueue).toEqual(
+            expect(newBoard.players[0].effectQueue).toMatchObject(
                 unitCard.enterEffects.reverse()
             );
         });

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -402,8 +402,8 @@ export const resolveEffect = (
                     activePlayer.effectQueue = activePlayer.effectQueue.concat(
                         cloneDeep(unitCard.enterEffects)
                             .reverse()
-                            .map((effect) => ({
-                                ...effect,
+                            .map((enterEffect) => ({
+                                ...enterEffect,
                                 sourceId: unitCard.id,
                             }))
                     );

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -400,7 +400,12 @@ export const resolveEffect = (
 
                 if (unitCard.enterEffects) {
                     activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                        cloneDeep(unitCard.enterEffects).reverse()
+                        cloneDeep(unitCard.enterEffects)
+                            .reverse()
+                            .map((effect) => ({
+                                ...effect,
+                                sourceId: unitCard.id,
+                            }))
                     );
                 }
             });

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -41,12 +41,12 @@ export interface ResourceCard extends CardBase {
  */
 export type Effect = {
     cardName?: string;
+    passiveEffect?: PassiveEffect;
     resourceType?: Resource;
     secondaryCardName?: string;
     strength?: number;
     summonType?: UnitCard;
     target?: TargetTypes;
-    passiveEffect?: PassiveEffect;
     type: EffectType;
 };
 
@@ -89,8 +89,8 @@ export interface UnitCard extends UnitBase {
     hp: number; // current hp
     hpBuff: number;
     id?: string;
-    isSelected: boolean;
-    isFresh: boolean; // true if unit card has entered this past turn
+    isFresh: boolean;
+    isSelected: boolean; // true if unit card has entered this past turn
     numAttacksLeft: number;
     oneCycleAttackBuff: number;
     // number of attack left this turn - starts at 0

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -47,6 +47,7 @@ export type Effect = {
     strength?: number;
     summonType?: UnitCard;
     target?: TargetTypes;
+    sourceId?: string;
     type: EffectType;
 };
 


### PR DESCRIPTION
Players going first have a massive advantage in this game because of the 'hearthstone' like mechanics where being the first on board means you can dictate combat

To balance this out, I've added in 2 player games a rule that players going second receive a 'riches' card after their mulligans (add one generic resource)

In 3+ player games, the players going 2nd will get just a landmark -aka (2) draw a card.  Players going 3rd / 4th will get riches