### PR TITLE
Fix: Prevent effect resolution ending games prematurely

### DIFF
--- a/src/client/components/GameManager/GameManager.tsx
+++ b/src/client/components/GameManager/GameManager.tsx
@@ -21,7 +21,7 @@ import {
     shouldLastEffectFizzle,
 } from '@/client/redux/selectors';
 import {
-    AutoResolvingTargets,
+    AUTO_RESOLVING_TARGETS,
     getDefaultTargetForEffect,
 } from '@/types/effects';
 import { AUTO_RESOLVE_LINGER_DURATION } from '@/constants/gameConstants';
@@ -58,14 +58,7 @@ export const GameManager = ({ children }: Props) => {
         if (!target) target = getDefaultTargetForEffect(lastEffect.type);
         // if the target of the effect auto-resolves, e.g. (ALL OPPONENTS),
         // then resolve the effect automatically
-        if (AutoResolvingTargets.indexOf(target) > -1) {
-            setTimeout(() => {
-                socket.emit('resolveEffect', {
-                    effect: lastEffect,
-                });
-            }, AUTO_RESOLVE_LINGER_DURATION);
-        }
-        if (willLastEffectFizzle) {
+        if (AUTO_RESOLVING_TARGETS.includes(target) || willLastEffectFizzle) {
             setTimeout(() => {
                 socket.emit('resolveEffect', {
                     effect: lastEffect,

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -6,7 +6,7 @@ export enum PlayerConstants {
     STARTING_DECK_SIZE_LIMITED = 40,
 }
 
-export const AUTO_RESOLVE_LINGER_DURATION = 1000;
+export const AUTO_RESOLVE_LINGER_DURATION = 1250;
 
 export const DRAFT_PACKS_BY_PLAYER_COUNT: Record<number, number> = {
     2: 9,

--- a/src/server/sockets/sockets.ts
+++ b/src/server/sockets/sockets.ts
@@ -291,7 +291,7 @@ export const configureIo = (server: HttpServer) => {
             });
 
             socket.on('takeGameAction', async (gameAction) => {
-                roomStore.takeGameAction({
+                await roomStore.takeGameAction({
                     socket,
                     gameAction,
                     recordGameResultToDatabase,
@@ -302,7 +302,7 @@ export const configureIo = (server: HttpServer) => {
             socket.on(
                 'resolveEffect',
                 async (effectParams: ResolveEffectParams) => {
-                    roomStore.resolveEffectForSocket({
+                    await roomStore.resolveEffectForSocket({
                         socket,
                         effectParams,
                         addGameResult,

--- a/src/server/stores/roomStore.ts
+++ b/src/server/stores/roomStore.ts
@@ -263,7 +263,7 @@ export const createRoomStore = ({ sessionStore, io }: CreateRoomStoreArgs) => {
         room.hasStartedGame = true;
         io.to(`${PLAYER_ROOM_PREFIX}${room.roomName}`).emit('startGame');
         io.to(`${SPECTATOR_ROOM_PREFIX}${room.roomName}`).emit('startGame');
-        broadcastBoardForRoom(room.roomName);
+        await broadcastBoardForRoom(room.roomName);
     };
 
     type TakeGameActionParams = {
@@ -274,7 +274,7 @@ export const createRoomStore = ({ sessionStore, io }: CreateRoomStoreArgs) => {
         ) => Promise<void>;
         socket: ExtendedSocket<ClientToServerEvents, ServerToClientEvents>;
     };
-    const takeGameAction = ({
+    const takeGameAction = async ({
         socket,
         gameAction,
         addGameResult,
@@ -313,7 +313,7 @@ export const createRoomStore = ({ sessionStore, io }: CreateRoomStoreArgs) => {
 
         // TODO: add error handling when user tries to take an invalid action
         room.board = newBoardState; // apply state changes to in-memory storage of boards
-        broadcastBoardForRoom(room.roomName);
+        await broadcastBoardForRoom(room.roomName);
     };
 
     type ResolveEffectForSocketParams = {
@@ -324,7 +324,7 @@ export const createRoomStore = ({ sessionStore, io }: CreateRoomStoreArgs) => {
         ) => Promise<void>;
         socket: ExtendedSocket<ClientToServerEvents, ServerToClientEvents>;
     };
-    const resolveEffectForSocket = ({
+    const resolveEffectForSocket = async ({
         socket,
         effectParams,
         addGameResult,
@@ -366,8 +366,10 @@ export const createRoomStore = ({ sessionStore, io }: CreateRoomStoreArgs) => {
         }
 
         // TODO: add error handling when user tries to take an invalid action
-        room.board = newBoardState; // apply state changes to in-memory storage of boards
-        broadcastBoardForRoom(room.roomName);
+        if (newBoardState) {
+            room.board = newBoardState; // apply state changes to in-memory storage of boards
+        }
+        await broadcastBoardForRoom(room.roomName);
     };
 
     type DisconnectFromGameParams = {

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -6,7 +6,7 @@ import {
     getDefaultTargetForEffect,
     TargetTypes,
 } from '@/types/effects';
-import { RESOURCE_GLOSSARY } from '@/types/resources';
+import { RESOURCE_GLOSSARY, Resource } from '@/types/resources';
 
 const TARGET_TYPES_TO_RULES_TEXT = {
     [TargetTypes.ALL_OPPONENTS]: 'all opponents',
@@ -240,7 +240,11 @@ export const transformEffectToRulesText = (effect: Effect): string => {
             return `Increase ${resourceType.toLowerCase()} resources by ${strength}${forText}`;
         }
         case EffectType.RAMP_FOR_TURN: {
-            return `Add ${strength} ${RESOURCE_GLOSSARY[resourceType].icon} this turn`;
+            let resourcesToDisplay = `${strength} ${RESOURCE_GLOSSARY[resourceType].icon}`;
+            if (resourceType === Resource.GENERIC) {
+                resourcesToDisplay = `${strength} generic mana`;
+            }
+            return `Add ${resourcesToDisplay} this turn`;
         }
         case EffectType.RAMP_FROM_HAND: {
             return `Deploy ${strength} ${resourceType} card${pluralizationEffectStrength} from your hand tapped`;

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -14,7 +14,7 @@ export enum TargetTypes {
     UNIT = 'UNIT',
 }
 
-export const AutoResolvingTargets = [
+export const AUTO_RESOLVING_TARGETS = [
     TargetTypes.ALL_OPPONENTS,
     TargetTypes.ALL_OPPOSING_UNITS,
     TargetTypes.ALL_PLAYERS,


### PR DESCRIPTION
**Problem**
In real testing on the actual domain, (not on local) we were able to reproduce twice cards with multiple effects (such as martial trainer, deep sea diver) causing a chain of effects where the latests effects didn't match properly, triggering a state where the game was rendered unplayable.

The reason was that our resolveEffect handler on the sockets connection was setting board to null. This meant whenever the game server was trying to emit the board for the room, it would exit early and not do anything.

**How did we fix it?**
To prevent this we added a series of guardrails:
1. Increased the timeout to 1250ms, from 1000ms for resolving effects automatically.  While in ideal world, the automatic effect resolution should be guided by the server side, we have yet to implement it there.  Resolution of effects that automatically resolve (e.g. "add 1 generic mana this turn") right now take place on the client side
2. If the effect was for any reason returning a null result instead of the board, we don't set the board state to null anymore.  Instead, we skip setting the new board state for the room.
3. Added more await statements around emitting to clients.  This will hopefully result in fewer bugs seen based on race conditions where parts of the game app are updated and other parts aren't updated yet (due to asynchronous code).