### PR TITLE
Feat: Introduce support for 'legendary leader'

### DIFF
--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@/test-utils';
 
 import { PlayerBriefInfo } from './PlayerBriefInfo';
 import { makeNewPlayer } from '@/factories/player';
@@ -70,5 +70,16 @@ describe('Player Brief Info', () => {
         player.resourcePool = { [Resource.GENERIC]: 1 };
         render(<PlayerBriefInfo player={player} />);
         expect(screen.getAllByText('1')).toHaveLength(1);
+    });
+
+    it('renders the legendary leader', () => {
+        const player = makeNewPlayer({
+            name: 'Grandma Jenkins',
+            decklist: SAMPLE_DECKLIST_1,
+        });
+        player.legendaryLeader = makeCard(UnitCards.ALADDIN);
+        player.resourcePool = { [Resource.GENERIC]: 1 };
+        render(<PlayerBriefInfo player={player} />);
+        expect(screen.getByText('Aladdin')).toBeInTheDocument();
     });
 });

--- a/src/client/components/PlayerBriefInfo/PlayerBriefInfo.tsx
+++ b/src/client/components/PlayerBriefInfo/PlayerBriefInfo.tsx
@@ -7,23 +7,27 @@ import { CastingCostFrame } from '../CastingCost';
 import { Resource, RESOURCE_GLOSSARY } from '@/types/resources';
 import { GameManagerContext } from '../GameManager';
 import { DEFAULT_AVATAR } from '@/types/players';
+import { CardGridItem } from '../CardGridItem';
 
 interface PlayerBriefInfoProps {
     player: Player;
 }
 
 interface PlayerBriefContainerProps {
+    displayLegendaryLeader: boolean;
     isActivePlayer: boolean;
 }
 
 const PlayerBriefContainer = styled.div<PlayerBriefContainerProps>`
     width: 170px;
-    height: 220px;
+    height: ${({ displayLegendaryLeader }) =>
+        displayLegendaryLeader ? 420 : 220}px;
     border: 6px solid
         ${({ isActivePlayer }) =>
             isActivePlayer ? Colors.FOCUS_BLUE : Colors.DARK_BROWN};
     display: grid;
-    grid-auto-rows: auto 1fr auto;
+    grid-auto-rows: ${({ displayLegendaryLeader }) =>
+        displayLegendaryLeader ? 'auto auto auto auto' : 'auto 1fr auto'};
     cursor: pointer;
     background-color: whitesmoke;
 `;
@@ -99,6 +103,7 @@ export const PlayerBriefInfo: React.FC<PlayerBriefInfoProps> = ({ player }) => {
             onClick={() => {
                 handleClickPlayer(player);
             }}
+            displayLegendaryLeader={!!player.legendaryLeader}
         >
             <UpperSection>
                 <div>
@@ -133,6 +138,16 @@ export const PlayerBriefInfo: React.FC<PlayerBriefInfoProps> = ({ player }) => {
             </UpperSection>
             <MiddleSection avatarUrl={avatar}>{`${health}`}</MiddleSection>
             <LowerSection>{name}</LowerSection>
+            {player.legendaryLeader && (
+                <div style={{ textAlign: 'center' }}>
+                    <CardGridItem
+                        isOnBoard={false}
+                        card={player.legendaryLeader}
+                        zoomLevel={0.8}
+                        hasTooltip
+                    />
+                </div>
+            )}
         </PlayerBriefContainer>
     );
 };

--- a/src/factories/board/makeNewBoard.ts
+++ b/src/factories/board/makeNewBoard.ts
@@ -42,7 +42,7 @@ export const makeNewBoard = ({
         if (skeleton && isFormatConstructed(format)) {
             const { decklist } = getDeckListFromSkeleton(skeleton);
             if (isDeckValidForFormat(decklist)) {
-                return makeNewPlayer({ name: playerName, decklist });
+                return makeNewPlayer({ name: playerName, decklist, format });
             }
         }
 
@@ -58,7 +58,12 @@ export const makeNewBoard = ({
             );
         }
         const avatarUrl = avatarsForPlayers[playerName];
-        const player = makeNewPlayer({ name: playerName, decklist, avatarUrl });
+        const player = makeNewPlayer({
+            name: playerName,
+            decklist,
+            avatarUrl,
+            format,
+        });
 
         if (format === Format.SEALED) {
             [...Array(SEALED_PACK_QUANTITY)].forEach(() => {

--- a/src/factories/cards/makeCards.ts
+++ b/src/factories/cards/makeCards.ts
@@ -39,6 +39,7 @@ export const makeUnitCard = (unitBase: UnitBase): UnitCard => {
         numAttacksLeft: hasQuick ? unitBase.numAttacks : 0,
         isFresh: true,
         isSelected: false,
+        isLegendaryLeader: false,
         hpBuff: 0,
         attackBuff: 0,
         oneCycleAttackBuff: 0,

--- a/src/factories/player/makeNewPlayer.spec.ts
+++ b/src/factories/player/makeNewPlayer.spec.ts
@@ -1,7 +1,9 @@
 import { Resource } from '@/types/resources';
-import { makeResourceCard } from '../cards';
+import { makeCard, makeResourceCard } from '../cards';
 import { makeNewPlayer } from './makeNewPlayer';
 import { DeckList } from '@/types/cards';
+import { UnitCards } from '@/cardDb/units';
+import { Format } from '@/types/games';
 
 describe('Make New Player', () => {
     it('generates distinct decks for players', () => {
@@ -15,5 +17,25 @@ describe('Make New Player', () => {
         const player2 = makeNewPlayer({ name: 'Donald Duck', decklist });
         expect(player1.name).toBe('Minnie Mouse');
         expect(player1.deck).not.toBe(player2.deck);
+    });
+
+    it('always separates the legendary leader', () => {
+        const decklist: DeckList = {
+            mainBoard: [
+                { card: makeResourceCard(Resource.IRON), quantity: 9 },
+                {
+                    card: makeCard(UnitCards.JOAN_OF_ARC_FOLK_HERO),
+                    quantity: 1,
+                },
+            ],
+            sideBoard: [],
+        };
+        const player1 = makeNewPlayer({
+            name: 'Minnie Mouse',
+            decklist,
+            format: Format.LEGENDARY_LEAGUE,
+        });
+        expect(player1.legendaryLeader.name).toBe('Joan of Arc, Folk Hero');
+        expect(player1.legendaryLeader.isLegendaryLeader).toBe(true);
     });
 });

--- a/src/factories/player/makeNewPlayer.ts
+++ b/src/factories/player/makeNewPlayer.ts
@@ -1,13 +1,16 @@
 import shuffle from 'lodash.shuffle';
 
 import { Player } from '@/types/board';
-import { DeckList } from '@/types/cards';
+import { DeckList, UnitCard } from '@/types/cards';
 import { makeDeck } from '../deck';
 import { PlayerConstants } from '@/constants/gameConstants';
+import { Format } from '@/types/games';
+import { isCardLegendary } from '@/transformers';
 
 type NewPlayerArgs = {
     avatarUrl?: string;
     decklist: DeckList;
+    format?: Format;
     name: string;
 };
 
@@ -15,9 +18,18 @@ export const makeNewPlayer = ({
     name,
     decklist,
     avatarUrl = '',
+    format = Format.STANDARD,
 }: NewPlayerArgs): Player => {
     const { STARTING_HAND_SIZE, STARTING_HEALTH } = PlayerConstants;
-    const deck = makeDeck(decklist);
+    const isLegendaryLeague = format === Format.LEGENDARY_LEAGUE;
+    let legendaryLeader: UnitCard;
+    let deck = makeDeck(decklist);
+
+    if (isLegendaryLeague && deck.find(isCardLegendary)) {
+        legendaryLeader = deck.find(isCardLegendary) as UnitCard;
+        legendaryLeader.isLegendaryLeader = true;
+        deck = deck.filter((card) => card !== legendaryLeader);
+    }
     const shuffledDeck = shuffle(deck);
     const activeDeck = shuffledDeck.slice(STARTING_HAND_SIZE);
     const hand = shuffledDeck.slice(0, STARTING_HAND_SIZE);
@@ -31,6 +43,9 @@ export const makeNewPlayer = ({
         health: STARTING_HEALTH,
         isActivePlayer: false,
         isAlive: true,
+        isLegendaryLeaderDeployed: false,
+        legendaryLeader,
+        legendaryLeaderExtraCost: 0,
         name,
         numCardsInDeck: activeDeck.length,
         numCardsInHand: hand.length,

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -610,7 +610,11 @@ export const applyGameAction = ({
             const { decklist, errors } = getDeckListFromSkeleton(skeleton);
             if (decklist && errors.length === 0) {
                 const { deck, hand, numCardsInDeck, numCardsInHand } =
-                    makeNewPlayer({ name: playerName, decklist });
+                    makeNewPlayer({
+                        name: playerName,
+                        decklist,
+                        format: clonedBoard.format,
+                    });
                 self.deck = deck;
                 self.hand = hand;
                 self.numCardsInDeck = numCardsInDeck;

--- a/src/transformers/filterCards/filterCards.ts
+++ b/src/transformers/filterCards/filterCards.ts
@@ -4,6 +4,7 @@ import { Filters, MatchStrategy, ResourceCost } from '@/types/deckBuilder';
 import { ORDERED_RESOURCES, Resource } from '@/types/resources';
 import { getTypeForUnitCard } from '../getTypeForUnitCard';
 import { transformEffectToRulesText } from '../transformEffectsToRulesText';
+import { isCardLegendary } from '../isCardLegendary';
 
 const cardMatchesText = (card: Card, text: string): boolean => {
     const nameIncludes = card.name.toLowerCase().includes(text.toLowerCase());
@@ -104,8 +105,8 @@ const cardMatchesLegendaryStatus = (
     isLegendaryFilter: boolean | null
 ): boolean => {
     if (isLegendaryFilter === null) return true;
-    const isCardLegendary = card.cardType === CardType.UNIT && card.isLegendary;
-    return isLegendaryFilter ? isCardLegendary : !isCardLegendary;
+    const isLegend = isCardLegendary(card);
+    return isLegendaryFilter ? isLegend : !isLegend;
 };
 
 /**

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -6,6 +6,7 @@ export * from './getDeckListFromSkeleton';
 export * from './getImgSrcForCard';
 export * from './getSkeletonFromDeckList';
 export * from './getTypeForUnitCard';
+export * from './isCardLegendary';
 export * from './isDeckValidForFomat';
 export * from './modifyCardForTooltip';
 export * from './payForCard';

--- a/src/transformers/isCardLegendary/index.ts
+++ b/src/transformers/isCardLegendary/index.ts
@@ -1,0 +1,1 @@
+export * from './isCardLegendary';

--- a/src/transformers/isCardLegendary/isCardLegendary.ts
+++ b/src/transformers/isCardLegendary/isCardLegendary.ts
@@ -1,0 +1,4 @@
+import { Card, CardType } from '@/types/cards';
+
+export const isCardLegendary = (card: Card) =>
+    card.cardType === CardType.UNIT && card.isLegendary;

--- a/src/transformers/isDeckValidForFomat/isDeckValidForFormat.spec.ts
+++ b/src/transformers/isDeckValidForFomat/isDeckValidForFormat.spec.ts
@@ -140,7 +140,7 @@ describe('isDeckValidForFormat', () => {
                 )
             ).toEqual({
                 isValid: false,
-                reason: 'Every card must match the color identify of your legendary leader',
+                reason: 'Every card must match the color identify of your legendary leader - [[Archery at Sunset]] does not match',
             });
         });
     });

--- a/src/transformers/isDeckValidForFomat/isDeckValidForFormat.ts
+++ b/src/transformers/isDeckValidForFomat/isDeckValidForFormat.ts
@@ -2,6 +2,7 @@ import { PlayerConstants } from '@/constants/gameConstants';
 import { CardType, DeckList } from '@/types/cards';
 import { Format, isFormatConstructed } from '@/types/games';
 import { getColorIdentityForCard } from '../getColorIdentityForCard';
+import { isCardLegendary } from '../isCardLegendary';
 
 export const MAX_DUPLICATES_FOR_FORMATS = {
     [Format.SINGLETON]: 1,
@@ -42,8 +43,8 @@ export const isDeckValidForFormat = (
         return { isValid, reason };
     }
 
-    const legendaries = deck.mainBoard.filter(
-        ({ card }) => card.cardType === CardType.UNIT && card.isLegendary
+    const legendaries = deck.mainBoard.filter(({ card }) =>
+        isCardLegendary(card)
     );
     if (format === Format.LEGENDARY_LEAGUE) {
         if (legendaries.length !== 1) {
@@ -63,9 +64,15 @@ export const isDeckValidForFormat = (
                 )
             )
         ) {
+            const { card: invalidCard } = deck.mainBoard.find(
+                ({ card }) =>
+                    !getColorIdentityForCard(card).every((color) =>
+                        legendaryColorIdentity.includes(color)
+                    )
+            );
             return {
                 isValid: false,
-                reason: `Every card must match the color identify of your legendary leader`,
+                reason: `Every card must match the color identify of your legendary leader - [[${invalidCard.name}]] does not match`,
             };
         }
     }

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -14,6 +14,9 @@ export type Player = {
     health: number;
     isActivePlayer: boolean;
     isAlive: boolean;
+    isLegendaryLeaderDeployed: boolean;
+    legendaryLeader: UnitCard | null;
+    legendaryLeaderExtraCost: number;
     name: string;
     numCardsInDeck: number;
     numCardsInHand: number;

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -91,6 +91,7 @@ export interface UnitCard extends UnitBase {
     hpBuff: number;
     id?: string;
     isFresh: boolean;
+    isLegendaryLeader: boolean;
     isSelected: boolean; // true if unit card has entered this past turn
     numAttacksLeft: number;
     oneCycleAttackBuff: number;


### PR DESCRIPTION
This PR introduces support for the 'legendary leader' of the 'legendary league' mode in both the game board API and in the game itself:

<img width="1699" alt="Screen Shot 2023-04-22 at 2 26 54 AM" src="https://user-images.githubusercontent.com/1839462/233766815-76b9bfb4-626c-4a48-a792-e746beeb21be.png">

Next PR's:

- highlight the legendary leader if its cost is payable (extract isCardDeployable into transformers)
- add an action to deploy the legendary leader
- add opacity to the legendary leader if it is deployed
- add cleanup logic to return legendary leaders back when they are destroyed