### PR TITLE
Fix: fix 3-player/4-player games bonuses for not going 1st

### DIFF
--- a/src/server/gameEngine/gameEngine.ts
+++ b/src/server/gameEngine/gameEngine.ts
@@ -338,7 +338,9 @@ export const applyGameAction = ({
                         index === clonedBoard.startingPlayerIndex;
                     if (!player.isActivePlayer) {
                         const positionAfterStartingPlayer =
-                            (index - clonedBoard.startingPlayerIndex) %
+                            (index -
+                                clonedBoard.startingPlayerIndex +
+                                clonedBoard.players.length) %
                             clonedBoard.players.length;
                         if (
                             clonedBoard.players.length === 2 ||


### PR DESCRIPTION
Modulo doesn't work with negative numbers in Javascript, causing some issues with players in 3/4 player games not getting their starting bonuses for not going 1st.

So trying to calculate the "starting position" by subtracting indexes can result in negative positions.

Example:
starting player is index 2
player A is index 0.
player B is index 1
player C is index 3

While player C will be correctly calculated as having a "positionAfterStartingPlayer" of 1, player B would be -1

This change fixes that by adding the total number of players before doing the modulo operator