### PR TITLE
Fix: Color identity should only be for effects with symbols

### DIFF
--- a/src/transformers/getColorIdentityForCard/getColorIdentityForCard.spec.ts
+++ b/src/transformers/getColorIdentityForCard/getColorIdentityForCard.spec.ts
@@ -1,6 +1,7 @@
 import { UnitCards } from '@/cardDb/units';
 import { getColorIdentityForCard } from './getColorIdentityForCard';
 import { Resource } from '@/types/resources';
+import { SpellCards } from '@/cardDb/spells';
 
 describe('color identities for cards', () => {
     it('returns with 4 colors (including blue) for the monkey king because it extracts bubble blast', () => {
@@ -17,6 +18,23 @@ describe('color identities for cards', () => {
             Resource.BAMBOO,
             Resource.FIRE,
             Resource.WATER,
+        ]);
+    });
+
+    it('does not return water for erupt', () => {
+        expect(getColorIdentityForCard(SpellCards.ERUPT)).toEqual([
+            Resource.FIRE,
+            Resource.CRYSTAL,
+        ]);
+    });
+
+    it('returns every color for a dark forest', () => {
+        expect(getColorIdentityForCard(SpellCards.A_DARK_FOREST)).toEqual([
+            Resource.BAMBOO,
+            Resource.CRYSTAL,
+            Resource.FIRE,
+            Resource.WATER,
+            Resource.IRON,
         ]);
     });
 });

--- a/src/transformers/getColorIdentityForCard/getColorIdentityForCard.ts
+++ b/src/transformers/getColorIdentityForCard/getColorIdentityForCard.ts
@@ -2,6 +2,14 @@ import { uniq } from 'lodash';
 import { Card, CardType, Effect } from '@/types/cards';
 import { Resource } from '@/types/resources';
 import { getAssociatedCards } from '../getAssociatedCards';
+import { EffectType } from '@/types/effects';
+
+// Effects where having a 'resourceType' indicates the rules text will use a
+// symbol for the resource type, making it change the color identity of the card
+const EFFECTS_WITH_RESOURCE_TYPE_SYMBOLS = [
+    EffectType.RAMP_FOR_TURN,
+    EffectType.EXTRACT_UNIT_AND_SET_COST,
+];
 
 /**
  *
@@ -53,7 +61,10 @@ export const getColorIdentityForCard = (
 
     // Add effect-specific colors
     effects.forEach((effect) => {
-        if (effect.resourceType) {
+        if (
+            effect.resourceType &&
+            EFFECTS_WITH_RESOURCE_TYPE_SYMBOLS.includes(effect.type)
+        ) {
             resourceTypes.push(effect.resourceType);
         }
     });


### PR DESCRIPTION
Closes: #462 

Similar to MTG, establishing color identity for a card should only be for a color symbol.  E.g. if the card says 4🌊: Add 🔥, it would have a 🌊/🔥 identity.  But if it says, 4🌊: Destroy a fire resource.  That would be a color identity for the legendary leaders format of just 🌊