### PR TITLE
Feat: Add 25+ new effect types

### DIFF
--- a/src/cardDb/units/misc.ts
+++ b/src/cardDb/units/misc.ts
@@ -829,7 +829,7 @@ const HUNGRY_GOAT: UnitCard = makeCard({
     description: '',
     enterEffects: [
         {
-            type: EffectType.DESTROY_RESOURCE_WITH_FEASTING,
+            type: EffectType.DESTROY_RESOURCE_TO_GAIN_STATS,
             strength: 1,
             resourceType: Resource.BAMBOO,
             target: TargetTypes.PLAYER,

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -549,7 +549,7 @@ describe('resolve effect', () => {
                 board,
                 {
                     effect: {
-                        type: EffectType.DESTROY_RESOURCE_WITH_FEASTING,
+                        type: EffectType.DESTROY_RESOURCE_TO_GAIN_STATS,
                         target: TargetTypes.ALL_OPPONENTS,
                         strength: 1,
                         resourceType: Resource.BAMBOO,

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -635,7 +635,7 @@ export const resolveEffect = (
             applyWinState(clonedBoard);
             return clonedBoard;
         }
-        case EffectType.DESTROY_RESOURCE_WITH_FEASTING: {
+        case EffectType.DESTROY_RESOURCE_TO_GAIN_STATS: {
             const { resourceType } = effect;
             playerTargets.forEach((player) => {
                 const resourcesToDestroy = sampleSize(

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
@@ -287,7 +287,7 @@ describe('transformEffectstoRulesText', () => {
 
         it('displays rules destroying a resource (all) - with feasting', () => {
             const effect: Effect = {
-                type: EffectType.DESTROY_RESOURCE_WITH_FEASTING,
+                type: EffectType.DESTROY_RESOURCE_TO_GAIN_STATS,
                 strength: Number.MAX_SAFE_INTEGER,
             };
             expect(transformEffectToRulesText(effect)).toEqual(

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -309,7 +309,7 @@ export const transformEffectToRulesText = (
                     numToDestroy === 'all' ? '' : ' at random'
                 }`;
             }
-            case EffectType.DESTROY_RESOURCE_WITH_FEASTING: {
+            case EffectType.DESTROY_RESOURCE_TO_GAIN_STATS: {
                 const numToDestroy =
                     strength === Number.MAX_SAFE_INTEGER ? 'all' : strength;
                 if (resourceType) {

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -41,6 +41,7 @@ export interface ResourceCard extends CardBase {
  */
 export type Effect = {
     cardName?: string;
+    cost?: PartialRecord<Resource, number>;
     passiveEffect?: PassiveEffect;
     requirements?: EffectRequirement[];
     resourceType?: Resource;

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -76,6 +76,7 @@ export enum EffectType {
      */
     FLICKER = 'Flicker',
     GAIN_ATTACK = 'Gain attack', // buff the unit's attack
+    GAIN_ATTACK_UNTIL = 'Gain attack until a threshold', // buff the unit's attack if it's under X to X
     GAIN_MAGICAL_HAND_AND_BOARD = 'Gain magical for hand and board units', // unit becomes magical
     GAIN_STATS = 'Gain stats', // buff the unit's attack + hp
     GAIN_STATS_AND_EFFECTS = 'Gain stats and effects', // buff the unit's attack + hp and gain passive effects
@@ -156,6 +157,7 @@ export const getDefaultTargetForEffect = (
         [EffectType.EXTRACT_SPELL_CARDS]: TargetTypes.SELF_PLAYER,
         [EffectType.FLICKER]: TargetTypes.OWN_UNIT,
         [EffectType.GAIN_ATTACK]: TargetTypes.SELF_PLAYER,
+        [EffectType.GAIN_ATTACK_UNTIL]: TargetTypes.ALL_SELF_UNITS,
         [EffectType.GAIN_MAGICAL_HAND_AND_BOARD]: TargetTypes.SELF_PLAYER,
         [EffectType.GAIN_STATS]: TargetTypes.SELF_PLAYER,
         [EffectType.GAIN_STATS_AND_EFFECTS]: TargetTypes.SELF_PLAYER,

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -30,6 +30,7 @@ export const AUTO_RESOLVING_TARGETS = [
 export enum EffectType {
     BLOOM = 'Bloom', // "Summer Bloom" - you may play X additional resources this turn
     BOUNCE = 'Bounce', // to any target
+    BOUNCE_UNITS_UNDER_THRESHOLD_ATTACK = 'Bounce units under threshold attack',
     BUFF_ATTACK = 'Buff attack', // increase/decrease attack of a single unit
     BUFF_ATTACK_FOR_CYCLE = 'Buff attack for cycle', // increase/decrease attack of a single unit
     BUFF_ATTACK_FOR_TURN = 'Buff attack for turn', // increase/decrease attack of a single unit
@@ -41,37 +42,63 @@ export enum EffectType {
     // increases all attack for non-magic units
     BUFF_TEAM_HP = 'Buff team hp',
     // increases maxHp and hp for whole team
+    BUFF_TEAM_LEGENDARY_UNITS = 'Buff team legendary units', // increase hp and attack for units with no effects text
     BUFF_TEAM_MAGIC = 'Buff team magic', // increase hp and attack for units with no effects text
-    CURSE_HAND = 'Curse Hand', // adds one generic cost to cards in hand
-    DEAL_DAMAGE = 'Deal Damage', // to any target
-    DESTROY_RESOURCE = 'Destroy Resource',
-    DESTROY_RESOURCE_WITH_FEASTING = 'Destroy Resource With Feasting', // destroy resource, gain +1, +1 for each resource destroyed
-    DESTROY_UNIT = 'Destroy Unit',
-    DISCARD_HAND = 'Discard Hand', // discard X cards at random
+    CURSE_HAND = 'Curse hand', // adds one generic cost to cards in hand
+    CURSE_HAND_SPELLS = 'Curse hand spells', // adds one generic cost to cards in hand
+    CURSE_HAND_RESOURCE_TYPE = 'Curse hand for cards of a specific resource type',
+    DEAL_DAMAGE = 'Deal damage', // to any target
+    DEAL_DAMAGE_TO_NON_SOLDIERS = 'Deal damage to non-soldier units',
+    DEPLOY_LEGENDARY_LEADER = 'Deploy legendary leader', // without triggering enter board efffects
+    DESTROY_RESOURCE = 'Destroy resource',
+    DESTROY_RESOURCE_TO_GAIN_STATS = 'Destroy resource to gain stats', // destroy resource, gain +1, +1 for each resource destroyed
+    DESTROY_UNIT = 'Destroy unit',
+    DISCARD_HAND = 'Discard hand', // discard X cards at random
     DRAW = 'Draw',
-    DRAW_MILL_WIN = 'Draw Mill Win',
-    DRAW_PER_UNIT = 'Draw Per Unit',
-    DRAW_UNTIL = 'Draw Until',
-    EXTRACT_CARD = 'Extract Card', // extract X of {cardName} card from deck
+    DRAW_MILL_WIN = 'Draw and win if no cards left',
+    DRAW_PER_UNIT = 'Draw per unit',
+    DRAW_UNTIL = 'Draw until',
+    DRAW_UNTIL_MATCHING_OPPONENTS = 'Draw until matching opponents',
+    EXTRACT_CARD = 'Extract card', // extract X of {cardName} card from deck
+    EXTRACT_SOLDIER_CARDS = 'Extract soldier cards',
+    EXTRACT_SPELL_CARDS = 'Extract spell cards',
+    EXTRACT_AND_SET_COST = 'Extract cards and set their costs',
     /**
      * Flicker own card (needs to be own - don't want to do opposing units yet
      * b/c it would involve too much new code - we'd have to control for opposing active player
      * effect resolutions)
      */
     FLICKER = 'Flicker',
-    GRANT_PASSIVE_EFFECT = 'Grant Passive Effect', // give unit(s) a passive effect
+    GAIN_ATTACK = 'Gain attack', // buff the unit's attack
+    GAIN_MAGICAL_HAND_AND_BOARD = 'Gain magical for hand and board units', // unit becomes magical
+    GAIN_STATS = 'Gain stats', // buff the unit's attack + hp
+    GAIN_STATS_EQUAL_TO_COST = 'Gain stats equal to cost', // buff the unit's attack + hp by the cost of the unit
+    GAIN_STATS_AND_EFFECTS = 'Gain stats and effects', // buff the unit's attack + hp and gain passive effects
+    GRANT_PASSIVE_EFFECT = 'Grant passive effect', // give unit(s) a passive effect
+    BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE = 'Buff hand attack with failsafe lifechange', // if no cards, do X to life instead
     HEAL = 'Heal', // to any target
     LEARN = 'Learn', // add spells / units to hand
+    LOSE_MAGICAL_AND_RANGED = 'Lose magical and ranged',
     MILL = 'Mill',
+    MODIFY_ATTACKS_PER_TURN = 'Modify attacks per turn',
     POLYMORPH = 'Polymorph', // polymorph a unit into a token type
     RAMP = 'Ramp', // add resources (tapped)
-    RAMP_FOR_TURN = 'Ramp for Turn',
-    RAMP_FROM_HAND = 'Ramp from Hand',
-    RETURN_FROM_CEMETERY = 'Return from cemetry', // Return X cards from cemetery -> board
+    RAMP_FOR_TURN = 'Ramp for turn',
+    RAMP_FROM_HAND = 'Ramp from hand',
+    REDUCE_LEGENDARY_LEADER_COST = 'Reduce legendary leader cost',
+    REDUCE_CARDS_COSTING_OVER_AMOUNT = 'Reduce cards costing over a threshold amount',
+    RETURN_FROM_CEMETERY = 'Return from cemetery', // Return X cards from cemetery -> board
+    RETURN_SPELLS_FROM_CEMETERY = 'Return spell cards from cemetery to hand',
+    RETURN_SPELLS_AND_RESOURCES_FROM_CEMETERY = 'Return X spell cards and resource cards from cemetery',
+    RETURN_RESOURCES_FROM_CEMETERY = 'Return resource cards from cemetery to hand',
     REVIVE = 'Revive', // revive units from the cemetery -> board
+    SHUFFLE_CEMETERY_INTO_DECK = 'Shuffle cemetery into deck',
+    SHUFFLE_HAND_INTO_DECK = 'Shuffle hand into deck',
     SHUFFLE_FROM_HAND = 'Shuffle from hand', // shuffle [all / N of] [X] card from hand into deck
+    SWAP_CARDS = 'Swap cards',
     SUMMON_UNITS = 'Summon Units', // summon units from cemeteries
     TRANSMUTE = 'Transmute', // turn [all/N of] [X] from hand into [Y]
+    TRANSFORM_RESOURCE = 'Transform resource', // turn resources at random into [X] card or ([X] cards into [Y] cards)
     TUCK = 'Tuck', // put on top of the deck
     TUCK_BOTTOM_AND_DRAW = 'Tuck to bottom and draw', // put on bottom of deck - that player draws for each put on bottom this way
 }
@@ -85,40 +112,69 @@ export const getDefaultTargetForEffect = (
     return {
         [EffectType.BLOOM]: TargetTypes.SELF_PLAYER,
         [EffectType.BOUNCE]: TargetTypes.UNIT,
+        [EffectType.BOUNCE_UNITS_UNDER_THRESHOLD_ATTACK]: TargetTypes.ALL_UNITS,
         [EffectType.BUFF_ATTACK]: TargetTypes.UNIT,
         [EffectType.BUFF_ATTACK_FOR_CYCLE]: TargetTypes.UNIT,
         [EffectType.BUFF_ATTACK_FOR_TURN]: TargetTypes.UNIT,
         [EffectType.BUFF_HAND_ATTACK]: TargetTypes.SELF_PLAYER,
+        [EffectType.BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE]:
+            TargetTypes.ALL_OPPONENTS,
         [EffectType.BUFF_MAGIC]: TargetTypes.UNIT,
         [EffectType.BUFF_TEAM_ATTACK]: TargetTypes.SELF_PLAYER,
         [EffectType.BUFF_TEAM_HP]: TargetTypes.SELF_PLAYER,
         [EffectType.BUFF_TEAM_MAGIC]: TargetTypes.SELF_PLAYER,
         [EffectType.BUFF_TEAM_GENERIC_UNITS]: TargetTypes.SELF_PLAYER,
+        [EffectType.BUFF_TEAM_LEGENDARY_UNITS]: TargetTypes.SELF_PLAYER,
         [EffectType.CURSE_HAND]: TargetTypes.OPPONENT,
+        [EffectType.CURSE_HAND_RESOURCE_TYPE]: TargetTypes.OPPONENT,
+        [EffectType.CURSE_HAND_SPELLS]: TargetTypes.OPPONENT,
         [EffectType.DEAL_DAMAGE]: TargetTypes.ANY,
+        [EffectType.DEAL_DAMAGE_TO_NON_SOLDIERS]: TargetTypes.UNIT,
+        [EffectType.DEPLOY_LEGENDARY_LEADER]: TargetTypes.ALL_PLAYERS,
         [EffectType.DESTROY_RESOURCE]: TargetTypes.OPPONENT,
-        [EffectType.DESTROY_RESOURCE_WITH_FEASTING]: TargetTypes.PLAYER,
+        [EffectType.DESTROY_RESOURCE_TO_GAIN_STATS]: TargetTypes.PLAYER,
         [EffectType.DESTROY_UNIT]: TargetTypes.OPPOSING_UNIT,
         [EffectType.DISCARD_HAND]: TargetTypes.OPPONENT,
         [EffectType.DRAW]: TargetTypes.SELF_PLAYER,
         [EffectType.DRAW_MILL_WIN]: TargetTypes.SELF_PLAYER,
         [EffectType.DRAW_PER_UNIT]: TargetTypes.SELF_PLAYER,
         [EffectType.DRAW_UNTIL]: TargetTypes.SELF_PLAYER,
+        [EffectType.DRAW_UNTIL_MATCHING_OPPONENTS]: TargetTypes.SELF_PLAYER,
+        [EffectType.EXTRACT_AND_SET_COST]: TargetTypes.SELF_PLAYER,
         [EffectType.EXTRACT_CARD]: TargetTypes.SELF_PLAYER,
+        [EffectType.EXTRACT_SOLDIER_CARDS]: TargetTypes.SELF_PLAYER,
+        [EffectType.EXTRACT_SPELL_CARDS]: TargetTypes.SELF_PLAYER,
         [EffectType.FLICKER]: TargetTypes.OWN_UNIT,
+        [EffectType.GAIN_ATTACK]: TargetTypes.SELF_PLAYER,
+        [EffectType.GAIN_MAGICAL_HAND_AND_BOARD]: TargetTypes.SELF_PLAYER,
+        [EffectType.GAIN_STATS]: TargetTypes.SELF_PLAYER,
+        [EffectType.GAIN_STATS_AND_EFFECTS]: TargetTypes.SELF_PLAYER,
+        [EffectType.GAIN_STATS_EQUAL_TO_COST]: TargetTypes.SELF_PLAYER,
         [EffectType.GRANT_PASSIVE_EFFECT]: TargetTypes.UNIT,
         [EffectType.HEAL]: TargetTypes.ALL_SELF_UNITS_CEMETERY,
         [EffectType.LEARN]: TargetTypes.SELF_PLAYER,
+        [EffectType.LOSE_MAGICAL_AND_RANGED]: TargetTypes.ALL_OPPOSING_UNITS,
         [EffectType.MILL]: TargetTypes.PLAYER,
+        [EffectType.MODIFY_ATTACKS_PER_TURN]: TargetTypes.UNIT,
         [EffectType.POLYMORPH]: TargetTypes.UNIT,
         [EffectType.RAMP]: TargetTypes.SELF_PLAYER,
         [EffectType.RAMP_FOR_TURN]: TargetTypes.SELF_PLAYER,
         [EffectType.RAMP_FROM_HAND]: TargetTypes.SELF_PLAYER,
-        [EffectType.REVIVE]: TargetTypes.ALL_SELF_UNITS_CEMETERY,
+        [EffectType.REDUCE_CARDS_COSTING_OVER_AMOUNT]: TargetTypes.SELF_PLAYER,
+        [EffectType.REDUCE_LEGENDARY_LEADER_COST]: TargetTypes.SELF_PLAYER,
         [EffectType.RETURN_FROM_CEMETERY]: TargetTypes.SELF_PLAYER,
+        [EffectType.RETURN_RESOURCES_FROM_CEMETERY]: TargetTypes.SELF_PLAYER,
+        [EffectType.RETURN_SPELLS_AND_RESOURCES_FROM_CEMETERY]:
+            TargetTypes.SELF_PLAYER,
+        [EffectType.RETURN_SPELLS_FROM_CEMETERY]: TargetTypes.SELF_PLAYER,
+        [EffectType.REVIVE]: TargetTypes.ALL_SELF_UNITS_CEMETERY,
+        [EffectType.SHUFFLE_CEMETERY_INTO_DECK]: TargetTypes.PLAYER,
         [EffectType.SHUFFLE_FROM_HAND]: TargetTypes.PLAYER,
+        [EffectType.SHUFFLE_HAND_INTO_DECK]: TargetTypes.PLAYER,
+        [EffectType.SWAP_CARDS]: TargetTypes.OPPONENT,
         [EffectType.SUMMON_UNITS]: TargetTypes.SELF_PLAYER,
         [EffectType.TRANSMUTE]: TargetTypes.SELF_PLAYER,
+        [EffectType.TRANSFORM_RESOURCE]: TargetTypes.SELF_PLAYER,
         [EffectType.TUCK]: TargetTypes.OPPOSING_UNIT,
         [EffectType.TUCK_BOTTOM_AND_DRAW]: TargetTypes.UNIT,
     }[effectType];
@@ -139,4 +195,5 @@ export enum PassiveEffect {
     POISONED = 'Poisonous (deals lethal damage)', // deals lethal dmg to enemy units
     QUICK = 'Quick (can attack right away)', // no summoning sickness
     STEADY = "Steady (this unit's stats cannot be modified)",
+    SNOW_BLINDED = 'Snow Blinded (Only able to attack players)',
 }

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -34,7 +34,10 @@ export enum EffectType {
     BUFF_ATTACK = 'Buff attack', // increase/decrease attack of a single unit
     BUFF_ATTACK_FOR_CYCLE = 'Buff attack for cycle', // increase/decrease attack of a single unit
     BUFF_ATTACK_FOR_TURN = 'Buff attack for turn', // increase/decrease attack of a single unit
-    BUFF_HAND_ATTACK = 'Buff hand attack', // buffs all creatures in hand
+    BUFF_HAND_ATTACK = 'Buff hand attack',
+    // give unit(s) a passive effect
+    BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE = 'Buff hand attack with failsafe lifechange',
+    // buffs all creatures in hand
     BUFF_MAGIC = 'Buff magic unit',
     BUFF_TEAM_ATTACK = 'Buff team attack',
     // increases attack for magic-units
@@ -42,13 +45,16 @@ export enum EffectType {
     // increases all attack for non-magic units
     BUFF_TEAM_HP = 'Buff team hp',
     // increases maxHp and hp for whole team
-    BUFF_TEAM_LEGENDARY_UNITS = 'Buff team legendary units', // increase hp and attack for units with no effects text
-    BUFF_TEAM_MAGIC = 'Buff team magic', // increase hp and attack for units with no effects text
+    BUFF_TEAM_LEGENDARY_UNITS = 'Buff team legendary units',
+    // increase hp and attack for units with no effects text
+    BUFF_TEAM_MAGIC = 'Buff team magic',
+    // increase hp and attack for units with no effects text
     CURSE_HAND = 'Curse hand', // adds one generic cost to cards in hand
-    CURSE_HAND_SPELLS = 'Curse hand spells', // adds one generic cost to cards in hand
     CURSE_HAND_RESOURCE_TYPE = 'Curse hand for cards of a specific resource type',
-    DEAL_DAMAGE = 'Deal damage', // to any target
-    DEAL_DAMAGE_TO_NON_SOLDIERS = 'Deal damage to non-soldier units',
+    // adds one generic cost to cards in hand
+    CURSE_HAND_SPELLS = 'Curse hand spells',
+    DEAL_DAMAGE = 'Deal damage',
+    DEAL_DAMAGE_TO_NON_SOLDIERS = 'Deal damage to non-soldier units', // if no cards, do X to life instead
     DEPLOY_LEGENDARY_LEADER = 'Deploy legendary leader', // without triggering enter board efffects
     DESTROY_RESOURCE = 'Destroy resource',
     DESTROY_RESOURCE_TO_GAIN_STATS = 'Destroy resource to gain stats', // destroy resource, gain +1, +1 for each resource destroyed
@@ -59,10 +65,10 @@ export enum EffectType {
     DRAW_PER_UNIT = 'Draw per unit',
     DRAW_UNTIL = 'Draw until',
     DRAW_UNTIL_MATCHING_OPPONENTS = 'Draw until matching opponents',
+    EXTRACT_AND_SET_COST = 'Extract cards and set their costs',
     EXTRACT_CARD = 'Extract card', // extract X of {cardName} card from deck
     EXTRACT_SOLDIER_CARDS = 'Extract soldier cards',
     EXTRACT_SPELL_CARDS = 'Extract spell cards',
-    EXTRACT_AND_SET_COST = 'Extract cards and set their costs',
     /**
      * Flicker own card (needs to be own - don't want to do opposing units yet
      * b/c it would involve too much new code - we'd have to control for opposing active player
@@ -72,10 +78,10 @@ export enum EffectType {
     GAIN_ATTACK = 'Gain attack', // buff the unit's attack
     GAIN_MAGICAL_HAND_AND_BOARD = 'Gain magical for hand and board units', // unit becomes magical
     GAIN_STATS = 'Gain stats', // buff the unit's attack + hp
-    GAIN_STATS_EQUAL_TO_COST = 'Gain stats equal to cost', // buff the unit's attack + hp by the cost of the unit
     GAIN_STATS_AND_EFFECTS = 'Gain stats and effects', // buff the unit's attack + hp and gain passive effects
-    GRANT_PASSIVE_EFFECT = 'Grant passive effect', // give unit(s) a passive effect
-    BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE = 'Buff hand attack with failsafe lifechange', // if no cards, do X to life instead
+    GAIN_STATS_EQUAL_TO_COST = 'Gain stats equal to cost', // buff the unit's attack + hp by the cost of the unit
+    GRANT_PASSIVE_EFFECT = 'Grant passive effect',
+    // to any target
     HEAL = 'Heal', // to any target
     LEARN = 'Learn', // add spells / units to hand
     LOSE_MAGICAL_AND_RANGED = 'Lose magical and ranged',
@@ -85,20 +91,24 @@ export enum EffectType {
     RAMP = 'Ramp', // add resources (tapped)
     RAMP_FOR_TURN = 'Ramp for turn',
     RAMP_FROM_HAND = 'Ramp from hand',
-    REDUCE_LEGENDARY_LEADER_COST = 'Reduce legendary leader cost',
     REDUCE_CARDS_COSTING_OVER_AMOUNT = 'Reduce cards costing over a threshold amount',
-    RETURN_FROM_CEMETERY = 'Return from cemetery', // Return X cards from cemetery -> board
-    RETURN_SPELLS_FROM_CEMETERY = 'Return spell cards from cemetery to hand',
-    RETURN_SPELLS_AND_RESOURCES_FROM_CEMETERY = 'Return X spell cards and resource cards from cemetery',
+    REDUCE_LEGENDARY_LEADER_COST = 'Reduce legendary leader cost',
+    RETURN_FROM_CEMETERY = 'Return from cemetery',
     RETURN_RESOURCES_FROM_CEMETERY = 'Return resource cards from cemetery to hand',
+    RETURN_SPELLS_AND_RESOURCES_FROM_CEMETERY = 'Return X spell cards and resource cards from cemetery',
+    // Return X cards from cemetery -> board
+    RETURN_SPELLS_FROM_CEMETERY = 'Return spell cards from cemetery to hand',
     REVIVE = 'Revive', // revive units from the cemetery -> board
     SHUFFLE_CEMETERY_INTO_DECK = 'Shuffle cemetery into deck',
+    SHUFFLE_FROM_HAND = 'Shuffle from hand',
     SHUFFLE_HAND_INTO_DECK = 'Shuffle hand into deck',
-    SHUFFLE_FROM_HAND = 'Shuffle from hand', // shuffle [all / N of] [X] card from hand into deck
+    SUMMON_UNITS = 'Summon Units',
+    // shuffle [all / N of] [X] card from hand into deck
     SWAP_CARDS = 'Swap cards',
-    SUMMON_UNITS = 'Summon Units', // summon units from cemeteries
-    TRANSMUTE = 'Transmute', // turn [all/N of] [X] from hand into [Y]
-    TRANSFORM_RESOURCE = 'Transform resource', // turn resources at random into [X] card or ([X] cards into [Y] cards)
+    // turn [all/N of] [X] from hand into [Y]
+    TRANSFORM_RESOURCE = 'Transform resource',
+    // summon units from cemeteries
+    TRANSMUTE = 'Transmute', // turn resources at random into [X] card or ([X] cards into [Y] cards)
     TUCK = 'Tuck', // put on top of the deck
     TUCK_BOTTOM_AND_DRAW = 'Tuck to bottom and draw', // put on bottom of deck - that player draws for each put on bottom this way
 }
@@ -193,7 +203,8 @@ export enum PassiveEffect {
     ETHEREAL = 'Ethereal (cannot be damaged outside of direct combat)',
     HEARTY = 'Hearty (Rather than going to cemetery, lose hearty and go to 1 hp)',
     POISONED = 'Poisonous (deals lethal damage)', // deals lethal dmg to enemy units
-    QUICK = 'Quick (can attack right away)', // no summoning sickness
-    STEADY = "Steady (this unit's stats cannot be modified)",
+    QUICK = 'Quick (can attack right away)',
     SNOW_BLINDED = 'Snow Blinded (Only able to attack players)',
+    // no summoning sickness
+    STEADY = "Steady (this unit's stats cannot be modified)",
 }


### PR DESCRIPTION
Adding a bunch of new effect types for cards I've brainstormed

Next up:
- adding them into the rules language models
- adding them into the rules engine (resolveEffect.ts)
- adding 'for each' multipliers (new feature for effects to describe ways of scaling effects)
- implementing the 'snowblind' mechanic
- ensuring that units with poisonous when dealing damage via effects destroy opposing units