### PR TITLE
Feat: Improve filter cards by resource 

### DIFF
--- a/src/client/components/CardFrame/CardFrame.tsx
+++ b/src/client/components/CardFrame/CardFrame.tsx
@@ -130,6 +130,7 @@ export const TypesAndRarityLine = ({
                 display: 'flex',
                 justifyContent: 'space-between',
                 alignItems: 'center',
+                fontSize: '12px',
             }}
         >
             <span>{children}</span>

--- a/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
+++ b/src/client/components/DeckBuilder/DeckBuilder.spec.tsx
@@ -369,31 +369,6 @@ describe('DeckBuilder', () => {
             ).toBeInTheDocument();
         });
 
-        it('searches by colors (strictly)', () => {
-            render(<DeckBuilder />);
-
-            fireEvent.change(
-                screen.getByTestId('Filters-ResourcesMatchStrategy'),
-                {
-                    target: {
-                        value: MatchStrategy.STRICT,
-                    },
-                }
-            );
-            fireEvent.click(screen.getByTestId('Filters-Resources-Iron'));
-            fireEvent.click(screen.getByTestId('Filters-Resources-Bamboo'));
-
-            expect(
-                screen.queryByText(UnitCards.LANCER.name)
-            ).not.toBeInTheDocument();
-            expect(
-                screen.queryByText(UnitCards.DRAGON_MIST_WARRIOR.name)
-            ).toBeInTheDocument();
-            expect(
-                screen.queryByText(AdvancedResourceCards.TANGLED_RUINS.name)
-            ).toBeInTheDocument();
-        });
-
         it('searches by colors (loosely)', () => {
             render(<DeckBuilder />);
 

--- a/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
+++ b/src/client/components/DeckBuilderFilters/DeckBuilderFilters.tsx
@@ -96,7 +96,6 @@ const ResourceFilter: React.FC = () => {
                 data-testid={`Filters-ResourcesMatchStrategy`}
             >
                 <option>{MatchStrategy.EXACT}</option>
-                <option>{MatchStrategy.STRICT}</option>
                 <option>{MatchStrategy.LOOSE}</option>
             </select>
         </div>

--- a/src/server/gameEngine/gameEngine.spec.ts
+++ b/src/server/gameEngine/gameEngine.spec.ts
@@ -1077,10 +1077,10 @@ describe('Game Action', () => {
                 playerName: 'Timmy',
             });
 
-            expect(newBoardState.players[0].effectQueue[0]).toEqual(
+            expect(newBoardState.players[0].effectQueue[0]).toMatchObject(
                 spellCard.effects[1]
             );
-            expect(newBoardState.players[0].effectQueue[1]).toEqual(
+            expect(newBoardState.players[0].effectQueue[1]).toMatchObject(
                 spellCard.effects[0]
             );
             expect(newBoardState.players[0].cemetery).toEqual([spellCard]);

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -557,7 +557,12 @@ export const applyGameAction = ({
                 matchingCard
             ).resourcePool;
             activePlayer.effectQueue = activePlayer.effectQueue.concat(
-                cloneDeep(matchingCard.effects).reverse()
+                cloneDeep(matchingCard.effects)
+                    .reverse()
+                    .map((spellEffect) => ({
+                        ...spellEffect,
+                        sourceId: cardId,
+                    }))
             );
             cemetery.push(hand.splice(matchingCardIndex, 1)[0]);
             addSystemChat(`${activePlayer.name} cast [[${matchingCard.name}]]`);

--- a/src/transformers/filterCards/filterCards.spec.ts
+++ b/src/transformers/filterCards/filterCards.spec.ts
@@ -1,0 +1,25 @@
+import { makeCard } from '@/factories';
+import { cardMatchesResources } from './filterCards';
+import { UnitCards } from '@/cardDb/units';
+import { Resource } from '@/types/resources';
+import { MatchStrategy } from '@/types/deckBuilder';
+import { AdvancedResourceCards } from '@/cardDb/resources/advancedResources';
+
+describe('filter cards', () => {
+    it('filters by resources loosely', () => {
+        expect(
+            cardMatchesResources(
+                makeCard(UnitCards.ALADDIN),
+                [Resource.CRYSTAL, Resource.WATER, Resource.FIRE],
+                MatchStrategy.LOOSE
+            )
+        ).toEqual(true);
+        expect(
+            cardMatchesResources(
+                makeCard(AdvancedResourceCards.TREACHEROUS_DESERT),
+                [Resource.CRYSTAL, Resource.WATER, Resource.FIRE],
+                MatchStrategy.LOOSE
+            )
+        ).toEqual(true);
+    });
+});

--- a/src/transformers/filterCards/filterCards.ts
+++ b/src/transformers/filterCards/filterCards.ts
@@ -31,9 +31,14 @@ const cardMatchesText = (card: Card, text: string): boolean => {
 
 const getResourcesForCard = (card: Card): Resource[] => {
     if (card.cardType === CardType.RESOURCE) {
-        if (!card.isAdvanced || !card.secondaryResourceType)
-            return [card.resourceType];
-        return [card.resourceType, card.secondaryResourceType];
+        if (!card.isAdvanced || !card.secondaryResourceType) {
+            return [card.resourceType].filter(
+                (resource) => resource !== Resource.GENERIC
+            );
+        }
+        return [card.resourceType, card.secondaryResourceType].filter(
+            (resource) => resource !== Resource.GENERIC
+        );
     }
     const toReturn: Resource[] = [];
     ORDERED_RESOURCES.forEach((r) => {
@@ -43,7 +48,7 @@ const getResourcesForCard = (card: Card): Resource[] => {
     return toReturn;
 };
 
-const cardMatchesResources = (
+export const cardMatchesResources = (
     card: Card,
     resourcesToMatch: Resource[],
     resourceMatchStrategy: MatchStrategy
@@ -58,21 +63,11 @@ const cardMatchesResources = (
                 resources.slice().sort()
             );
         }
-        // all filtered resources match
-        case MatchStrategy.STRICT: {
-            let toReturn = true;
-            resourcesToMatch.forEach((r) => {
-                if (resources.indexOf(r) === -1) toReturn = false;
-            });
-            return toReturn;
-        }
         // At least one color matches on the card
         case MatchStrategy.LOOSE: {
-            let toReturn = false;
-            resourcesToMatch.forEach((r) => {
-                if (resources.indexOf(r) > -1) toReturn = true;
-            });
-            return toReturn;
+            return resources.every((resource) =>
+                resourcesToMatch.includes(resource)
+            );
         }
         default: {
             return true;
@@ -105,7 +100,6 @@ const cardMatchesRarities = (card: Card, rarities: CardRarity[]): boolean => {
 };
 
 /**
- * Note: unit tests omitted temporarily in favor of an integration test on DeckBuilder
  * @param cards - cards to filter
  * @param filters - see @/types/Filters
  * @returns - cards that match the criteria

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -44,10 +44,10 @@ export type Effect = {
     passiveEffect?: PassiveEffect;
     resourceType?: Resource;
     secondaryCardName?: string;
+    sourceId?: string;
     strength?: number;
     summonType?: UnitCard;
     target?: TargetTypes;
-    sourceId?: string;
     type: EffectType;
 };
 

--- a/src/types/deckBuilder.ts
+++ b/src/types/deckBuilder.ts
@@ -5,10 +5,8 @@ import { Resource } from './resources';
 export enum MatchStrategy {
     // every resource chosen must be present on the card
     EXACT = 'Exact',
-    // as long as one or more resources on the card match
+    // any subset of the resource cards can be present
     LOOSE = 'Loose',
-    // at least 1+ chosen resources must be present, cannot have any other resources
-    STRICT = 'Strict',
 }
 
 export type ResourceCost = '7+' | number;


### PR DESCRIPTION
In the deck builder component, our previous 'strict' and 'loose' filters for resources turned out to be impractical for deckbuilding - for instance, if one wanted to build a blue/green deck, the filters would send them in the direction of any card having at least blue OR green.  What we really wanted was a filter to say, give me Blue cards / green cards / blue+green cards.

This overhaul gets rid of the 3 filters (exact, strict, loose) in favor of just exact (all resources selected must match) and loose (the cards must fall under the resources selected, but can be missing some)

Before:

https://user-images.githubusercontent.com/1839462/229257678-1c7319a3-118c-4662-92f3-9d9116b695d3.mov

After:

https://user-images.githubusercontent.com/1839462/229257743-1dafa3e3-c55c-45f8-81ab-b3e2cb315203.mov


