### PR TITLE
Feat: Update rules text engine to support 25+ new effects added

### DIFF
--- a/src/cardDb/resources/utilityLands.ts
+++ b/src/cardDb/resources/utilityLands.ts
@@ -52,7 +52,7 @@ const SLAG_FIELDS = makeAdvancedResourceCard({
     imgSrc: 'https://images.pexels.com/photos/955662/pexels-photo-955662.jpeg',
     enterEffects: [
         {
-            type: EffectType.BUFF_HAND_ATTACK,
+            type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK,
             strength: 1,
         },
     ],

--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -970,7 +970,7 @@ const BANDIT_AMBUSH = makeCard({
             strength: 2,
         },
         {
-            type: EffectType.BUFF_HAND_ATTACK,
+            type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK,
             target: TargetTypes.SELF_PLAYER,
             strength: 1,
         },
@@ -1209,7 +1209,7 @@ const FISH_MARKET_VISIT = makeCard({
     cost: { [Resource.BAMBOO]: 1, [Resource.IRON]: 1 },
     effects: [
         { type: EffectType.BUFF_TEAM_HP, strength: 1 },
-        { type: EffectType.BUFF_HAND_ATTACK, strength: 2 },
+        { type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK, strength: 2 },
     ],
     rarity: CardRarity.UNCOMMON,
 });
@@ -1218,7 +1218,7 @@ const CONCENTRATED_FOCUS = makeCard({
     name: 'Concentrated Focus',
     imgSrc: 'https://images.pexels.com/photos/11331536/pexels-photo-11331536.jpeg',
     cost: { [Resource.BAMBOO]: 1, [Resource.IRON]: 1 },
-    effects: [{ type: EffectType.BUFF_HAND_ATTACK, strength: 3 }],
+    effects: [{ type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK, strength: 3 }],
     rarity: CardRarity.RARE,
 });
 

--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -84,7 +84,7 @@ const FURY_OF_THE_OWL = makeCard({
     effects: [
         {
             type: EffectType.GRANT_PASSIVE_EFFECT,
-            passiveEffect: PassiveEffect.QUICK,
+            passiveEffects: [PassiveEffect.QUICK],
             target: TargetTypes.UNIT,
         },
     ],
@@ -1258,7 +1258,7 @@ const BRIDGE_TO_IMMORTALITY = makeCard({
         {
             type: EffectType.GRANT_PASSIVE_EFFECT,
             target: TargetTypes.ALL_UNITS,
-            passiveEffect: PassiveEffect.HEARTY,
+            passiveEffects: [PassiveEffect.HEARTY],
         },
     ],
     rarity: CardRarity.MYTHIC,

--- a/src/cardDb/spells/spells.ts
+++ b/src/cardDb/spells/spells.ts
@@ -15,7 +15,7 @@ export const makeCard = (spellBase: SpellBase): SpellCard => ({
     ...spellBase,
     cardType: CardType.SPELL,
     isSelected: false,
-    originalCost: cloneDeep(spellBase.cost),
+    originalAttributes: { cost: cloneDeep(spellBase.cost) },
 });
 
 // Fire Magic

--- a/src/cardDb/units/misc.ts
+++ b/src/cardDb/units/misc.ts
@@ -457,7 +457,7 @@ const IRONSMITH: UnitCard = makeCard({
     description: '',
     enterEffects: [
         {
-            type: EffectType.BUFF_HAND_ATTACK,
+            type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK,
             strength: 1,
             target: TargetTypes.SELF_PLAYER,
         },

--- a/src/cardDb/units/tribes/dragons.ts
+++ b/src/cardDb/units/tribes/dragons.ts
@@ -125,7 +125,7 @@ const LEAPING_DRAGON: UnitCard = makeCard({
     enterEffects: [
         {
             type: EffectType.GRANT_PASSIVE_EFFECT,
-            passiveEffect: PassiveEffect.QUICK,
+            passiveEffects: [PassiveEffect.QUICK],
             target: TargetTypes.UNIT,
         },
     ],

--- a/src/cardDb/units/tribes/pirates.ts
+++ b/src/cardDb/units/tribes/pirates.ts
@@ -198,7 +198,7 @@ const DOUBLE_DEALING_ROGUE: UnitCard = makeCard({
     description: '',
     enterEffects: [
         {
-            type: EffectType.BUFF_HAND_ATTACK,
+            type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK,
             strength: 2,
             target: TargetTypes.SELF_PLAYER,
         },

--- a/src/cardDb/units/units.spec.ts
+++ b/src/cardDb/units/units.spec.ts
@@ -24,7 +24,7 @@ describe('Unit Cards', () => {
             isRanged: true,
             isMagical: true,
             isSoldier: false,
-            passiveEffects: [],
+            passiveEffects: [PassiveEffect.ETHEREAL],
             rarity: CardRarity.COMMON,
         };
         const unitCard = makeCard(unitBase);
@@ -34,7 +34,10 @@ describe('Unit Cards', () => {
         expect(unitCard.numAttacksLeft).toBe(0);
         expect(unitCard.hp).toBe(10);
         expect(unitCard.hpBuff).toBe(0);
-        expect(unitCard.originalCost).toEqual(unitBase.cost);
+        expect(unitCard.originalAttributes.cost).toEqual(unitBase.cost);
+        expect(unitCard.originalAttributes.passiveEffects).toEqual(
+            unitBase.passiveEffects
+        );
         expect(unitCard.cardType).toBe(CardType.UNIT);
         expect(unitCard.isSelected).toBe(false);
     });

--- a/src/client/components/SpellGridItem/SpellGridItem.tsx
+++ b/src/client/components/SpellGridItem/SpellGridItem.tsx
@@ -29,7 +29,12 @@ export const SpellGridItem: React.FC<SpellGridItemProps> = ({
     onClick,
     zoomLevel,
 }) => {
-    const { cost, name, effects, originalCost } = card;
+    const {
+        cost,
+        name,
+        effects,
+        originalAttributes: { cost: originalCost },
+    } = card;
     const { primaryColor, secondaryColor } = getColorsForCard(card);
 
     return (

--- a/src/client/components/UnitGridItem/UnitGridItem.tsx
+++ b/src/client/components/UnitGridItem/UnitGridItem.tsx
@@ -57,7 +57,7 @@ export const UnitGridItem: React.FC<UnitGridItemProps> = ({
         numAttacksLeft,
         oneCycleAttackBuff,
         oneTurnAttackBuff,
-        originalCost,
+        originalAttributes: { cost: originalCost },
         passiveEffects,
         totalHp,
     } = card;

--- a/src/factories/cards/makeCards.ts
+++ b/src/factories/cards/makeCards.ts
@@ -44,8 +44,13 @@ export const makeUnitCard = (unitBase: UnitBase): UnitCard => {
         attackBuff: 0,
         oneCycleAttackBuff: 0,
         oneTurnAttackBuff: 0,
-        originalCost: cloneDeep(unitBase.cost),
-        originalPassiveEffects: cloneDeep(unitBase.passiveEffects),
+        originalAttributes: {
+            cost: cloneDeep(unitBase.cost),
+            isMagical: unitBase.isMagical,
+            isRanged: unitBase.isRanged,
+            numAttacks: unitBase.numAttacks,
+            passiveEffects: cloneDeep(unitBase.passiveEffects),
+        },
     };
 };
 

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -85,7 +85,9 @@ export function applyWinState(board: Board): Board {
 }
 
 export const resetUnitCard = (unitCard: UnitCard) => {
-    unitCard.passiveEffects = cloneDeep(unitCard.originalPassiveEffects);
+    unitCard.passiveEffects = cloneDeep(
+        unitCard.originalAttributes?.passiveEffects || []
+    );
     const hasQuick = unitCard.passiveEffects.includes(PassiveEffect.QUICK);
 
     unitCard.hp = unitCard.totalHp;
@@ -94,8 +96,11 @@ export const resetUnitCard = (unitCard: UnitCard) => {
     unitCard.oneCycleAttackBuff = 0;
     unitCard.oneTurnAttackBuff = 0;
     unitCard.isFresh = true;
+    unitCard.isMagical = unitCard.originalAttributes?.isMagical || false;
+    unitCard.isRanged = unitCard.originalAttributes?.isRanged || false;
+    unitCard.numAttacks = unitCard.originalAttributes?.numAttacks || 1;
     unitCard.numAttacksLeft = hasQuick ? unitCard.numAttacks : 0;
-    unitCard.cost = cloneDeep(unitCard.originalCost);
+    unitCard.cost = cloneDeep(unitCard.originalAttributes?.cost || {});
 };
 
 /**
@@ -453,8 +458,8 @@ export const applyGameAction = ({
             // bump legendary leader costs
             activePlayer.legendaryLeaderExtraCost += 2;
             activePlayer.legendaryLeader.cost.Generic =
-                (activePlayer.legendaryLeader.originalCost.Generic || 0) +
-                activePlayer.legendaryLeaderExtraCost;
+                (activePlayer.legendaryLeader.originalAttributes.cost.Generic ||
+                    0) + activePlayer.legendaryLeaderExtraCost;
 
             return clonedBoard;
         }

--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -3,7 +3,13 @@ import shuffle from 'lodash.shuffle';
 
 import { Board, GameState, Player } from '@/types/board';
 import { GameAction, GameActionTypes } from '@/types/gameActions';
-import { Card, CardType, ResourceCard, UnitCard } from '@/types/cards';
+import {
+    Card,
+    CardType,
+    ResourceCard,
+    SpellCard,
+    UnitCard,
+} from '@/types/cards';
 import { canPlayerPayForCard } from '@/transformers/canPlayerPayForCard';
 import { payForCard } from '@/transformers/payForCard';
 import { PassiveEffect } from '@/types/effects';
@@ -101,6 +107,22 @@ export const resetUnitCard = (unitCard: UnitCard) => {
     unitCard.numAttacks = unitCard.originalAttributes?.numAttacks || 1;
     unitCard.numAttacksLeft = hasQuick ? unitCard.numAttacks : 0;
     unitCard.cost = cloneDeep(unitCard.originalAttributes?.cost || {});
+    return unitCard;
+};
+
+export const resetSpellCard = (spellCard: SpellCard) => {
+    spellCard.cost = cloneDeep(spellCard.originalAttributes?.cost || {});
+    return spellCard;
+};
+
+export const resetCard = (card: Card) => {
+    if (card.cardType === CardType.UNIT) {
+        return resetUnitCard(card);
+    }
+    if (card.cardType === CardType.SPELL) {
+        return resetSpellCard(card);
+    }
+    return card;
 };
 
 /**

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -6,12 +6,7 @@ import { EffectType, PassiveEffect, TargetTypes } from '@/types/effects';
 import { resolveEffect } from './resolveEffect';
 import { makeCard, makeResourceCard, makeUnitCard } from '@/factories/cards';
 import { Tokens, UnitCards } from '@/mocks/units';
-import {
-    CardType,
-    EffectRequirementsType,
-    SpellCard,
-    UnitCard,
-} from '@/types/cards';
+import { EffectRequirementsType, UnitCard } from '@/types/cards';
 import { Resource } from '@/types/resources';
 import { SpellCards } from '@/mocks/spells';
 

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -209,7 +209,10 @@ describe('resolve effect', () => {
             const newBoard = resolveEffect(
                 board,
                 {
-                    effect: { type: EffectType.BUFF_HAND_ATTACK, strength: 2 },
+                    effect: {
+                        type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK,
+                        strength: 2,
+                    },
                 },
                 'Timmy'
             );

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -1080,7 +1080,7 @@ describe('resolve effect', () => {
                     effect: {
                         type: EffectType.GRANT_PASSIVE_EFFECT,
                         target: TargetTypes.ALL_UNITS,
-                        passiveEffect: PassiveEffect.QUICK,
+                        passiveEffects: [PassiveEffect.QUICK],
                     },
                 },
                 'Timmy'

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -6,8 +6,14 @@ import { EffectType, PassiveEffect, TargetTypes } from '@/types/effects';
 import { resolveEffect } from './resolveEffect';
 import { makeCard, makeResourceCard, makeUnitCard } from '@/factories/cards';
 import { Tokens, UnitCards } from '@/mocks/units';
-import { EffectRequirementsType, UnitCard } from '@/types/cards';
+import {
+    CardType,
+    EffectRequirementsType,
+    SpellCard,
+    UnitCard,
+} from '@/types/cards';
 import { Resource } from '@/types/resources';
+import { SpellCards } from '@/mocks/spells';
 
 describe('resolve effect', () => {
     let board: Board;
@@ -971,6 +977,32 @@ describe('resolve effect', () => {
             expect(newBoard.players[0].hand).toHaveLength(0);
             expect(newBoard.players[0].cemetery).toHaveLength(
                 PlayerConstants.STARTING_HAND_SIZE
+            );
+        });
+
+        it('resets costs', () => {
+            board.players[0].hand = [
+                { ...makeUnitCard(UnitCards.ASSASSIN), cost: {} },
+                { ...makeCard(SpellCards.A_GENTLE_GUST), cost: {} },
+            ];
+
+            const newBoard = resolveEffect(
+                board,
+                {
+                    effect: {
+                        type: EffectType.DISCARD_HAND,
+                        strength: Number.MAX_SAFE_INTEGER,
+                        target: TargetTypes.ALL_PLAYERS,
+                    },
+                },
+                'Timmy'
+            );
+            expect(newBoard.players[0].hand).toHaveLength(0);
+            expect((newBoard.players[0].cemetery[0] as UnitCard).cost).toEqual(
+                UnitCards.ASSASSIN.cost
+            );
+            expect((newBoard.players[0].cemetery[1] as SpellCard).cost).toEqual(
+                SpellCards.A_GENTLE_GUST.cost
             );
         });
 

--- a/src/server/resolveEffect/resolveEffect.spec.ts
+++ b/src/server/resolveEffect/resolveEffect.spec.ts
@@ -998,12 +998,22 @@ describe('resolve effect', () => {
                 'Timmy'
             );
             expect(newBoard.players[0].hand).toHaveLength(0);
-            expect((newBoard.players[0].cemetery[0] as UnitCard).cost).toEqual(
-                UnitCards.ASSASSIN.cost
-            );
-            expect((newBoard.players[0].cemetery[1] as SpellCard).cost).toEqual(
-                SpellCards.A_GENTLE_GUST.cost
-            );
+            // cards are discarded in random order b/c of lodash's sampleSize, so we can't rely on order
+            // e.g. expeting newBoard.players[0].cemetery[0] to always be UnitCards.ASSASSIN
+            expect(
+                (
+                    newBoard.players[0].cemetery.find(
+                        (card) => card.name === UnitCards.ASSASSIN.name
+                    ) as UnitCard
+                ).cost
+            ).toEqual(UnitCards.ASSASSIN.cost);
+            expect(
+                (
+                    newBoard.players[0].cemetery.find(
+                        (card) => card.name === SpellCards.A_GENTLE_GUST.name
+                    ) as UnitCard
+                ).cost
+            ).toEqual(SpellCards.A_GENTLE_GUST.cost);
         });
 
         it('broadcasts what was discarded', () => {

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -102,7 +102,9 @@ const performEffectRequirement = ({
             const unitsByCost: Map<number, UnitCard[]> = new Map();
 
             activePlayer.units.forEach((unit) => {
-                const totalCost = sum(Object.values(unit.originalCost));
+                const totalCost = sum(
+                    Object.values(unit.originalAttributes.cost)
+                );
                 if (unitsByCost.has(totalCost)) {
                     unitsByCost.get(totalCost).push(unit);
                 } else {

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -503,7 +503,7 @@ export const resolveEffect = (
             processBoardToCemetery(clonedBoard, addSystemChat);
             return clonedBoard;
         }
-        case EffectType.BUFF_HAND_ATTACK: {
+        case EffectType.BUFF_HAND_NON_MAGIC_ATTACK: {
             playerTargets.forEach((player) => {
                 player.hand.forEach((card) => {
                     if (card.cardType !== CardType.UNIT) return;

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -26,6 +26,7 @@ import { makeCard, makeResourceCard } from '@/factories/cards';
 import {
     applyWinState,
     processBoardToCemetery,
+    resetCard,
     resetUnitCard,
 } from '../gameEngine';
 import { transformEffectToRulesText } from '@/transformers/transformEffectsToRulesText';
@@ -677,7 +678,13 @@ export const resolveEffect = (
                     Math.min(hand.length, effectStrength)
                 );
                 player.hand = difference(hand, cardsToDiscard);
-                player.cemetery = player.cemetery.concat(cardsToDiscard);
+
+                const cardsToDiscardWithResets = cardsToDiscard.map((card) =>
+                    resetCard(card)
+                );
+                player.cemetery = player.cemetery.concat(
+                    cardsToDiscardWithResets
+                );
                 addSystemChat(
                     `${player.name} discarded ${cardsToDiscard
                         .map((card) => `[[${card.name}]]`)

--- a/src/server/resolveEffect/resolveEffect.ts
+++ b/src/server/resolveEffect/resolveEffect.ts
@@ -281,7 +281,7 @@ export const resolveEffect = (
         strength: effectStrength = 0,
         cardName,
         secondaryCardName,
-        passiveEffect,
+        passiveEffects,
         sourceId,
         requirements,
     } = effect;
@@ -771,18 +771,20 @@ export const resolveEffect = (
         }
         case EffectType.GRANT_PASSIVE_EFFECT: {
             unitTargets.forEach(({ unitCard }) => {
-                if (!unitCard.passiveEffects.includes(passiveEffect)) {
-                    unitCard.passiveEffects.push(passiveEffect);
+                passiveEffects.forEach((passiveEffect) => {
+                    if (!unitCard.passiveEffects.includes(passiveEffect)) {
+                        unitCard.passiveEffects.push(passiveEffect);
 
-                    // handle adding attacks to units getting 'quick'
-                    if (
-                        passiveEffect === PassiveEffect.QUICK &&
-                        unitCard.isFresh
-                    ) {
-                        unitCard.numAttacksLeft = unitCard.numAttacks;
-                        unitCard.isFresh = false;
+                        // handle adding attacks to units getting 'quick'
+                        if (
+                            passiveEffect === PassiveEffect.QUICK &&
+                            unitCard.isFresh
+                        ) {
+                            unitCard.numAttacksLeft = unitCard.numAttacks;
+                            unitCard.isFresh = false;
+                        }
                     }
-                }
+                });
             });
             return clonedBoard;
         }

--- a/src/transformers/joinPhrases/joinPhrases.ts
+++ b/src/transformers/joinPhrases/joinPhrases.ts
@@ -1,0 +1,19 @@
+/**
+ * Natural language helper for joining phrases together, e.g.
+ * @param phrases - example: ['hearty', 'quick', 'steady']
+ * @returns 'hearty, quick, and steady'
+ */
+export const joinPhrases = (phrases: string[]) => {
+    if (phrases.length === 1) {
+        return phrases[0];
+    }
+    if (phrases.length === 2) {
+        return `${phrases[0]} and ${phrases[1]}`;
+    }
+    if (phrases.length > 2) {
+        return `${phrases.slice(0, -1).join(', ')}, and ${
+            phrases.slice(-1)[0]
+        }`;
+    }
+    return '';
+};

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
@@ -5,7 +5,7 @@ import { Resource } from '@/types/resources';
 import { transformEffectToRulesText } from './transformEffectsToRulesText';
 
 describe('transformEffectstoRulesText', () => {
-    describe('bloom effect', () => {
+    describe('Bloom effect', () => {
         const effect: Effect = {
             type: EffectType.BLOOM,
             strength: 3,
@@ -15,7 +15,7 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
-    describe('bounce', () => {
+    describe('Bounce', () => {
         it('displays rules for bouncing units (any unit, plural)', () => {
             const effect: Effect = {
                 type: EffectType.BOUNCE,
@@ -43,6 +43,17 @@ describe('transformEffectstoRulesText', () => {
             };
             expect(transformEffectToRulesText(effect)).toEqual(
                 `Return all opposing units back to their controllers' hand`
+            );
+        });
+
+        it('displays rules for bouncing units under a threshold', () => {
+            const effect: Effect = {
+                type: EffectType.BOUNCE_UNITS_UNDER_THRESHOLD_ATTACK,
+                target: TargetTypes.ALL_OPPOSING_UNITS,
+                strength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Return all opposing units with 2 attack or lower back to their controllers' hand`
             );
         });
     });
@@ -163,7 +174,7 @@ describe('transformEffectstoRulesText', () => {
         });
     });
 
-    describe('buffing generic units', () => {
+    describe('Buffing generic units', () => {
         const effect: Effect = {
             type: EffectType.BUFF_TEAM_GENERIC_UNITS,
             strength: 5,
@@ -174,61 +185,86 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
-    it('displays rules for buffing your hand (attack)', () => {
-        const effect: Effect = {
-            type: EffectType.BUFF_HAND_ATTACK,
-            target: TargetTypes.SELF_PLAYER,
-            strength: 5,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase attack of non-magical units in your hand by 5`
-        );
+    describe('other buffing effects', () => {
+        it('displays rules for buffing your hand (attack)', () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_HAND_NON_MAGIC_ATTACK,
+                target: TargetTypes.SELF_PLAYER,
+                strength: 5,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase attack of non-magical units in your hand by 5`
+            );
+        });
+
+        it("displays rules for debuffing your opponents' hand with a failsafe", () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE,
+                target: TargetTypes.ALL_OPPONENTS,
+                strength: -3,
+                secondaryStrength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Decrease attack of units in all opponents' hand by 3. If no units are changed this way, gain 3 life`
+            );
+        });
+
+        it('displays rules for buffing your team attack', () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_TEAM_ATTACK,
+                strength: 5,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase attack of your non-magic units by 5`
+            );
+        });
+
+        it("displays rules for debuffing your opponents' attack", () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_TEAM_ATTACK,
+                strength: -2,
+                target: TargetTypes.ALL_OPPONENTS,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Decrease attack of all opponents' non-magic units by 2`
+            );
+        });
+
+        it("displays rules for buffing your team's hp", () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_TEAM_HP,
+                target: TargetTypes.SELF_PLAYER,
+                strength: 5,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase HP of your units by 5`
+            );
+        });
+
+        it("displays rules for buffing your team's magic", () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_TEAM_MAGIC,
+                target: TargetTypes.SELF_PLAYER,
+                strength: 5,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase attack of your magic units by 5`
+            );
+        });
+
+        it("displays rules for buffing your team's legendary unit", () => {
+            const effect: Effect = {
+                type: EffectType.BUFF_TEAM_LEGENDARY_UNITS,
+                target: TargetTypes.SELF_PLAYER,
+                strength: 5,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase attack and HP of your legendary units by 5`
+            );
+        });
     });
 
-    it('displays rules for buffing your team attack', () => {
-        const effect: Effect = {
-            type: EffectType.BUFF_TEAM_ATTACK,
-            strength: 5,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase attack of your non-magic units by 5`
-        );
-    });
-
-    it("displays rules for debuffing your opponents' attack", () => {
-        const effect: Effect = {
-            type: EffectType.BUFF_TEAM_ATTACK,
-            strength: -2,
-            target: TargetTypes.ALL_OPPONENTS,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Decrease attack of all opponents' non-magic units by 2`
-        );
-    });
-
-    it('displays rules for buffing your team hp', () => {
-        const effect: Effect = {
-            type: EffectType.BUFF_TEAM_HP,
-            target: TargetTypes.SELF_PLAYER,
-            strength: 5,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase HP of your units by 5`
-        );
-    });
-
-    it('displays rules for buffing your team magic', () => {
-        const effect: Effect = {
-            type: EffectType.BUFF_TEAM_MAGIC,
-            target: TargetTypes.SELF_PLAYER,
-            strength: 5,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Increase attack of your magic units by 5`
-        );
-    });
-
-    describe('curse hand', () => {
+    describe('Curse hand', () => {
         it('displays rules for cursing a hand', () => {
             const effect: Effect = {
                 type: EffectType.CURSE_HAND,
@@ -250,9 +286,32 @@ describe('transformEffectstoRulesText', () => {
                 `Decrease cost of cards in your hand by 5 (generic)`
             );
         });
+
+        it('displays rules for increasing costs from a hand (for specific resource types)', () => {
+            const effect: Effect = {
+                type: EffectType.CURSE_HAND_RESOURCE_TYPE,
+                strength: 5,
+                resourceType: Resource.CRYSTAL,
+                target: TargetTypes.SELF_PLAYER,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase cost of purple cards in your hand by 5 (generic)`
+            );
+        });
+
+        it('displays rules for increasing costs from a hand (for specific resource types)', () => {
+            const effect: Effect = {
+                type: EffectType.CURSE_HAND_SPELLS,
+                strength: 5,
+                target: TargetTypes.SELF_PLAYER,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Increase cost of spell cards in your hand by 5 (generic)`
+            );
+        });
     });
 
-    describe('destroy resource', () => {
+    describe('Destroy resource', () => {
         it('displays rules destroying a resource', () => {
             const effect: Effect = {
                 type: EffectType.DESTROY_RESOURCE,
@@ -307,15 +366,40 @@ describe('transformEffectstoRulesText', () => {
         });
     });
 
-    it('displays rules for dealing damage', () => {
-        const effect: Effect = {
-            type: EffectType.DEAL_DAMAGE,
-            strength: 7,
-            target: TargetTypes.ALL_UNITS,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Deal 7 damage to all units`
-        );
+    describe('Dealing damage', () => {
+        it('displays rules for dealing damage', () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE,
+                strength: 7,
+                target: TargetTypes.ALL_UNITS,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Deal 7 damage to all units`
+            );
+        });
+
+        it('displays rules for dealing damage to non-soldier units', () => {
+            const effect: Effect = {
+                type: EffectType.DEAL_DAMAGE_TO_NON_SOLDIERS,
+                strength: 7,
+                target: TargetTypes.ALL_UNITS,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Deal 7 damage to all non-soldier units`
+            );
+        });
+    });
+
+    describe('Deploy legendary leaders', () => {
+        it('displays rules for forcing players to deploy legendary leaders', () => {
+            const effect: Effect = {
+                type: EffectType.DEPLOY_LEGENDARY_LEADER,
+                target: TargetTypes.ALL_PLAYERS,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Deploy all players' legendary leaders onto the board. Don't trigger any enter the board effects`
+            );
+        });
     });
 
     it('displays rules for forcing hand discard', () => {
@@ -390,14 +474,13 @@ describe('transformEffectstoRulesText', () => {
             );
         });
 
-        it('displays rules for drawing cards (until a limit) - all players', () => {
+        it('displays rules for drawing cards (until equal to greatest for opponents) - all players', () => {
             const effect: Effect = {
-                type: EffectType.DRAW_UNTIL,
+                type: EffectType.DRAW_UNTIL_MATCHING_OPPONENTS,
                 target: TargetTypes.ALL_PLAYERS,
-                strength: 3,
             };
             expect(transformEffectToRulesText(effect)).toEqual(
-                `If under 3 cards in hand, all players draw cards until having 3 in hand`
+                `All players draw cards until they have X cards, where X is the greatest amount of cards in hand amongst all opponents`
             );
         });
     });
@@ -414,7 +497,7 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
-    describe('flicker', () => {
+    describe('Flicker', () => {
         it('displays rules for flickering a single unit', () => {
             const effect: Effect = {
                 type: EffectType.FLICKER,

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
@@ -665,6 +665,17 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
+    describe('Losing properties', () => {
+        it('displays rules for losing magical and ranged', () => {
+            const effect: Effect = {
+                type: EffectType.LOSE_MAGICAL_AND_RANGED,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `All opposing units' units lose magical/ranged`
+            );
+        });
+    });
+
     describe('Mill', () => {
         it('displays rules for milling all players', () => {
             const effect: Effect = {
@@ -697,6 +708,19 @@ describe('transformEffectstoRulesText', () => {
         expect(transformEffectToRulesText(effect)).toEqual(
             `Turn all units into a [Frog]`
         );
+    });
+
+    describe('Modifying attacks per turn', () => {
+        it('displays rules for setting attacks per turn', () => {
+            const effect: Effect = {
+                type: EffectType.MODIFY_ATTACKS_PER_TURN,
+                target: TargetTypes.ALL_UNITS,
+                strength: 1,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Set all units to have 1 attack per turn`
+            );
+        });
     });
 
     describe('Ramp', () => {

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
@@ -774,6 +774,19 @@ describe('transformEffectstoRulesText', () => {
         });
     });
 
+    describe('Reducing costs', () => {
+        it('displays rules for reducing costs with a minimum floor', () => {
+            const effect: Effect = {
+                type: EffectType.REDUCE_CARDS_COSTING_OVER_AMOUNT,
+                strength: 3,
+                secondaryStrength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Decrease cost of cards in your hand by 3 (generic).  Cards reduced this way cannot be reduced below 2 total cost`
+            );
+        });
+    });
+
     it('displays rules for returning from cemetery', () => {
         const effect: Effect = {
             type: EffectType.RETURN_FROM_CEMETERY,

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
@@ -785,17 +785,59 @@ describe('transformEffectstoRulesText', () => {
                 `Decrease cost of cards in your hand by 3 (generic).  Cards reduced this way cannot be reduced below 2 total cost`
             );
         });
+
+        it('displays rules for reducing costs for legendary leader', () => {
+            const effect: Effect = {
+                type: EffectType.REDUCE_LEGENDARY_LEADER_COST,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Decrease cost of your legendary leader by 3 (generic).  Cards reduced this way cannot be reduced below their original costs`
+            );
+        });
     });
 
-    it('displays rules for returning from cemetery', () => {
-        const effect: Effect = {
-            type: EffectType.RETURN_FROM_CEMETERY,
-            strength: 3,
-            cardName: 'Ember Spear',
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Return 3 Ember Spear cards from your cemetery`
-        );
+    describe('returning cards from cemetery', () => {
+        it('displays rules for returning specific cards from cemetery', () => {
+            const effect: Effect = {
+                type: EffectType.RETURN_FROM_CEMETERY,
+                strength: 3,
+                cardName: 'Ember Spear',
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Return 3 Ember Spear cards from your cemetery`
+            );
+        });
+
+        it('displays rules for returning resource cards from cemetery', () => {
+            const effect: Effect = {
+                type: EffectType.RETURN_RESOURCES_FROM_CEMETERY,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Return 3 resource cards at random from your cemetery`
+            );
+        });
+
+        it('displays rules for returning spell+resource cards from cemetery', () => {
+            const effect: Effect = {
+                type: EffectType.RETURN_SPELLS_AND_RESOURCES_FROM_CEMETERY,
+                strength: 1,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Return 1 resource card and 1 spell card at random from your cemetery`
+            );
+        });
+
+        it('displays rules for returning spell cards from cemetery', () => {
+            const effect: Effect = {
+                type: EffectType.RETURN_SPELLS_FROM_CEMETERY,
+                strength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Return 2 spell cards at random from your cemetery`
+            );
+        });
     });
 
     it('displays rules for reviving', () => {
@@ -808,8 +850,8 @@ describe('transformEffectstoRulesText', () => {
         );
     });
 
-    describe('Shuffle from hand', () => {
-        it("displays rules for shuffling into a player's deck", () => {
+    describe('Shuffling cards', () => {
+        it("displays rules for shuffling cards into a player's deck", () => {
             const effect: Effect = {
                 type: EffectType.SHUFFLE_FROM_HAND,
                 strength: 2,
@@ -818,6 +860,24 @@ describe('transformEffectstoRulesText', () => {
             };
             expect(transformEffectToRulesText(effect)).toEqual(
                 `Shuffle 2 [Tea] cards in hand into any opponent's decks`
+            );
+        });
+
+        it('displays rules for shuffling cards from a cemetery into a deck', () => {
+            const effect: Effect = {
+                type: EffectType.SHUFFLE_CEMETERY_INTO_DECK,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Any player shuffles cards in their cemetery into their deck`
+            );
+        });
+
+        it('displays rules for shuffling cards from a hand into a deck', () => {
+            const effect: Effect = {
+                type: EffectType.SHUFFLE_HAND_INTO_DECK,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Any player shuffles cards in their hand into their deck`
             );
         });
     });
@@ -843,6 +903,58 @@ describe('transformEffectstoRulesText', () => {
             };
             expect(transformEffectToRulesText(effect)).toEqual(
                 `Summon 2 Demons - 1 ⚔️ 1 💙 for any opponent`
+            );
+        });
+    });
+
+    describe('Swapping cards', () => {
+        it('displays rules for swapping cards', () => {
+            const effect: Effect = {
+                type: EffectType.SWAP_CARDS,
+                strength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Swap 2 cards at random with any opponent.  If a player has fewer cards, swap up to 2 cards instead`
+            );
+        });
+    });
+
+    describe('Summon units', () => {
+        it('displays rules for summoning units (opponents)', () => {
+            const effect: Effect = {
+                type: EffectType.SUMMON_UNITS,
+                strength: 2,
+                target: TargetTypes.OPPONENT,
+                summonType: Tokens.DEMON,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Summon 2 Demons - 1 ⚔️ 1 💙 for any opponent`
+            );
+        });
+    });
+
+    describe('Transforming resources', () => {
+        it('displays rules for transforming resource cards (any)', () => {
+            const effect: Effect = {
+                type: EffectType.TRANSFORM_RESOURCE,
+                strength: 1,
+                target: TargetTypes.SELF_PLAYER,
+                secondaryCardName: 'Water',
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Turn 1 non-[Water] resource cards controlled by you into [Water] at random`
+            );
+        });
+
+        it('displays rules for transforming resource cards (specific ones)', () => {
+            const effect: Effect = {
+                type: EffectType.TRANSFORM_RESOURCE,
+                target: TargetTypes.ALL_OPPONENTS,
+                cardName: 'Bamboo',
+                secondaryCardName: 'Water',
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Turn all [Bamboo] cards controlled by an opponent into [Water]`
             );
         });
     });

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.spec.ts
@@ -485,16 +485,52 @@ describe('transformEffectstoRulesText', () => {
         });
     });
 
-    it('displays rules for extracting cards from a deck', () => {
-        const effect: Effect = {
-            type: EffectType.EXTRACT_CARD,
-            strength: 2,
-            cardName: 'Iron',
-            target: TargetTypes.OPPONENT,
-        };
-        expect(transformEffectToRulesText(effect)).toEqual(
-            `Extract 2 Iron cards from any opponent's deck`
-        );
+    describe('Extracting cards', () => {
+        it('displays rules for extracting cards from a deck', () => {
+            const effect: Effect = {
+                type: EffectType.EXTRACT_CARD,
+                strength: 2,
+                cardName: 'Iron',
+                target: TargetTypes.OPPONENT,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Extract 2 Iron cards from any opponent's deck`
+            );
+        });
+
+        it('displays rules for extracting cards from a deck', () => {
+            const effect: Effect = {
+                type: EffectType.EXTRACT_UNIT_AND_SET_COST,
+                strength: 2,
+                cost: {
+                    Generic: 1,
+                    Bamboo: 2,
+                },
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Extract 2 unit cards from your deck and set their costs to 1🎋🎋`
+            );
+        });
+
+        it('displays rules for extracting soldier cards from a deck', () => {
+            const effect: Effect = {
+                type: EffectType.EXTRACT_SOLDIER_CARDS,
+                strength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Extract 2 soldier cards from your deck`
+            );
+        });
+
+        it('displays rules for extracting spell cards from a deck', () => {
+            const effect: Effect = {
+                type: EffectType.EXTRACT_SPELL_CARDS,
+                strength: 2,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Extract 2 spell cards from your deck`
+            );
+        });
     });
 
     describe('Flicker', () => {
@@ -517,12 +553,78 @@ describe('transformEffectstoRulesText', () => {
         });
     });
 
+    describe('Gaining stats and effects', () => {
+        it('displays rules for gaining attack', () => {
+            const effect: Effect = {
+                type: EffectType.GAIN_ATTACK,
+                target: TargetTypes.ALL_SELF_UNITS,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `All your units gain 3 attack`
+            );
+        });
+
+        it('displays rules for gaining attack until a threshold amount', () => {
+            const effect: Effect = {
+                type: EffectType.GAIN_ATTACK_UNTIL,
+                target: TargetTypes.ALL_UNITS,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `All units gain attack until they are at least 3 attack`
+            );
+        });
+
+        it('displays rules for gaining magical for units on both hand and board', () => {
+            const effect: Effect = {
+                type: EffectType.GAIN_MAGICAL_HAND_AND_BOARD,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Your units in hand and board become magical units`
+            );
+        });
+
+        it('displays rules for gaining stats', () => {
+            const effect: Effect = {
+                type: EffectType.GAIN_STATS,
+                strength: 3,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Gain 3 attack and HP`
+            );
+        });
+
+        it('displays rules for gaining stats and passive effects', () => {
+            const effect: Effect = {
+                type: EffectType.GAIN_STATS_AND_EFFECTS,
+                strength: 3,
+                passiveEffects: [
+                    PassiveEffect.HEARTY,
+                    PassiveEffect.SNOW_BLINDED,
+                ],
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Gain 3 attack/HP, [Hearty (Rather than going to cemetery, lose hearty and go to 1 hp)], and [Snow Blinded (Only able to attack players)]`
+            );
+        });
+
+        it('displays rules for gaining stats equal to cost', () => {
+            const effect: Effect = {
+                type: EffectType.GAIN_STATS_EQUAL_TO_COST,
+            };
+            expect(transformEffectToRulesText(effect)).toEqual(
+                `Gain attack/HP equal to the total cost of this card`
+            );
+        });
+    });
+
     describe('Granting passive effects', () => {
         it('displays rules for granting effects', () => {
             const effect: Effect = {
                 type: EffectType.GRANT_PASSIVE_EFFECT,
                 target: TargetTypes.ALL_SELF_UNITS,
-                passiveEffect: PassiveEffect.POISONED,
+                passiveEffects: [PassiveEffect.POISONED],
             };
             expect(transformEffectToRulesText(effect)).toEqual(
                 `Give all your units [Poisonous (deals lethal damage)]`

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -605,7 +605,9 @@ export const transformEffectToRulesText = (
                 return `Deploy ${strength} ${resourceType} card${pluralizationEffectStrength} from your hand tapped`;
             }
             case EffectType.REDUCE_CARDS_COSTING_OVER_AMOUNT: {
-                // TODO
+                return `Decrease cost of cards in ${targetNamePossessive} ${
+                    isTargetTypePlural(target) ? 'hands' : 'hand'
+                } by ${strength} (generic).  Cards reduced this way cannot be reduced below ${secondaryStrength} total cost`;
             }
             case EffectType.REDUCE_LEGENDARY_LEADER_COST: {
                 // TODO

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -570,6 +570,9 @@ export const transformEffectToRulesText = (
                 } to your hand`;
             }
             case EffectType.LOSE_MAGICAL_AND_RANGED: {
+                return `${titleize(
+                    targetNamePossessive
+                )} units lose magical/ranged`;
             }
             case EffectType.MILL: {
                 return `Put ${strength} ${
@@ -581,7 +584,9 @@ export const transformEffectToRulesText = (
                 }`;
             }
             case EffectType.MODIFY_ATTACKS_PER_TURN: {
-                // TODO
+                return `Set ${targetName} to have ${strength} attack${
+                    strength === 1 ? '' : 's'
+                } per turn`;
             }
             case EffectType.POLYMORPH: {
                 return `Turn ${targetName} into a [${summonType.name}]`;

--- a/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
+++ b/src/transformers/transformEffectsToRulesText/transformEffectsToRulesText.ts
@@ -678,9 +678,6 @@ export const transformEffectToRulesText = (
                     strength || 'all'
                 } [${cardName}] card${pluralizationEffectStrength} in hand into [${secondaryCardName}]${forText}`;
             }
-            case EffectType.TRANSFORM_RESOURCE: {
-                // TODO
-            }
             case EffectType.TUCK: {
                 return `Put ${targetName} on top of ${controllerPossessiveText} library`;
             }

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -42,7 +42,7 @@ export interface ResourceCard extends CardBase {
 export type Effect = {
     cardName?: string;
     cost?: PartialRecord<Resource, number>;
-    passiveEffect?: PassiveEffect;
+    passiveEffects?: PassiveEffect[];
     requirements?: EffectRequirement[];
     resourceType?: Resource;
     secondaryCardName?: string;

--- a/src/types/cards.ts
+++ b/src/types/cards.ts
@@ -96,9 +96,7 @@ export interface UnitBase extends CardBase {
     name: string;
     // how much damage is inflicted per attack
     numAttacks: number;
-    originalCost?: PartialRecord<Resource, number>;
     originalImagePage?: string;
-    originalPassiveEffects?: PassiveEffect[];
     // all units except magic must attack soldiers first 🛡️
     passiveEffects: PassiveEffect[];
     totalHp: number; // max HP
@@ -123,6 +121,13 @@ export interface UnitCard extends UnitBase {
     oneCycleAttackBuff: number;
     // number of attack left this turn - starts at 0
     oneTurnAttackBuff: number;
+    originalAttributes?: {
+        cost: PartialRecord<Resource, number>;
+        isMagical: boolean;
+        isRanged: boolean;
+        numAttacks: number;
+        passiveEffects: PassiveEffect[];
+    };
 }
 
 export type UnitType = 'Magical' | 'Soldier' | 'Ranged' | 'None';
@@ -131,7 +136,9 @@ export interface SpellBase extends CardBase {
     cost: PartialRecord<Resource, number>;
     effects: Effect[];
     name: string;
-    originalCost?: PartialRecord<Resource, number>;
+    originalAttributes?: {
+        cost: PartialRecord<Resource, number>;
+    };
     originalImagePage?: string;
 }
 

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -33,10 +33,11 @@ export enum EffectType {
     BOUNCE_UNITS_UNDER_THRESHOLD_ATTACK = 'Bounce units under threshold attack',
     BUFF_ATTACK = 'Buff attack', // increase/decrease attack of a single unit
     BUFF_ATTACK_FOR_CYCLE = 'Buff attack for cycle', // increase/decrease attack of a single unit
-    BUFF_ATTACK_FOR_TURN = 'Buff attack for turn', // increase/decrease attack of a single unit
-    BUFF_HAND_ATTACK = 'Buff hand attack',
+    BUFF_ATTACK_FOR_TURN = 'Buff attack for turn',
     // give unit(s) a passive effect
     BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE = 'Buff hand attack with failsafe lifechange',
+    // increase/decrease attack of a single unit
+    BUFF_HAND_NON_MAGIC_ATTACK = 'Buff hand non-magic attack',
     // buffs all creatures in hand
     BUFF_MAGIC = 'Buff magic unit',
     BUFF_TEAM_ATTACK = 'Buff team attack',
@@ -127,7 +128,7 @@ export const getDefaultTargetForEffect = (
         [EffectType.BUFF_ATTACK]: TargetTypes.UNIT,
         [EffectType.BUFF_ATTACK_FOR_CYCLE]: TargetTypes.UNIT,
         [EffectType.BUFF_ATTACK_FOR_TURN]: TargetTypes.UNIT,
-        [EffectType.BUFF_HAND_ATTACK]: TargetTypes.SELF_PLAYER,
+        [EffectType.BUFF_HAND_NON_MAGIC_ATTACK]: TargetTypes.SELF_PLAYER,
         [EffectType.BUFF_HAND_ATTACK_WITH_FAILSAFE_LIFECHANGE]:
             TargetTypes.ALL_OPPONENTS,
         [EffectType.BUFF_MAGIC]: TargetTypes.UNIT,

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -66,10 +66,10 @@ export enum EffectType {
     DRAW_PER_UNIT = 'Draw per unit',
     DRAW_UNTIL = 'Draw until',
     DRAW_UNTIL_MATCHING_OPPONENTS = 'Draw until matching opponents',
-    EXTRACT_AND_SET_COST = 'Extract cards and set their costs',
     EXTRACT_CARD = 'Extract card', // extract X of {cardName} card from deck
     EXTRACT_SOLDIER_CARDS = 'Extract soldier cards',
     EXTRACT_SPELL_CARDS = 'Extract spell cards',
+    EXTRACT_UNIT_AND_SET_COST = 'Extract cards and set their costs',
     /**
      * Flicker own card (needs to be own - don't want to do opposing units yet
      * b/c it would involve too much new code - we'd have to control for opposing active player
@@ -152,7 +152,7 @@ export const getDefaultTargetForEffect = (
         [EffectType.DRAW_PER_UNIT]: TargetTypes.SELF_PLAYER,
         [EffectType.DRAW_UNTIL]: TargetTypes.SELF_PLAYER,
         [EffectType.DRAW_UNTIL_MATCHING_OPPONENTS]: TargetTypes.SELF_PLAYER,
-        [EffectType.EXTRACT_AND_SET_COST]: TargetTypes.SELF_PLAYER,
+        [EffectType.EXTRACT_UNIT_AND_SET_COST]: TargetTypes.SELF_PLAYER,
         [EffectType.EXTRACT_CARD]: TargetTypes.SELF_PLAYER,
         [EffectType.EXTRACT_SOLDIER_CARDS]: TargetTypes.SELF_PLAYER,
         [EffectType.EXTRACT_SPELL_CARDS]: TargetTypes.SELF_PLAYER,

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -20,6 +20,7 @@ export const ORDERED_RESOURCES = [
 ];
 
 type GlossaryEntry = {
+    explicitColorName: string;
     icon: string;
     name: string;
     primaryColor: string;
@@ -30,26 +31,36 @@ export const RESOURCE_GLOSSARY: Record<Resource, GlossaryEntry> = {
         icon: '1',
         name: 'Generic',
         primaryColor: '#050426',
+        explicitColorName: 'generic',
     },
-    [Resource.BAMBOO]: { icon: '🎋', name: 'Bamboo', primaryColor: '#136313' },
+    [Resource.BAMBOO]: {
+        icon: '🎋',
+        name: 'Bamboo',
+        primaryColor: '#136313',
+        explicitColorName: 'green',
+    },
     [Resource.CRYSTAL]: {
         icon: '🔮',
         name: 'Crystal',
         primaryColor: Colors.CRYSTAL_PURPLE,
+        explicitColorName: 'purple',
     },
     [Resource.FIRE]: {
         icon: '🔥',
         name: 'Fire',
         primaryColor: Colors.FIRE_ORANGE,
+        explicitColorName: 'orange',
     },
     [Resource.IRON]: {
         icon: '🛠️',
         name: 'Iron',
         primaryColor: Colors.IRON_GREY,
+        explicitColorName: 'grey',
     },
     [Resource.WATER]: {
         icon: '🌊',
         name: 'Water',
         primaryColor: Colors.WATER_BLUE,
+        explicitColorName: 'blue',
     },
 };


### PR DESCRIPTION
This update adds in all the NLP-like rules constructions to the 25+ new effects added in #453.  No player-facing changes yet - we still need to implement the cards that use these new effects as well as adding in support for these new effects on an engine-level

- Also adds in support for resetting units' types (a pre-emptive move to support the implementation of the 'gain magical' and 'lose magical/ranged' effects) + smarter unit/spell resetting when moving cards from hand to cemetery

Next up:
- Adding new effects into the rules engine (resolveEffect.ts)
- Adding 'for each' multipliers (new feature for effects to describe ways of scaling effects)
- Implementing the 'snowblind' mechanic
- Ensuring that units with poisonous when dealing damage via effects destroy opposing units
- Adding in the cards that use these new mechanics